### PR TITLE
Add PR template to standardise PR descriptions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+## Context
+
+<!-- Is there a Trello ticket you can link to? -->
+<!-- Do you need to add any environment variables? -->
+<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->
+
+## Changes in this PR


### PR DESCRIPTION
## Changes in this PR

Adds a PR template (this one!) to remind us to do things like link relevant trello tickets, update environment variables, add ADRs when opening a PR.