### PR TITLE
Implement the GET /courses/{courseId}/offerings/{offeringId} end-point

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/HmppsAccreditedProgrammesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/HmppsAccreditedProgrammesApiExceptionHandler.kt
@@ -4,9 +4,11 @@ import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
+import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.NotFoundException
 import javax.validation.ValidationException
 
 @RestControllerAdvice
@@ -20,6 +22,20 @@ class HmppsAccreditedProgrammesApiExceptionHandler {
         ErrorResponse(
           status = BAD_REQUEST,
           userMessage = "Validation failure: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(NotFoundException::class)
+  fun handleNotFoundException(e: NotFoundException): ResponseEntity<ErrorResponse> {
+    log.info("Validation exception: {}", e.message)
+    return ResponseEntity
+      .status(NOT_FOUND)
+      .body(
+        ErrorResponse(
+          status = NOT_FOUND,
+          userMessage = "Not Found: ${e.message}",
           developerMessage = e.message,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseService.kt
@@ -13,6 +13,9 @@ class CourseService {
       .filter { it.course.id == courseId }
       .toList()
 
+  fun courseOffering(courseId: UUID, offeringId: UUID): Offering? =
+    offerings.find { it.id == offeringId && it.course.id == courseId }
+
   companion object {
     private val tsp = CourseEntity(
       name = "Thinking Skills Programme",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesController.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.controller
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi
 
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseEn
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Offering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.transformer.toApi
+import java.util.UUID
 
 @Service
 class CoursesController(
@@ -22,11 +23,16 @@ class CoursesController(
           .map(CourseEntity::toApi),
       )
 
-  override fun coursesCourseIdOfferingsGet(courseId: java.util.UUID): ResponseEntity<List<CourseOffering>> =
+  override fun coursesCourseIdOfferingsGet(courseId: UUID): ResponseEntity<List<CourseOffering>> =
     ResponseEntity
       .ok(
         courseService
           .offeringsForCourse(courseId)
           .map(Offering::toApi),
       )
+
+  override fun coursesCourseIdOfferingsOfferingIdGet(courseId: UUID, offeringId: UUID): ResponseEntity<CourseOffering> =
+    courseService.courseOffering(courseId, offeringId)?.let {
+      ResponseEntity.ok(it.toApi())
+    } ?: throw NotFoundException("No CourseOffering  found at /courses/$courseId/offerings/$offeringId")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/NotFoundException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/NotFoundException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi
+
+class NotFoundException(message: String) : RuntimeException(message)

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -73,6 +73,12 @@ paths:
             'application/json':
               schema:
                   $ref: '#/components/schemas/CourseOffering'
+        404:
+          description: invalid course and/or course offering id
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
 components:
   schemas:
@@ -140,3 +146,21 @@ components:
         - contactEmail
         - duration
         - groupSize
+
+    ErrorResponse:
+      type: object
+      properties:
+        status:
+          type: integer
+          example: 404
+        errorCode:
+          type: integer
+        userMessage:
+          type: string
+          example: "Course not found"
+        developerMessage:
+          type: string
+        moreInfo:
+          type: string
+      required:
+        - status

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/CourseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/CourseServiceTest.kt
@@ -3,12 +3,13 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseService
-import java.util.*
+import java.util.UUID
 
 class CourseServiceTest {
   private val service = CourseService()
@@ -31,5 +32,32 @@ class CourseServiceTest {
 
     offerings.forAll { it.course.id shouldBe course.id }
     offerings shouldHaveSize 3
+  }
+
+  @Test
+  fun `find an offering by known course id and offering id - success`() {
+    val courseId = service.allCourses().find { it.name == "Thinking Skills Programme" }?.id
+    courseId.shouldNotBeNull()
+
+    val expectedOffering = service.offeringsForCourse(courseId).find { it.organisationId == "BXI" }
+    expectedOffering.shouldNotBeNull()
+
+    val actualOffering = service.courseOffering(courseId = courseId, offeringId = expectedOffering.id)
+    actualOffering
+      .shouldNotBeNull()
+      .id shouldBe expectedOffering.id
+  }
+
+  @Test
+  fun `find an offering by known course id and unknown offering id - fail`() {
+    val courseId = service.allCourses().find { it.name == "Thinking Skills Programme" }?.id
+    courseId.shouldNotBeNull()
+
+    service.courseOffering(courseId = courseId, offeringId = UUID.randomUUID()).shouldBeNull()
+  }
+
+  @Test
+  fun `find an offering by unknown course id and unknown offering id - fail`() {
+    service.courseOffering(courseId = UUID.randomUUID(), offeringId = UUID.randomUUID()).shouldBeNull()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesControllerTest.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi
+
+import org.hamcrest.Matchers.matchesRegex
+import org.hamcrest.Matchers.startsWith
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseService
+import java.util.UUID
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class CoursesControllerTest(
+  @Autowired val webTestClient: WebTestClient,
+  @Autowired val coursesService: CourseService,
+) {
+
+  @Test
+  fun `get a course offering - happy path`() {
+    val courseId = coursesService.allCourses().first().id
+    val courseOfferingId = coursesService.offeringsForCourse(courseId).first().id
+
+    webTestClient.get().uri("/courses/$courseId/offerings/$courseOfferingId")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody()
+      .jsonPath("$.id").isEqualTo(courseOfferingId.toString())
+      .jsonPath("$.organisationId").isNotEmpty
+      .jsonPath("$.contactEmail").isNotEmpty
+      .jsonPath("$.duration").value(matchesRegex("""^P\d*(T\d+[H])?$"""))
+      .jsonPath("$.groupSize").isNumber
+  }
+
+  @Test
+  fun `get a course offering - not found`() {
+    val randomUuid = UUID.randomUUID()
+
+    webTestClient.get().uri("/courses/$randomUuid/offerings/$randomUuid")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isNotFound
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody()
+      .jsonPath("$.status").isEqualTo(404)
+      .jsonPath("$.errorCode").isEmpty
+      .jsonPath("$.userMessage").value(startsWith("Not Found: No CourseOffering  found at /courses/"))
+      .jsonPath("$.developerMessage").value(startsWith("No CourseOffering  found at /courses/"))
+      .jsonPath("$.moreInfo").isEmpty
+  }
+}


### PR DESCRIPTION
## Context

Trello ticket [346]( https://trello.com/c/90RhMAnl/346-add-api-endpoint-for-an-individual-courseoffering)

## Changes in this PR

* New GET `/courses/{courseId}/offerings/{offeringId}` end-point returns information about a single course offering
* Returns 404 NOT_FOUND if the ids do not select an offering
* Added full stack test of new end-point. (Integration test)

Notes:
* hmps-approved-premises-api uses  library ["org.zalando:problem-spring-web-starter:0.27.0"](https://github.com/zalando/problem-spring-web)  to assist with handling HTTP error responses following [RFC 7807](https://datatracker.ietf.org/doc/html/rfc7807).  Currently this application does not do so and does not adhere to the response format defined in rfc7807. Should it?
* The `GET /courses/{courseId}/offerings` returns an empty response when the supplied `courseId` does not select a course.  Should it return 404 NOT FOUND instead?