### PR TITLE
328 :sparkles: Add hmpps auth to api

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,14 +9,22 @@ configurations {
 }
 
 dependencies {
-  val kotestVersion = "5.6.0"
+  val kotestVersion = "5.6.2"
+  val springdocVersion = "1.7.0"
 
   implementation("org.springframework.boot:spring-boot-starter-webflux")
-  implementation("org.springdoc:springdoc-openapi-data-rest:1.7.0")
-  implementation("org.springdoc:springdoc-openapi-ui:1.7.0")
-  implementation("org.springdoc:springdoc-openapi-kotlin:1.7.0")
+  implementation("org.springframework.boot:spring-boot-starter-security")
+  implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+  implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+
+  implementation("org.springdoc:springdoc-openapi-data-rest:$springdocVersion")
+  implementation("org.springdoc:springdoc-openapi-ui:$springdocVersion")
+  implementation("org.springdoc:springdoc-openapi-kotlin:$springdocVersion")
 
   testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+  testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")
+  testImplementation("io.jsonwebtoken:jjwt-impl:0.11.5")
+  testImplementation("io.jsonwebtoken:jjwt-orgjson:0.11.5")
 }
 
 java {

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -1,4 +1,2 @@
 version: "3"
-services:
-  database:
-    image: "ghcr.io/baosystems/postgis:15-3.3" # Official PostGIS image doesn't have ARM64 support
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,17 @@
 version: "3"
 services:
-  database:
-    image: "postgis/postgis"
-    container_name: accredited-programmes-postgres-dev
-    environment:
-      - POSTGRES_USER=localdev
-      - POSTGRES_PASSWORD=localdev_password
-      - POSTGRES_DB=accredited-programmes_localdev
-    volumes:
-      - database-data-development:/var/lib/postgresql/data/
+  hmpps-auth:
+    image: quay.io/hmpps/hmpps-auth:latest
+    container_name: hmpps-auth
     ports:
-      - "5431:5432"
-
-  hmpps-accredited-programmes-api:
-    build:
-      context: .
-    container_name: hmpps-accredited-programmes-api
-    ports:
-      - "8081:8080"
+      - "9090:8080"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health/ping"]
+      test:
+        [ "CMD", "curl", "-f", "http://localhost:8080/auth/health" ]
     environment:
-      - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
-
-volumes:
-  database-data-development:
+      - APPLICATION_AUTHENTICATION_UI_ALLOWLIST=0.0.0.0/0
+      - SPRING_H2_CONSOLE_SETTINGS_WEBALLOWOTHERS=true
 
 networks:
   hmpps:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -10,6 +10,7 @@ generic-service:
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
+    HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -7,6 +7,8 @@ generic-service:
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
+    HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -5,6 +5,10 @@ generic-service:
   ingress:
     host: hmpps-accredited-programmes-api.hmpps.service.justice.gov.uk
 
+
+env:
+  HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/script/all_courses
+++ b/script/all_courses
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# GET all courses from http://localhost:8080/courses and print formatted json to stdout
+# Requires the hmpps-auth app to be running and accessible to the application. (See docker-compose.yml)
+
+DIR="$(dirname "$(realpath "$0")")"
+TOKEN=$("$DIR"/get_token)
+curl -v --header "Authorization: Bearer $TOKEN" http://localhost:8080/courses | jq

--- a/script/get_token
+++ b/script/get_token
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# GET a JWT access token from hmpps-auth at localhost:9090 (See docker-compose.yml)
+
+curl --location -s --request POST "http://localhost:9090/auth/oauth/token?grant_type=client_credentials" \
+     --header 'Content-Type: application/json' \
+     --header 'Content-Length: 0' \
+     --header "Authorization: Basic $(echo -n 'whereabouts-api-client:clientsecret' | base64 -b 0)" | jq -r .access_token

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -1,0 +1,114 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Bean
+import org.springframework.core.convert.converter.Converter
+import org.springframework.http.HttpMethod
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.config.web.servlet.invoke
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.SecurityFilterChain
+
+@EnableWebSecurity
+class OAuth2ResourceServerSecurityConfiguration {
+  @Bean
+  @Throws(Exception::class)
+  fun securityFilterChain(http: HttpSecurity, @Autowired objectMapper: ObjectMapper): SecurityFilterChain {
+    http {
+      csrf { disable() }
+
+      authorizeHttpRequests {
+        authorize(HttpMethod.GET, "/health/**", permitAll)
+        authorize(HttpMethod.GET, "/swagger-ui/**", permitAll)
+        authorize(HttpMethod.GET, "/v3/api-docs/swagger-config", permitAll)
+        authorize(HttpMethod.GET, "/api.yml", permitAll)
+        authorize(HttpMethod.GET, "/info", permitAll)
+        authorize(anyRequest, authenticated)
+      }
+
+      anonymous { disable() }
+
+      oauth2ResourceServer {
+        jwt { jwtAuthenticationConverter = AuthAwareTokenConverter() }
+
+        authenticationEntryPoint = AuthenticationEntryPoint { _, response, _ ->
+          response.apply {
+            status = 401
+            contentType = "application/problem+json"
+            characterEncoding = "UTF-8"
+
+            writer.write(
+              objectMapper.writeValueAsString(
+                object {
+                  val title = "Unauthenticated"
+                  val status = 401
+                  val detail =
+                    "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint"
+                },
+              ),
+            )
+          }
+        }
+      }
+      sessionManagement {
+        sessionCreationPolicy = SessionCreationPolicy.STATELESS
+      }
+    }
+
+    return http.build()
+  }
+}
+
+class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
+  private val jwtGrantedAuthoritiesConverter: Converter<Jwt, Collection<GrantedAuthority>> =
+    JwtGrantedAuthoritiesConverter()
+
+  override fun convert(jwt: Jwt): AbstractAuthenticationToken =
+    AuthAwareAuthenticationToken(
+      jwt,
+      findPrincipal(jwt.claims),
+      extractAuthorities(jwt),
+    )
+
+  private fun findPrincipal(claims: Map<String, Any?>): String = when {
+    claims.containsKey(CLAIM_USERNAME) -> claims[CLAIM_USERNAME]
+    claims.containsKey(CLAIM_USER_ID) -> claims[CLAIM_USER_ID]
+    claims.containsKey(CLAIM_CLIENT_ID) -> claims[CLAIM_CLIENT_ID]
+    else -> throw RuntimeException("Unable to find a claim to identify Subject by")
+  } as String
+
+  private fun extractAuthorities(jwt: Jwt): Collection<GrantedAuthority> {
+    val grantedAuthorities = jwtGrantedAuthoritiesConverter.convert(jwt) ?: emptyList()
+
+    @Suppress("UNCHECKED_CAST")
+    val claimStrings = (jwt.claims[CLAIM_AUTHORITY] as Collection<String>?) ?: emptyList()
+
+    return grantedAuthorities + claimStrings.map(::SimpleGrantedAuthority)
+  }
+
+  companion object {
+    const val CLAIM_USERNAME = "user_name"
+    const val CLAIM_USER_ID = "user_id"
+    const val CLAIM_CLIENT_ID = "client_id"
+    const val CLAIM_AUTHORITY = "authorities"
+  }
+}
+
+class AuthAwareAuthenticationToken(
+  jwt: Jwt,
+  private val aPrincipal: String,
+  authorities: Collection<GrantedAuthority>,
+) : JwtAuthenticationToken(jwt, authorities) {
+  override fun getPrincipal(): String {
+    return aPrincipal
+  }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,8 @@
+oauth:
+  client:
+    id: whereabouts-api-client
+    secret: clientsecret
+
+hmpps:
+  auth:
+    url: http://localhost:9090/auth

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,13 @@ spring:
     group:
       test:
         - "stdout"
+
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          jwk-set-uri: ${hmpps.auth.url}/.well-known/jwks.json
+
 springdoc:
   swagger-ui:
     urls:
@@ -54,3 +61,5 @@ management:
     info:
       cache:
         time-to-live: 2000ms
+
+log-client-credentials-jwt-info: false

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/fixture/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/fixture/JwtAuthHelper.kt
@@ -1,0 +1,66 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import org.springframework.context.annotation.Bean
+import org.springframework.http.HttpHeaders
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.stereotype.Component
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPublicKey
+import java.time.Duration
+import java.util.Date
+import java.util.UUID
+
+@Component
+class JwtAuthHelper {
+  private val keyPair: KeyPair = with(KeyPairGenerator.getInstance("RSA")) {
+    initialize(2048)
+    generateKeyPair()
+  }
+
+  /**
+   * This bean is injected into the Spring OAuth2 configuration.
+   */
+  @Bean
+  fun jwtDecoder(): JwtDecoder = NimbusJwtDecoder.withPublicKey(keyPair.public as RSAPublicKey).build()
+
+  fun clientCredentials() = clientCredentials("hmpps-accredited-programmes-ui")
+  fun clientCredentials(
+    user: String,
+    roles: List<String> = listOf(),
+    scopes: List<String> = listOf(),
+  ): (HttpHeaders) -> Unit {
+    val token = createJwt(
+      subject = user,
+      scope = scopes,
+      expiryTime = Duration.ofHours(1L),
+      roles = roles,
+    )
+    return { it.set(HttpHeaders.AUTHORIZATION, "Bearer $token") }
+  }
+
+  private fun createJwt(
+    subject: String?,
+    scope: List<String>? = listOf(),
+    roles: List<String>? = listOf(),
+    expiryTime: Duration = Duration.ofHours(1),
+    jwtId: String = UUID.randomUUID().toString(),
+  ): String =
+    mutableMapOf<String, Any>()
+      .also { subject?.let { subject -> it["user_name"] = subject } }
+      .also { it["client_id"] = "court-reg-client" }
+      .also { roles?.let { roles -> it["authorities"] = roles } }
+      .also { scope?.let { scope -> it["scope"] = scope } }
+      .let {
+        Jwts.builder()
+          .setId(jwtId)
+          .setSubject(subject)
+          .addClaims(it.toMap())
+          .setExpiration(Date(System.currentTimeMillis() + expiryTime.toMillis()))
+          .signWith(keyPair.private, SignatureAlgorithm.RS256)
+          .compact()
+      }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesControllerTest.kt
@@ -5,16 +5,80 @@ import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
 import java.util.UUID
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(JwtAuthHelper::class)
 class CoursesControllerTest(
   @Autowired val webTestClient: WebTestClient,
   @Autowired val coursesService: CourseService,
+  @Autowired val jwtAuthHelper: JwtAuthHelper,
 ) {
+
+  @Test
+  fun `get all courses`() {
+    webTestClient.get().uri("/courses")
+      .headers(jwtAuthHelper.clientCredentials())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody()
+      .json(
+        """
+          [
+            { "name": "Thinking Skills Programme" },
+            { "name": "New me strengths" },
+            { "name": "Becoming new me +" }
+        ]
+        """,
+      )
+  }
+
+  @Test
+  fun `get all courses - no token`() {
+    webTestClient.get().uri("/courses")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectUnauthenticatedResponse()
+  }
+
+  @Test
+  fun `get all offerings for a course`() {
+    val courseId = coursesService.allCourses().first().id
+
+    webTestClient.get().uri("/courses/$courseId/offerings")
+      .headers(jwtAuthHelper.clientCredentials())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody()
+      .json(
+        """
+        [
+          { "organisationId": "MDI", "contactEmail":"nobody-mdi@digital.justice.gov.uk", "groupSize": 10 },
+          { "organisationId": "BWN", "contactEmail":"nobody-bwn@digital.justice.gov.uk", "groupSize": 6 },
+          { "organisationId": "BXI", "contactEmail":"nobody-bxi@digital.justice.gov.uk", "groupSize": 6 }
+        ]
+      """,
+      )
+  }
+
+  @Test
+  fun `get all offerings for a course - no token`() {
+    webTestClient.get().uri("/courses/${UUID.randomUUID()}/offerings")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectUnauthenticatedResponse()
+  }
 
   @Test
   fun `get a course offering - happy path`() {
@@ -22,6 +86,7 @@ class CoursesControllerTest(
     val courseOfferingId = coursesService.offeringsForCourse(courseId).first().id
 
     webTestClient.get().uri("/courses/$courseId/offerings/$courseOfferingId")
+      .headers(jwtAuthHelper.clientCredentials())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -30,7 +95,7 @@ class CoursesControllerTest(
       .jsonPath("$.id").isEqualTo(courseOfferingId.toString())
       .jsonPath("$.organisationId").isNotEmpty
       .jsonPath("$.contactEmail").isNotEmpty
-      .jsonPath("$.duration").value(matchesRegex("""^P\d*(T\d+[H])?$"""))
+      .jsonPath("$.duration").value(matchesRegex("""^P\d*(T\d+H)?$"""))
       .jsonPath("$.groupSize").isNumber
   }
 
@@ -40,6 +105,7 @@ class CoursesControllerTest(
 
     webTestClient.get().uri("/courses/$randomUuid/offerings/$randomUuid")
       .accept(MediaType.APPLICATION_JSON)
+      .headers(jwtAuthHelper.clientCredentials())
       .exchange()
       .expectStatus().isNotFound
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -50,4 +116,30 @@ class CoursesControllerTest(
       .jsonPath("$.developerMessage").value(startsWith("No CourseOffering  found at /courses/"))
       .jsonPath("$.moreInfo").isEmpty
   }
+
+  @Test
+  fun `get a course offering - no token`() {
+    val randomUuid = UUID.randomUUID()
+
+    webTestClient.get().uri("/courses/$randomUuid/offerings/$randomUuid")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectUnauthenticatedResponse()
+  }
+}
+
+private fun (WebTestClient.ResponseSpec).expectUnauthenticatedResponse(): WebTestClient.ResponseSpec {
+  this.expectStatus().isUnauthorized
+    .expectHeader().contentType("application/problem+json;charset=UTF-8")
+    .expectBody()
+    .json(
+      """ 
+      {
+        "title": "Unauthenticated",
+        "status": 401,
+        "detail": "A valid HMPPS Auth JWT must be supplied via bearer authentication to access this endpoint"
+      } 
+      """,
+    )
+  return this
 }


### PR DESCRIPTION
## Context

Trello [328](https://trello.com/c/tF7qCm3p/328-add-hmpps-auth-to-api)

This change introduces a new spring boot configuration parameter `hmpps.auth.url` which as an environment variable is `HMPPS_AUTH_URL`.

## Changes in this PR

### Remove postgres/postgis and app from docker-compose. Add hmpps-auth
Required for integration testing.

### Integrate with HMPPS Auth
Use spring-boot ouath2 framework, test for guarded and unguarded end-points.
The hmpps auth end-point url is configurable as `HMPPS_AUTH_URL`

### Add a script for getting new token from local HMPPS Auth
A valid token must be included in requests to guarded end-points. This script fetches suitable tokens from the hmpps-auth instance deployed in docker. Requires curl and jq.

### Add script for fetching courses from locally-running API
This script performs a 'GET /courses' request to a locally running instance of the application. It includes a valid bearer token, retrieved using the get_token script,  in the Authentication header
