### PR TITLE
:sparkles: Add a 'GET /courses/{courseId}' endpoint to return info for one course or 404 Not Found.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseService.kt
@@ -8,13 +8,18 @@ import kotlin.time.Duration
 class CourseService {
   fun allCourses(): List<CourseEntity> = courses.toList()
 
+  fun course(courseId: UUID): CourseEntity? =
+    courses
+      .find { it.id == courseId }
+
   fun offeringsForCourse(courseId: UUID): List<Offering> =
     offerings
       .filter { it.course.id == courseId }
       .toList()
 
   fun courseOffering(courseId: UUID, offeringId: UUID): Offering? =
-    offerings.find { it.id == offeringId && it.course.id == courseId }
+    offerings
+      .find { it.id == offeringId && it.course.id == courseId }
 
   companion object {
     private val tsp = CourseEntity(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesController.kt
@@ -23,6 +23,11 @@ class CoursesController(
           .map(CourseEntity::toApi),
       )
 
+  override fun coursesCourseIdGet(courseId: UUID): ResponseEntity<Course> =
+    courseService.course(courseId)?.let {
+      ResponseEntity.ok(it.toApi())
+    } ?: throw NotFoundException("No Course found at /courses/$courseId")
+
   override fun coursesCourseIdOfferingsGet(courseId: UUID): ResponseEntity<List<CourseOffering>> =
     ResponseEntity
       .ok(

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -20,6 +20,27 @@ paths:
                 items:
                   $ref: '#/components/schemas/Course'
 
+  /courses/{courseId}:
+    get:
+      tags:
+        - Courses
+      summary: Details for a single course
+      parameters:
+        - name: courseId
+          in: path
+          description: A course identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                  $ref: '#/components/schemas/Course'
+
   /courses/{courseId}/offerings:
     get:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/CourseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/CourseServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -17,6 +18,14 @@ class CourseServiceTest {
   @Test
   fun `all courses`() {
     service.allCourses() shouldHaveSize 3
+  }
+
+  @Test
+  fun `a course`() {
+    val aCourse = service.allCourses().first()
+    (service.course(aCourse.id))
+      .shouldNotBeNull()
+      .shouldBeEqualToComparingFields(aCourse)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesControllerTest.kt
@@ -51,6 +51,47 @@ class CoursesControllerTest(
   }
 
   @Test
+  fun `get a course - happy path`() {
+    val expectedCourse = coursesService.allCourses().first()
+
+    webTestClient.get().uri("/courses/${expectedCourse.id}")
+      .headers(jwtAuthHelper.clientCredentials())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody()
+      .jsonPath("$.id").isEqualTo(expectedCourse.id.toString())
+  }
+
+  @Test
+  fun `get a course - not found`() {
+    val courseId = UUID.randomUUID()
+    webTestClient.get().uri("/courses/$courseId")
+      .headers(jwtAuthHelper.clientCredentials())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isNotFound
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody()
+      .jsonPath("$.status").isEqualTo(404)
+      .jsonPath("$.errorCode").isEmpty
+      .jsonPath("$.userMessage").value(startsWith("Not Found: No Course found at /courses/$courseId"))
+      .jsonPath("$.developerMessage").value(startsWith("No Course found at /courses/$courseId"))
+      .jsonPath("$.moreInfo").isEmpty
+  }
+
+  @Test
+  fun `get a course - no token`() {
+    val expectedCourse = coursesService.allCourses().first()
+
+    webTestClient.get().uri("/courses/${expectedCourse.id}")
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectUnauthenticatedResponse()
+  }
+
+  @Test
   fun `get all offerings for a course`() {
     val courseId = coursesService.allCourses().first().id
 


### PR DESCRIPTION
## Context

Trello [416 Add endpoint for /courses/id](https://trello.com/c/2lDAgqm2/416-add-endpoint-for-courses-id)

## Changes in this PR
Add the end-point with tests for service and controller.