### PR TITLE
:arrow_up: Update Gradle plugins

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -32,6 +32,3 @@ CVE-2022-42889
 # Suppression for h2 2.1.214 password on command line vulnerability
 #   can be suppressed as we only run h2 locally and not on build environments
 CVE-2022-45868
-# Suppression for spring-web 5.3.24 as bundled with spring boot
-#   can be suppressed as we are not using java serialization and deserialization explicitly
-CVE-2016-1000027

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.7"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.1.4"
   kotlin("plugin.spring") version "1.8.21"
-  id("org.openapi.generator") version "5.4.0"
+  id("org.openapi.generator") version "6.6.0"
 }
 
 configurations {
@@ -60,6 +60,7 @@ openApiGenerate {
   apiPackage.set("uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api")
   modelPackage.set("uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model")
   configOptions.apply {
+    put("useSpringBoot3", "true")
     put("basePackage", "uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi")
     put("delegatePattern", "true")
     put("gradleBuildFile", "false")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/HmppsAccreditedProgrammesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/HmppsAccreditedProgrammesApiExceptionHandler.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.config
 
+import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
@@ -9,7 +10,6 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.NotFoundException
-import javax.validation.ValidationException
 
 @RestControllerAdvice
 class HmppsAccreditedProgrammesApiExceptionHandler {

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -22,11 +22,9 @@
                 <Pattern>${LOG_PATTERN}</Pattern>
             </layout>
         </appender>
-        <appender name="logAppender" class="com.microsoft.applicationinsights.logback.ApplicationInsightsAppender"/>
     </springProfile>
 
-    <logger name="uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.HmppsAccreditedProgrammesApiKt" additivity="false"
-            level="DEBUG">
+    <logger name="uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.Application" additivity="false" level="DEBUG">
         <appender-ref ref="logAppender"/>
         <appender-ref ref="consoleAppender"/>
     </logger>


### PR DESCRIPTION
Updates recommended by renovate bot. 

## Changes in this PR

* Gradle plugin uk.gov.justice.hmpps.gradle-spring-boot updated to version 5.1.4
* Gradle plugin org.openapi.generator updated to version 6.6.0
* Configure openApi generator to generate code compatible with Spring Boot 3 (package javax renamed to jakarta)
* Update package dependencies in code from javax.servlet etc to jakarta.servlet
* Update Spring Boot web security configuration to use Spring Security 6 kotlin configuration style. (class SecurityConfiguration)
* Correct problems with Logback configuration when spring profile is neither 'dev' or 'stdout' (remove Application Insights logback appender)
