### PR TITLE
325 :sparkles: Add Pact provider contract verification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,11 @@ jobs:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
       - run:
-          command: ./gradlew check
+          command: |
+            PACT_PROVIDER_VERSION="$CIRCLE_SHA1" \
+            PACT_PROVIDER_TAG="$CIRCLE_BRANCH" \
+            PACT_PUBLISH_RESULTS="true" \
+            ./gradlew check
       - save_cache:
           paths:
             - ~/.gradle
@@ -32,12 +36,36 @@ jobs:
           path: build/test-results
       - store_artifacts:
           path: build/reports/tests
+      - store_artifacts:
+          path: build/pact
+
+  tag_pact_version:
+    environment:
+      PACT_BROKER_BASE_URL: "https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk"
+    executor:
+      name: hmpps/node
+      tag: "16.17"
+    parameters:
+      tag:
+        type: string
+    steps:
+      - run:
+          name: Tag contract version with deployment
+          command: |
+            npx --package='@pact-foundation/pact-node' pact-broker create-version-tag \
+              --pacticipant="Accredited Programmes API" \
+              --version="$CIRCLE_SHA1" \
+              --tag="<< parameters.tag >>" \
+              --broker-base-url="$PACT_BROKER_BASE_URL" \
+              --broker-username="$PACT_BROKER_USERNAME" \
+              --broker-password="$PACT_BROKER_PASSWORD"
 
 workflows:
   version: 2
   build-test-and-deploy:
     jobs:
       - validate:
+          context: [ hmpps-common-vars ]
           filters:
             tags:
               ignore: /.*/
@@ -53,7 +81,7 @@ workflows:
           name: deploy_dev
           env: "dev"
           jira_update: true
-          context: hmpps-common-vars
+          context: [ hmpps-common-vars ]
           filters:
             branches:
               only:
@@ -63,6 +91,11 @@ workflows:
             - build_docker
             - helm_lint
           helm_timeout: 5m
+      - tag_pact_version:
+          name: "tag_pact_version_dev"
+          tag: "deployed:dev"
+          requires: [ deploy_dev ]
+          context: [ hmpps-common-vars ]
 #      - request-preprod-approval:
 #          type: approval
 #          requires:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
   testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")
   testImplementation("io.jsonwebtoken:jjwt-impl:0.11.5")
   testImplementation("io.jsonwebtoken:jjwt-orgjson:0.11.5")
+  testImplementation("au.com.dius.pact.provider:junit5spring:4.6.0")
 }
 
 java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.1.4"
   kotlin("plugin.spring") version "1.8.21"
@@ -33,7 +35,7 @@ java {
 }
 
 tasks {
-  withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+  withType<KotlinCompile> {
     kotlinOptions {
       jvmTarget = "19"
     }
@@ -41,17 +43,32 @@ tasks {
     kotlin.sourceSets["main"].kotlin.srcDir("$buildDir/generated/src/main/kotlin")
     dependsOn("openApiGenerate")
   }
-}
 
-tasks.register("bootRunLocal") {
-  group = "application"
-  description = "Runs this project as a Spring Boot application with the local profile"
-  doFirst {
-    tasks.bootRun.configure {
-      systemProperty("spring.profiles.active", "local")
-    }
+  test {
+    useJUnitPlatform()
+
+    maxParallelForks = Runtime.getRuntime().availableProcessors()
+
+    environment["pact_do_not_track"] = "true"
+    environment["pact.provider.tag"] = environment["PACT_PROVIDER_TAG"]
+    environment["pact.provider.version"] = environment["PACT_PROVIDER_VERSION"]
+    environment["pact.verifier.publishResults"] = environment["PACT_PUBLISH_RESULTS"] ?: "false"
   }
-  finalizedBy("bootRun")
+
+  register("bootRunLocal") {
+    group = "application"
+    description = "Runs this project as a Spring Boot application with the local profile"
+    doFirst {
+      bootRun.configure {
+        systemProperty("spring.profiles.active", "local")
+      }
+    }
+    finalizedBy("bootRun")
+  }
+
+  runKtlintCheckOverMainSourceSet {
+    dependsOn("openApiGenerate")
+  }
 }
 
 openApiGenerate {
@@ -77,8 +94,4 @@ ktlint {
   filter {
     exclude { it.file.path.contains("$buildDir${File.separator}generated${File.separator}") }
   }
-}
-
-tasks.runKtlintCheckOverMainSourceSet {
-  dependsOn("openApiGenerate")
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/contract/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/contract/PactContractTest.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.contract
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext
+import au.com.dius.pact.provider.junitsupport.Provider
+import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.loader.PactBroker
+import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider
+import org.apache.hc.core5.http.HttpRequest
+import org.junit.jupiter.api.TestTemplate
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("test")
+@Import(JwtAuthHelper::class)
+@PactBroker
+@Provider("Accredited Programmes API")
+class PactContractTest {
+  @Autowired
+  lateinit var jwtAuthHelper: JwtAuthHelper
+
+  @State("Server is healthy")
+  fun healthy() {
+  }
+
+  @TestTemplate
+  @ExtendWith(PactVerificationSpringProvider::class)
+  fun template(context: PactVerificationContext, request: HttpRequest) {
+    request.setHeader(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+    context.verifyInteraction()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesControllerTest.kt
@@ -25,7 +25,7 @@ class CoursesControllerTest(
   @Test
   fun `get all courses`() {
     webTestClient.get().uri("/courses")
-      .headers(jwtAuthHelper.clientCredentials())
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -55,7 +55,7 @@ class CoursesControllerTest(
     val expectedCourse = coursesService.allCourses().first()
 
     webTestClient.get().uri("/courses/${expectedCourse.id}")
-      .headers(jwtAuthHelper.clientCredentials())
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -68,7 +68,7 @@ class CoursesControllerTest(
   fun `get a course - not found`() {
     val courseId = UUID.randomUUID()
     webTestClient.get().uri("/courses/$courseId")
-      .headers(jwtAuthHelper.clientCredentials())
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isNotFound
@@ -96,7 +96,7 @@ class CoursesControllerTest(
     val courseId = coursesService.allCourses().first().id
 
     webTestClient.get().uri("/courses/$courseId/offerings")
-      .headers(jwtAuthHelper.clientCredentials())
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -127,7 +127,7 @@ class CoursesControllerTest(
     val courseOfferingId = coursesService.offeringsForCourse(courseId).first().id
 
     webTestClient.get().uri("/courses/$courseId/offerings/$courseOfferingId")
-      .headers(jwtAuthHelper.clientCredentials())
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -146,7 +146,7 @@ class CoursesControllerTest(
 
     webTestClient.get().uri("/courses/$randomUuid/offerings/$randomUuid")
       .accept(MediaType.APPLICATION_JSON)
-      .headers(jwtAuthHelper.clientCredentials())
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .exchange()
       .expectStatus().isNotFound
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
@@ -174,7 +174,7 @@ private fun (WebTestClient.ResponseSpec).expectUnauthenticatedResponse(): WebTes
     .expectHeader().contentType("application/problem+json;charset=UTF-8")
     .expectBody()
     .json(
-      """ 
+      """
       {
         "title": "Unauthenticated",
         "status": 401,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.contract
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi
 
 import au.com.dius.pact.provider.junit5.PactVerificationContext
 import au.com.dius.pact.provider.junitsupport.Provider
@@ -8,12 +8,18 @@ import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider
 import org.apache.hc.core5.http.HttpRequest
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
+import java.util.*
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("test")
@@ -24,8 +30,12 @@ class PactContractTest {
   @Autowired
   lateinit var jwtAuthHelper: JwtAuthHelper
 
+  @MockBean
+  lateinit var service: CourseService
   @State("Server is healthy")
-  fun healthy() {
+  fun programCourseServiceMock() {
+    `when`(service.allCourses())
+      .thenReturn(listOf(CourseEntity(UUID.randomUUID(), "", "", "", emptyList())))
   }
 
   @TestTemplate
@@ -33,5 +43,6 @@ class PactContractTest {
   fun template(context: PactVerificationContext, request: HttpRequest) {
     request.setHeader(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
     context.verifyInteraction()
+    verify(service).allCourses()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
@@ -34,6 +34,7 @@ class PactContractTest {
 
   @MockBean
   lateinit var service: CourseService
+
   @State("Server is healthy")
   fun programCourseServiceMock() {
     `when`(service.allCourses())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi
 import au.com.dius.pact.provider.junit5.PactVerificationContext
 import au.com.dius.pact.provider.junitsupport.Provider
 import au.com.dius.pact.provider.junitsupport.State
+import au.com.dius.pact.provider.junitsupport.VerificationReports
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker
 import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider
 import org.apache.hc.core5.http.HttpRequest
@@ -26,6 +27,7 @@ import java.util.*
 @Import(JwtAuthHelper::class)
 @PactBroker
 @Provider("Accredited Programmes API")
+@VerificationReports(value = ["markdown", "console"], reportDir = "build/pact")
 class PactContractTest {
   @Autowired
   lateinit var jwtAuthHelper: JwtAuthHelper

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,3 +4,7 @@ server:
 management.endpoint:
   health.cache.time-to-live: 0
   info.cache.time-to-live: 0
+
+pactbroker:
+  host: 'pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk'
+  scheme: https


### PR DESCRIPTION
## Context

Trello: [325](https://trello.com/c/8ajNIPEn/325-set-up-pact-on-the-api)

## Changes in this PR

### Add test dependency on Pact JUnit + Spring runner
Add the Pact `junit5spring` runner to the Gradle `testImplementation` configuration 

### Implement Pact contract tests for the api using the `junit5spring` runner.
Pulls the latest contracts for provider 'Accredited Programmes API' from the pact broker. 
Verifies  the API server against all matching contracts - adding a valid token to the `Authorization` header in each request.

### Use a CourseService mock in PactContractTest.
Use Spring Boot facilities to inject and program a mocked version of CourseService when verifying pacts.

### Make Pact create a markdown report
Saved in directory build/pact

### Prepare for running Pact provider tests on CircleCI
Update `build.gradle.kts` to provide the environment variables and values needed by junit5spring so that the Pact validation results can be published to the Pact server by the CircleCI workflow.

### Publish pact provider verification results to the pact broker...
Update the CircleCI configuration so that the Pact provider verification results are published to the Pact broker as part of the validate job.
Add a tag to the published version for each environment to which the build is deployed (currently only 'dev')
