### PR TITLE
422 Add "audience" field to Course model (API)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
   implementation("org.springdoc:springdoc-openapi-kotlin:$springdocVersion")
 
   testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+  testImplementation("com.ninja-squad:springmockk:4.0.2")
   testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")
   testImplementation("io.jsonwebtoken:jjwt-impl:0.11.5")
   testImplementation("io.jsonwebtoken:jjwt-orgjson:0.11.5")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/Audience.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/Audience.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain
+
+import java.util.UUID
+
+class Audience(
+  val value: String,
+  val id: UUID? = UUID.randomUUID(),
+) : CharSequence by value {
+  init {
+    require(value.isNotBlank())
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || other !is Audience) return false
+    return this.value == other.value
+  }
+
+  override fun hashCode(): Int = value.hashCode()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseEntity.kt
@@ -8,6 +8,7 @@ class CourseEntity(
   val type: String,
   val description: String? = null,
   val prerequisites: List<Prerequisite>,
+  val audience: List<Audience>,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseService.kt
@@ -31,6 +31,7 @@ class CourseService {
         Prerequisite(name = "risk score", description = "ORGS: 50+"),
         Prerequisite(name = "offence type", description = "some offence here"),
       ),
+      audience = listOf(Audience("Sexual offence")),
     )
 
     private val bnm = CourseEntity(
@@ -42,6 +43,7 @@ class CourseService {
         Prerequisite(name = "risk score", description = "ORGS: 50+"),
         Prerequisite(name = "offence type", description = "some offence here"),
       ),
+      audience = listOf(Audience("Extremism"), Audience("General violence")),
     )
 
     private val nms = CourseEntity(
@@ -54,6 +56,7 @@ class CourseService {
         Prerequisite(name = "risk score", description = "ORGS: 50+"),
         Prerequisite(name = "offence type", description = "some offence here"),
       ),
+      audience = listOf(Audience("General violence")),
     )
 
     private val courses: Set<CourseEntity> = setOf(tsp, bnm, nms)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/transformer/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/transformer/Transformers.kt
@@ -1,29 +1,37 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.transformer
 
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Course
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseAudience
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseOffering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CoursePrerequisite
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Audience
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Offering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Prerequisite
 
 fun CourseEntity.toApi(): Course = Course(
-  id = this.id,
-  name = this.name,
-  type = this.type,
-  description = this.description,
-  coursePrerequisites = this.prerequisites.map(Prerequisite::toApi),
+  id = id,
+  name = name,
+  type = type,
+  description = description,
+  coursePrerequisites = prerequisites.map(Prerequisite::toApi),
+  audience = audience.map(Audience::toApi),
 )
 
 fun Prerequisite.toApi(): CoursePrerequisite = CoursePrerequisite(
-  name = this.name,
-  description = this.description,
+  name = name,
+  description = description,
 )
 
 fun Offering.toApi(): CourseOffering = CourseOffering(
-  id = this.id,
-  organisationId = this.organisationId,
-  duration = this.duration.toIsoString(),
-  groupSize = this.groupSize,
+  id = id,
+  organisationId = organisationId,
+  duration = duration.toIsoString(),
+  groupSize = groupSize,
   contactEmail = contactEmail,
+)
+
+fun Audience.toApi(): CourseAudience = CourseAudience(
+  id = id!!,
+  value = value,
 )

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -122,6 +122,17 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CoursePrerequisite'
+        audience:
+          type: array
+          items:
+            $ref: '#/components/schemas/CourseAudience'
+      required:
+        - id
+        - name
+        - type
+        - type
+        - coursePrerequisites
+        - audience
 
     CoursePrerequisite:
       type: object
@@ -137,6 +148,9 @@ components:
           description: 'ORGS: 50+'
         - name: offence type
           description: some offence here
+      required:
+        - name
+        - description
 
     CourseOffering:
       type: object
@@ -167,6 +181,19 @@ components:
         - contactEmail
         - duration
         - groupSize
+
+    CourseAudience:
+      type: object
+      properties:
+        value:
+          type: string
+          example: "General Violence"
+        id:
+          type: string
+          format: uuid
+      required:
+        - id
+        - value
 
     ErrorResponse:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
@@ -38,7 +38,7 @@ class PactContractTest {
   @State("Server is healthy")
   fun programCourseServiceMock() {
     `when`(service.allCourses())
-      .thenReturn(listOf(CourseEntity(UUID.randomUUID(), "", "", "", emptyList())))
+      .thenReturn(listOf(CourseEntity(UUID.randomUUID(), "", "", "", emptyList(), emptyList())))
   }
 
   @TestTemplate

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/transformer/TransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/transformer/TransformerTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CoursePrerequisite
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Audience
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Offering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Prerequisite
@@ -19,6 +20,7 @@ class TransformerTest {
       name = "A Course",
       type = "A type",
       prerequisites = emptyList(),
+      audience = emptyList(),
     )
 
     with(entity.toApi()) {
@@ -38,6 +40,7 @@ class TransformerTest {
       type = "A type",
       description = "A description",
       prerequisites = emptyList(),
+      audience = emptyList(),
     )
 
     with(entity.toApi()) {
@@ -46,7 +49,7 @@ class TransformerTest {
   }
 
   @Test
-  fun `transform course entity to api with prerequisites`() {
+  fun `transform course entity to api with prerequisites and audience`() {
     val entity = CourseEntity(
       id = UUID.randomUUID(),
       name = "A Course",
@@ -55,6 +58,11 @@ class TransformerTest {
         Prerequisite(name = "gender", description = "female"),
         Prerequisite(name = "risk score", description = "ORGS: 50+"),
       ),
+      audience = listOf(
+        Audience("A"),
+        Audience("B"),
+        Audience("C"),
+      ),
     )
 
     with(entity.toApi()) {
@@ -62,6 +70,7 @@ class TransformerTest {
         CoursePrerequisite(name = "gender", description = "female"),
         CoursePrerequisite(name = "risk score", description = "ORGS: 50+"),
       )
+      audience.map { it.value } shouldContainExactlyInAnyOrder listOf("C", "B", "A")
     }
   }
 
@@ -91,6 +100,7 @@ class TransformerTest {
         name = "A Course",
         type = "A type",
         prerequisites = emptyList(),
+        audience = emptyList(),
       ),
     )
 
@@ -100,6 +110,15 @@ class TransformerTest {
       Duration.parseIsoString(duration) shouldBe offering.duration
       groupSize shouldBe offering.groupSize
       contactEmail shouldBe offering.contactEmail
+    }
+  }
+
+  @Test
+  fun `transform domain Audience to a CourseAudience`() {
+    val audience = Audience("An audience")
+    with(audience.toApi()) {
+      id shouldBe audience.id
+      value shouldBe audience.value
     }
   }
 }


### PR DESCRIPTION
## Context

Trello [442](https://trello.com/c/RQVOzssn/442-add-audience-field-to-course-model-api) Add audience field to course model API

## Changes in this PR

Extended tests to show presence of 'audience' property of CourseEntity, Added audience field to api, domain and CourseEntity transformer.