### PR TITLE
(415) Run E2E tests on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   hmpps: ministryofjustice/hmpps@7.3.1
+  node: circleci/node@4.5.2
 
 parameters:
   alerts-slack-channel:
@@ -38,6 +39,27 @@ jobs:
           path: build/reports/tests
       - store_artifacts:
           path: build/pact
+
+  end_to_end_test:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.34.2-focal
+    circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
+    steps:
+      - run:
+          name: Clone E2E repo
+          command: |
+            git clone https://github.com/ministryofjustice/hmpps-accredited-programmes-e2e.git .
+      - run:
+          name: Update npm
+          command: 'npm install -g npm@latest'
+      - node/install-packages
+      - run:
+          name: E2E Check
+          command: |
+            npx playwright test
+      - store_artifacts:
+          path: test_results
+          destination: test_results
 
   tag_pact_version:
     environment:
@@ -91,6 +113,14 @@ workflows:
             - build_docker
             - helm_lint
           helm_timeout: 5m
+      - end_to_end_test:
+          context: hmpps-common-vars
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - deploy_dev
       - tag_pact_version:
           name: "tag_pact_version_dev"
           tag: "deployed:dev"

--- a/doc/adr/0002-use-playwright-for-end-to-end-tests.md
+++ b/doc/adr/0002-use-playwright-for-end-to-end-tests.md
@@ -1,0 +1,58 @@
+# 2. Use Playwright for End-to-End tests
+
+Date: 2023-05-30
+
+## Status
+
+Accepted
+
+## Context
+
+We have a suite of integration tests in this repository that use
+[Cypress](https://www.cypress.io/) to test the application locally against a
+mock API. We'd like to be able to test the application as a whole with a real
+backend to ensure everything is working as expected on a deployed environment.
+
+Although in [this ADR](./0002-use-pact-for-contract-testing.md) we decided we'd
+use contract tests instead of E2E tests to cover some of this functionality,
+contract tests don't quite cover everything we might want to test, so, for the
+sake of confidence, we would like to keep using a suite of E2E tests somewhere.
+
+Other teams, particularly the Approved Premises team initially trialled running
+Cypress against a deployed environment but encountered issues with slowness,
+flakiness and conflicting Typescript settings with their main codebase and the
+code used to write the tests so have moved away from this.
+
+## Decision
+
+As the Approved Premises team [have
+done](https://github.com/ministryofjustice/hmpps-approved-premises-ui/blob/main/doc/architecture/decisions/0010-use-playwright-for-end-to-end-tests.md),
+we're going to trial using a suite of end to end tests in a different repo
+using [Playwright](https://playwright.dev/). This is a more lightweight
+alternative to Cypress, which is in use in other parts of HMPPS (See
+<https://github.com/ministryofjustice/hmpps-probation-integration-e2e-tests>).
+
+These tests will be run in the `end_to_end_test` CircleCI pipeline on the
+development environment, after the environment has deployed, both on the UI and
+API codebases.
+
+We will deliberately keep the tests focused, as more of a smoke test to ensure
+the application runs as expected, rather than reusing integration test code
+which is more robust and has a lot of expectations.
+
+We will keep an eye on these tests and how they go, because there is a balance
+between us having a consistently passing test suite (which may suggest our
+happy path is too "happy") and a test suite that breaks a lot, but for
+legitimate reasons (i.e. a change in the UI or API that breaks functionality).
+
+## Consequences
+
+This will mean we're maintaining two test suites, one for integration and one
+for end-to-end tests, however:
+
+- The end-to-end tests will be kept deliberately simplistic, only testing the
+  "happy path", with minimal expectations
+- We will be able to use the VSCode [Playwright Test
+  plugin](https://marketplace.visualstudio.com/items?itemName=ms-playwright.playwright),
+  which will allow us to "record" any new/changed tests - meaning we can
+  rapidly generate / iterate end to end tests


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->

[Trello card](https://trello.com/c/zGaYc1r5/415-add-e2e-tests)

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

We now run end-to-end tests on CI.

This will run end-to-end tests on the deployed dev environment to ensure we're testing the entire end-to-end journey with a real front and back end to catch anything that might break functionality.

The script clones the e2e test repo locally, installs dependencies and runs the Playwright test script.

This PR also adds an ADR to document our decision to use Playwright for our tests.


