### PR TITLE
Fix failing Pact tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseEntity.kt
@@ -8,7 +8,7 @@ class CourseEntity(
   val type: String,
   val description: String? = null,
   val prerequisites: List<Prerequisite>,
-  val audience: List<Audience>,
+  val audiences: List<Audience>,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseService.kt
@@ -20,72 +20,79 @@ class CourseService {
     offerings
       .find { it.id == offeringId && it.course.id == courseId }
 
-  companion object {
+  private companion object {
     private val tsp = CourseEntity(
-      name = "Thinking Skills Programme",
-      type = "TypeA",
-      description = "Thinking Skills Programme (TSP) is for adult men and women with a medium or high risk of re offending...",
+      id = UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"),
+      name = "Lime Course",
+      type = "Accredited Programme",
+      description = "Explicabo exercitationem non asperiores corrupti accusamus quidem autem amet modi. Mollitia tenetur fugiat quo aperiam quasi error consectetur. Fugit neque rerum velit rem laboriosam. Atque nostrum quam aspernatur excepturi laborum harum officia eveniet porro.",
       prerequisites = listOf(
-        Prerequisite(name = "gender", description = "female"),
-        Prerequisite(name = "risk score", description = "ORGS: 50+"),
-        Prerequisite(name = "offence type", description = "some offence here"),
+        Prerequisite(name = "Setting", description = "Custody"),
+        Prerequisite(name = "Risk criteria", description = "High ESARA/SARA/OVP, High OGRS"),
+        Prerequisite(name = "Criminogenic needs", description = "Relationships, Thinking and Behaviour, Attitudes, Lifestyle"),
       ),
-      audience = listOf(Audience("Sexual offence")),
+      audiences = emptyList(),
     )
 
     private val bnm = CourseEntity(
-      name = "Becoming new me +",
-      type = "TypeB",
-      description = "Becoming new me + is for adult men and women with a medium or high risk of re offending...",
+      id = UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"),
+      name = "Azure Course",
+      type = "Accredited Programme",
+      description = "Similique laborum incidunt sequi rem quidem incidunt incidunt dignissimos iusto. Explicabo nihil atque quod culpa animi quia aspernatur dolorem consequuntur.",
       prerequisites = listOf(
-        Prerequisite(name = "gender", description = "female"),
-        Prerequisite(name = "risk score", description = "ORGS: 50+"),
-        Prerequisite(name = "offence type", description = "some offence here"),
+        Prerequisite(name = "Setting", description = "Custody"),
+        Prerequisite(name = "Risk criteria", description = "High ESARA/SARA/OVP, High OGRS"),
+        Prerequisite(name = "Criminogenic needs", description = "Relationships, Thinking and Behaviour, Attitudes, Lifestyle"),
       ),
-      audience = listOf(Audience("Extremism"), Audience("General violence")),
+      audiences = listOf(Audience(value = "Sexual violence")),
     )
 
     private val nms = CourseEntity(
-
-      name = "New me strengths",
-      type = "TypeA",
-      description = "New me strengths is for adult men and women with a medium or high risk of re offending...",
+      id = UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"),
+      name = "Violet Course",
+      type = "Accredited Programme",
+      description = "Tenetur a quisquam facilis amet illum voluptas error. Eaque eum sunt odit dolor voluptatibus eius sint impedit. Illo voluptatem similique quod voluptate laudantium. Ratione suscipit tempore amet autem quam dolorum. Necessitatibus tenetur recusandae aliquam recusandae temporibus voluptate velit similique fuga. Id tempora doloremque.",
       prerequisites = listOf(
-        Prerequisite(name = "gender", description = "female"),
-        Prerequisite(name = "risk score", description = "ORGS: 50+"),
-        Prerequisite(name = "offence type", description = "some offence here"),
+        Prerequisite(name = "Setting", description = "Custody"),
+        Prerequisite(name = "Risk criteria", description = "High ESARA/SARA/OVP, High OGRS"),
+        Prerequisite(name = "Criminogenic needs", description = "Relationships, Thinking and Behaviour, Attitudes, Lifestyle"),
       ),
-      audience = listOf(Audience("General violence")),
+      audiences = emptyList(),
     )
 
     private val courses: Set<CourseEntity> = setOf(tsp, bnm, nms)
 
     private val offerings: Set<Offering> = setOf(
       Offering(
+        id = UUID.randomUUID(),
         organisationId = "MDI",
         contactEmail = "nobody-mdi@digital.justice.gov.uk",
         course = tsp,
       ),
 
       Offering(
+        id = UUID.randomUUID(),
         organisationId = "BWN",
         contactEmail = "nobody-bwn@digital.justice.gov.uk",
         course = tsp,
       ),
 
       Offering(
+        id = UUID.randomUUID(),
         organisationId = "BXI",
         contactEmail = "nobody-bxi@digital.justice.gov.uk",
         course = tsp,
       ),
 
       Offering(
+        id = UUID.randomUUID(),
         organisationId = "MDI",
         contactEmail = "nobody-mdi@digital.justice.gov.uk",
         course = bnm,
       ),
 
       Offering(
+        id = UUID.randomUUID(),
         organisationId = "BWN",
         contactEmail = "nobody-bwn@digital.justice.gov.uk",
         course = nms,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/transformer/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/transformer/Transformers.kt
@@ -15,7 +15,7 @@ fun CourseEntity.toApi(): Course = Course(
   type = type,
   description = description,
   coursePrerequisites = prerequisites.map(Prerequisite::toApi),
-  audience = audience.map(Audience::toApi),
+  audiences = audiences.map(Audience::toApi),
 )
 
 fun Prerequisite.toApi(): CoursePrerequisite = CoursePrerequisite(

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -122,7 +122,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CoursePrerequisite'
-        audience:
+        audiences:
           type: array
           items:
             $ref: '#/components/schemas/CourseAudience'
@@ -132,7 +132,7 @@ components:
         - type
         - type
         - coursePrerequisites
-        - audience
+        - audiences
 
     CoursePrerequisite:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/CourseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/CourseServiceTest.kt
@@ -35,7 +35,7 @@ class CourseServiceTest {
 
   @Test
   fun `offerings for a known course should return the offerings`() {
-    val course = service.allCourses().find { it.name == "Thinking Skills Programme" }
+    val course = service.allCourses().find { it.name == "Lime Course" }
     course.shouldNotBeNull()
     val offerings = service.offeringsForCourse(course.id)
 
@@ -45,7 +45,7 @@ class CourseServiceTest {
 
   @Test
   fun `find an offering by known course id and offering id - success`() {
-    val courseId = service.allCourses().find { it.name == "Thinking Skills Programme" }?.id
+    val courseId = service.allCourses().find { it.name == "Lime Course" }?.id
     courseId.shouldNotBeNull()
 
     val expectedOffering = service.offeringsForCourse(courseId).find { it.organisationId == "BXI" }
@@ -59,7 +59,7 @@ class CourseServiceTest {
 
   @Test
   fun `find an offering by known course id and unknown offering id - fail`() {
-    val courseId = service.allCourses().find { it.name == "Thinking Skills Programme" }?.id
+    val courseId = service.allCourses().find { it.name == "Lime Course" }?.id
     courseId.shouldNotBeNull()
 
     service.courseOffering(courseId = courseId, offeringId = UUID.randomUUID()).shouldBeNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesControllerTest.kt
@@ -33,9 +33,9 @@ class CoursesControllerTest(
       .json(
         """
           [
-            { "name": "Thinking Skills Programme" },
-            { "name": "New me strengths" },
-            { "name": "Becoming new me +" }
+            { "name": "Lime Course" },
+            { "name": "Azure Course" },
+            { "name": "Violet Course" }
         ]
         """,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
@@ -7,23 +7,15 @@ import au.com.dius.pact.provider.junitsupport.VerificationReports
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker
 import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider
 import org.apache.hc.core5.http.HttpRequest
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.Mockito.`when`
-import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
 import org.springframework.test.context.ActiveProfiles
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
-import java.util.*
 
-@Disabled
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("test")
 @Import(JwtAuthHelper::class)
@@ -34,20 +26,22 @@ class PactContractTest {
   @Autowired
   lateinit var jwtAuthHelper: JwtAuthHelper
 
-  @MockBean
-  lateinit var service: CourseService
-
   @State("Server is healthy")
-  fun programCourseServiceMock() {
-    `when`(service.allCourses())
-      .thenReturn(listOf(CourseEntity(UUID.randomUUID(), "", "", "", emptyList(), emptyList())))
-  }
+  fun ensureServerIsHealthy() {}
+
+  @State("Courses exist on the API")
+  fun ensureCoursesExist() {}
+
+  @State("A course exists with ID 28e47d30-30bf-4dab-a8eb-9fda3f6400e8")
+  fun ensureCourseExists() {}
+
+  @State("Offerings exist for a course with ID 28e47d30-30bf-4dab-a8eb-9fda3f6400e8")
+  fun ensureOfferingExists() {}
 
   @TestTemplate
   @ExtendWith(PactVerificationSpringProvider::class)
   fun template(context: PactVerificationContext, request: HttpRequest) {
     request.setHeader(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
     context.verifyInteraction()
-    verify(service).allCourses()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/transformer/TransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/transformer/TransformerTest.kt
@@ -19,7 +19,7 @@ class TransformerTest {
       name = "A Course",
       type = "A type",
       prerequisites = emptyList(),
-      audience = emptyList(),
+      audiences = emptyList(),
     )
 
     with(entity.toApi()) {
@@ -39,7 +39,7 @@ class TransformerTest {
       type = "A type",
       description = "A description",
       prerequisites = emptyList(),
-      audience = emptyList(),
+      audiences = emptyList(),
     )
 
     with(entity.toApi()) {
@@ -57,7 +57,7 @@ class TransformerTest {
         Prerequisite(name = "gender", description = "female"),
         Prerequisite(name = "risk score", description = "ORGS: 50+"),
       ),
-      audience = listOf(
+      audiences = listOf(
         Audience("A"),
         Audience("B"),
         Audience("C"),
@@ -69,7 +69,7 @@ class TransformerTest {
         CoursePrerequisite(name = "gender", description = "female"),
         CoursePrerequisite(name = "risk score", description = "ORGS: 50+"),
       )
-      audience.map { it.value } shouldContainExactlyInAnyOrder listOf("C", "B", "A")
+      audiences.map { it.value } shouldContainExactlyInAnyOrder listOf("C", "B", "A")
     }
   }
 
@@ -97,7 +97,7 @@ class TransformerTest {
         name = "A Course",
         type = "A type",
         prerequisites = emptyList(),
-        audience = emptyList(),
+        audiences = emptyList(),
       ),
     )
 


### PR DESCRIPTION
## Context

Trello [465 API: fix failing Pact tests](https://trello.com/c/jcc6cAsa/465-api-fix-failing-pact-tests)

## Changes in this PR
`PactContractTest` enabled, model and data tweaked to comply with current state of the Pact contract for this API.
