### PR TITLE
:bug: Helm deployment: Use the correct name for the kubernetes database credentials secret

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-api/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-api/values.yaml
@@ -30,7 +30,7 @@ generic-service:
   namespace_secrets:
     hmpps-accredited-programmes-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
-    dps-rds-instance-output:
+    rds-postgresql-instance-output:
       DATABASE_ENDPOINT: "rds_instance_endpoint"
       DATABASE_NAME: "database_name"
       DATABASE_USERNAME: "database_username"


### PR DESCRIPTION


## Context
Trello: [417 Create Database](https://trello.com/c/kUnIVhHw/417-create-database)
Dev deployment fails due to Helm chart misconfiguration. 

## Changes in this PR
Fix the Helm deployment by updating `vaules.yml` to use the correct name for the Kubernetes secret that contains the PostgreSQL Database credentials.