### PR TITLE
417 :bug: Add the current AWS RDS root certificate to the Java trust store when building the Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,11 @@ RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezo
 RUN addgroup --gid 2000 --system appgroup && \
     adduser --uid 2000 --system appuser --gid 2000
 
+# Install AWS RDS Root cert into Java truststore
+RUN mkdir /home/appuser/.postgresql \
+  && curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem \
+    > /home/appuser/.postgresql/root.crt
+
 WORKDIR /app
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-accredited-programmes-api*.jar /app/app.jar
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar


### PR DESCRIPTION
## Changes in this PR
Added 
 ```
RUN mkdir /home/appuser/.postgresql \
  && curl https://s3.amazonaws.com/rds-downloads/rds-ca-2019-root.pem \
    > /home/appuser/.postgresql/root.crt

```
to the `Dockerfile`.  The PostgreSQL driver should now trust the AWS RDS PostgreSQL instance to which it connects.