### PR TITLE
(395) Add Sentry spring boot SDK and configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ configurations {
 dependencies {
   val kotestVersion = "5.6.2"
   val springdocVersion = "1.7.0"
+  val sentryVersion = "6.22.0"
 
   runtimeOnly("org.postgresql:postgresql:42.6.0")
 
@@ -23,6 +24,9 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("org.flywaydb:flyway-core")
+
+  implementation("io.sentry:sentry-spring-boot-starter:$sentryVersion")
+  implementation("io.sentry:sentry-logback:$sentryVersion")
 
   implementation("org.springdoc:springdoc-openapi-data-rest:$springdocVersion")
   implementation("org.springdoc:springdoc-openapi-ui:$springdocVersion")

--- a/helm_deploy/hmpps-accredited-programmes-api/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-api/values.yaml
@@ -30,6 +30,7 @@ generic-service:
   namespace_secrets:
     hmpps-accredited-programmes-api:
       APPINSIGHTS_INSTRUMENTATIONKEY: "APPINSIGHTS_INSTRUMENTATIONKEY"
+      SENTRY_DSN: "SENTRY_DSN"
     rds-postgresql-instance-output:
       DATABASE_ENDPOINT: "rds_instance_endpoint"
       DATABASE_NAME: "database_name"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,6 +11,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+    SENTRY_ENVIRONMENT: dev
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->

https://trello.com/c/jZYDnjEO/395-add-sentry-to-ui-and-api-for-logging-errors

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

Adds and configures Sentry via the Spring Boot SDK following instructions here: https://ministryofjustice.sentry.io/projects/hmpps-approved-premises-api-k1/getting-started/

I've added the new `SENTRY_DSN` environment variable as a Kubernetes secret so this should hopefully deploy successfully.
