### PR TITLE
Remove the 'allowlist' from the helm chart configuration. 

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-api/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-api/values.yaml
@@ -37,15 +37,5 @@ generic-service:
       DATABASE_USERNAME: "database_username"
       DATABASE_PASSWORD: "database_password"
 
-  allowlist:
-    office: "217.33.148.210/32"
-    health-kick: "35.177.252.195/32"
-    petty-france-wifi: "213.121.161.112/28"
-    global-protect: "35.176.93.186/32"
-    mojvpn: "81.134.202.29/32"
-    cloudplatform-live-1: "35.178.209.113/32"
-    cloudplatform-live-2: "3.8.51.207/32"
-    cloudplatform-live-3: "35.177.252.54/32"
-
 generic-prometheus-alerts:
   targetApplication: hmpps-accredited-programmes-api


### PR DESCRIPTION

## Changes in this PR
Removed the 'allowlist' from the helm chart configuration.  Access to the application is now allowed from any IP address.  Standard authentication / authorisation still applies.
