### PR TITLE
(444) Add prod and pre-prod deployment config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,38 +126,34 @@ workflows:
           tag: "deployed:dev"
           requires: [ deploy_dev ]
           context: [ hmpps-common-vars ]
-#      - request-preprod-approval:
-#          type: approval
-#          requires:
-#            - deploy_dev
-#      - hmpps/deploy_env:
-#          name: deploy_preprod
-#          env: "preprod"
-#          jira_update: true
-#          jira_env_type: staging
-#          context:
-#            - hmpps-common-vars
-#            - hmpps-accredited-programmes-api-preprod
-#          requires:
-#            - request-preprod-approval
-#          helm_timeout: 5m
-#      - request-prod-approval:
-#          type: approval
-#          requires:
-#            - deploy_preprod
-#      - hmpps/deploy_env:
-#          name: deploy_prod
-#          env: "prod"
-#          jira_update: true
-#          jira_env_type: production
-#          slack_notification: true
-#          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-#          context:
-#            - hmpps-common-vars
-#            - hmpps-accredited-programmes-api-prod
-#          requires:
-#            - request-prod-approval
-#          helm_timeout: 5m
+
+      - request-preprod-approval:
+          type: approval
+          requires:
+            - deploy_dev
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: "preprod"
+          context:
+            - hmpps-common-vars
+            - hmpps-accredited-programmes-api-preprod
+          requires:
+            - request-preprod-approval
+
+      - request-prod-approval:
+          type: approval
+          requires:
+            - deploy_preprod
+      - hmpps/deploy_env:
+          name: deploy_prod
+          env: "prod"
+          slack_notification: true
+          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+          context:
+            - hmpps-common-vars
+            - hmpps-accredited-programmes-api-prod
+          requires:
+            - request-prod-approval
 
   security:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,11 @@ workflows:
             - hmpps-accredited-programmes-api-preprod
           requires:
             - request-preprod-approval
+      - tag_pact_version:
+          name: "tag_pact_version_preprod"
+          tag: "deployed:preprod"
+          requires: [ deploy_preprod ]
+          context: [ hmpps-common-vars ]
 
       - request-prod-approval:
           type: approval
@@ -154,6 +159,11 @@ workflows:
             - hmpps-accredited-programmes-api-prod
           requires:
             - request-prod-approval
+      - tag_pact_version:
+          name: "tag_pact_version_prod"
+          tag: "deployed:prod"
+          requires: [ deploy_prod ]
+          context: [ hmpps-common-vars ]
 
   security:
     triggers:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -8,6 +8,7 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
+    SENTRY_ENVIRONMENT: preprod
 
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -8,6 +8,7 @@ generic-service:
 
 env:
   HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
+  SENTRY_ENVIRONMENT: prod
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/CWoUr4XC/444-create-prod-pre-prod-environments
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

- Adds environment variables to be used in Sentry for filtering issues based on the deployed environment
- Adds deployment steps to CircleCI script for prod and pre-prod environments.