### PR TITLE
(503) Add pact provider test for a single offering

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
@@ -38,6 +38,9 @@ class PactContractTest {
   @State("Offerings exist for a course with ID 28e47d30-30bf-4dab-a8eb-9fda3f6400e8")
   fun ensureOfferingsExist() {}
 
+  @State("An offering exists with ID 20f3abc8-dd92-43ae-b88e-5797a0ad3f4b")
+  fun ensureOfferingExists() {}
+
   @TestTemplate
   @ExtendWith(PactVerificationSpringProvider::class)
   fun template(context: PactVerificationContext, request: HttpRequest) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
@@ -36,7 +36,7 @@ class PactContractTest {
   fun ensureCourseExists() {}
 
   @State("Offerings exist for a course with ID 28e47d30-30bf-4dab-a8eb-9fda3f6400e8")
-  fun ensureOfferingExists() {}
+  fun ensureOfferingsExist() {}
 
   @TestTemplate
   @ExtendWith(PactVerificationSpringProvider::class)

--- a/src/test/resources/db/migration/R__test_data.sql
+++ b/src/test/resources/db/migration/R__test_data.sql
@@ -22,7 +22,7 @@ VALUES ('7fffcc6a-11f8-4713-be35-cf5ff1aee517', 'd3abc217-75ee-46e9-a010-368f302
        ('790a2dfe-7de5-4504-bb9c-83e6e53a6537', 'd3abc217-75ee-46e9-a010-368f30282367', 'BWN', 'nobody-bwn@digital.justice.gov.uk'),
        ('39b77a2f-7398-4d5f-b744-cdcefca12671', 'd3abc217-75ee-46e9-a010-368f30282367', 'BXI', 'nobody-bxi@digital.justice.gov.uk'),
 
-       ('ee20f564-4853-40b2-bae4-65dd7e0207fa', '28e47d30-30bf-4dab-a8eb-9fda3f6400e8', 'MDI', 'nobody-mdi@digital.justice.gov.uk'),
+       ('20f3abc8-dd92-43ae-b88e-5797a0ad3f4b', '28e47d30-30bf-4dab-a8eb-9fda3f6400e8', 'OCC', 'nobody-iry@digital.justice.gov.uk'),
 
        ('b328ebc8-1f7b-4236-b4ac-30f50b43a92d', '1811faa6-d568-4fc4-83ce-41118b90242e', 'BWN', 'nobody-bwn@digital.justice.gov.uk');
 


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
[503-add-new-pact-provider-test-for-a-single-offering
](https://trello.com/c/GTnZa5qw/503-add-new-pact-provider-test-for-a-single-offering)

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

Adds a new Pact state to cover requests made for an individual offering with id `20f3abc8-dd92-43ae-b88e-5797a0ad3f4b`