### PR TITLE
Add correct host and tlsconfig for Prod and Preprod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -4,6 +4,7 @@
 generic-service:
   ingress:
     host: accredited-programmes-api-preprod.hmpps.service.justice.gov.uk
+    tlsSecretName: hmpps-accredited-programmes-api-preprod-cert
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -3,13 +3,12 @@
 
 generic-service:
   ingress:
-    host: hmpps-accredited-programmes-api-preprod.hmpps.service.justice.gov.uk
+    host: accredited-programmes-api-preprod.hmpps.service.justice.gov.uk
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
     SENTRY_ENVIRONMENT: preprod
-
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -3,8 +3,7 @@
 
 generic-service:
   ingress:
-    host: hmpps-accredited-programmes-api.hmpps.service.justice.gov.uk
-
+    host: accredited-programmes-api.hmpps.service.justice.gov.uk
 
 env:
   HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -4,6 +4,7 @@
 generic-service:
   ingress:
     host: accredited-programmes-api.hmpps.service.justice.gov.uk
+    tlsSecretName: hmpps-accredited-programmes-api-prod-cert
 
 env:
   HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth


### PR DESCRIPTION
## Changes in this PR

When testing out the preprod environment, I noticed the API doesn't appear to be accessible on the web, despite the service successfully running on a Kubernetes pod.

I believe the reason for this is the incorrect `host` and `tlsConfig` values we're setting for each environment, which have been wrong since the initial setup - we had an erroneous `hmpps-` prefix and a missing `tlsSecret` field here.

These values now match those specified in the Cloud Platform Environments repository:

- [Prod](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-prod/06-certificates.yaml)
- [Preprod](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-accredited-programmes-preprod/06-certificates.yaml)
