### PR TITLE
Add a Spring Boot profile 'seed' that loads seed data into the appliation's database.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,13 +49,11 @@ services:
         condition: service_healthy
 
     environment:
-      - SPRING_PROFILES_ACTIVE=dev
+      - SPRING_PROFILES_ACTIVE=dev,local,seed
       - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgresql:5432/postgres
       - SPRING_DATASOURCE_USERNAME=admin
       - SPRING_DATASOURCE_PASSWORD=admin_password
-      - OAUTH_CLIENT_ID=whereabouts-api-client
-      - OAUTH_CLIENT_SECRET=clientsecret
 
 networks:
   hmpps:

--- a/src/main/resources/application-seed.yml
+++ b/src/main/resources/application-seed.yml
@@ -1,0 +1,3 @@
+spring:
+  flyway:
+    locations: classpath:db/migration,classpath:/seed/db/migration/

--- a/src/main/resources/seed/db/migration/R__Seed_Data.sql
+++ b/src/main/resources/seed/db/migration/R__Seed_Data.sql
@@ -1,0 +1,46 @@
+DELETE from course_audience;
+DELETE from offering;
+DELETE from prerequisite;
+DELETE from audience;
+DELETE from course;
+
+INSERT INTO audience(audience_id, audience_value)
+VALUES ('7fffcc6a-11f8-4713-be35-cf5ff1aee517', 'Sexual violence'),
+       ('7fffcc6a-11f8-4713-be35-cf5ff1aee518', 'Extremism offence'),
+       ('7fffcc6a-11f8-4713-be35-cf5ff1aee519', 'Gang offence'),
+       ('7fffcc6a-11f8-4713-be35-cf5ff1aee510', 'Violent offence'),
+       ('7fffcc6a-11f8-4713-be35-cf5ff1aee511', 'Intimate partner violence');
+
+INSERT INTO course(course_id, name, description)
+VALUES ('d3abc217-75ee-46e9-a010-368f30282367', 'Lime Course', 'Explicabo exercitationem non asperiores corrupti accusamus quidem autem amet modi. Mollitia tenetur fugiat quo aperiam quasi error consectetur. Fugit neque rerum velit rem laboriosam. Atque nostrum quam aspernatur excepturi laborum harum officia eveniet porro.'),
+       ('28e47d30-30bf-4dab-a8eb-9fda3f6400e8', 'Azure Course', 'Similique laborum incidunt sequi rem quidem incidunt incidunt dignissimos iusto. Explicabo nihil atque quod culpa animi quia aspernatur dolorem consequuntur.'),
+       ('1811faa6-d568-4fc4-83ce-41118b90242e', 'Violet Course', 'Tenetur a quisquam facilis amet illum voluptas error. Eaque eum sunt odit dolor voluptatibus eius sint impedit. Illo voluptatem similique quod voluptate laudantium. Ratione suscipit tempore amet autem quam dolorum. Necessitatibus tenetur recusandae aliquam recusandae temporibus voluptate velit similique fuga. Id tempora doloremque.');
+
+INSERT INTO prerequisite(course_id, name, description)
+VALUES ('d3abc217-75ee-46e9-a010-368f30282367', 'Setting', 'Custody'),
+       ('d3abc217-75ee-46e9-a010-368f30282367', 'Risk criteria', 'High ESARA/SARA/OVP, High OGRS'),
+       ('d3abc217-75ee-46e9-a010-368f30282367', 'Criminogenic needs', 'Relationships, Thinking and Behaviour, Attitudes, Lifestyle'),
+       ('28e47d30-30bf-4dab-a8eb-9fda3f6400e8', 'Setting', 'Custody'),
+       ('28e47d30-30bf-4dab-a8eb-9fda3f6400e8', 'Risk criteria', 'High ESARA/SARA/OVP, High OGRS'),
+       ('28e47d30-30bf-4dab-a8eb-9fda3f6400e8', 'Criminogenic needs', 'Relationships, Thinking and Behaviour, Attitudes, Lifestyle'),
+       ('1811faa6-d568-4fc4-83ce-41118b90242e', 'Setting', 'Custody'),
+       ('1811faa6-d568-4fc4-83ce-41118b90242e', 'Risk criteria', 'High ESARA/SARA/OVP, High OGRS'),
+       ('1811faa6-d568-4fc4-83ce-41118b90242e', 'Criminogenic needs', 'Relationships, Thinking and Behaviour, Attitudes, Lifestyle');
+
+INSERT INTO offering(offering_id, course_id, organisation_id, contact_email)
+VALUES ('7fffcc6a-11f8-4713-be35-cf5ff1aee517', 'd3abc217-75ee-46e9-a010-368f30282367', 'MDI', 'nobody-mdi@digital.justice.gov.uk'),
+       ('790a2dfe-7de5-4504-bb9c-83e6e53a6537', 'd3abc217-75ee-46e9-a010-368f30282367', 'BWN', 'nobody-bwn@digital.justice.gov.uk'),
+       ('39b77a2f-7398-4d5f-b744-cdcefca12671', 'd3abc217-75ee-46e9-a010-368f30282367', 'BXI', 'nobody-bxi@digital.justice.gov.uk'),
+
+       ('20f3abc8-dd92-43ae-b88e-5797a0ad3f4b', '28e47d30-30bf-4dab-a8eb-9fda3f6400e8', 'OCC', 'nobody-iry@digital.justice.gov.uk'),
+
+       ('b328ebc8-1f7b-4236-b4ac-30f50b43a92d', '1811faa6-d568-4fc4-83ce-41118b90242e', 'BWN', 'nobody-bwn@digital.justice.gov.uk');
+
+INSERT INTO course_audience (course_id, audience_id)
+VALUES ('28e47d30-30bf-4dab-a8eb-9fda3f6400e8', '7fffcc6a-11f8-4713-be35-cf5ff1aee517'),
+       ('28e47d30-30bf-4dab-a8eb-9fda3f6400e8', '7fffcc6a-11f8-4713-be35-cf5ff1aee511'),
+       ('d3abc217-75ee-46e9-a010-368f30282367', '7fffcc6a-11f8-4713-be35-cf5ff1aee518'),
+       ('d3abc217-75ee-46e9-a010-368f30282367', '7fffcc6a-11f8-4713-be35-cf5ff1aee519'),
+       ('d3abc217-75ee-46e9-a010-368f30282367', '7fffcc6a-11f8-4713-be35-cf5ff1aee510'),
+       ('1811faa6-d568-4fc4-83ce-41118b90242e', '7fffcc6a-11f8-4713-be35-cf5ff1aee518'),
+       ('1811faa6-d568-4fc4-83ce-41118b90242e', '7fffcc6a-11f8-4713-be35-cf5ff1aee519');


### PR DESCRIPTION
## Context

Trello: [529 Seed local dev database](https://trello.com/c/n2CpKiCa/529-seed-local-dev-database)
The seed profile is defined by application-seed.yml. Seed data is loaded into the database using a flyway repeatable migration at src/main/resources/seed/db/migration/R__Seed_Data.sql and finally, the docker compose configuration file docker-compose.yml has been updated to launch the hmpps-accredited-programmes-api image container with the seed profile enabled. This means that application can be started and populated with seed data using 'docker-compose up'.

## Changes in this PR

* Introduced a new Spring Boot profile 'seed' defined in `application-seed.yml` 
* The profile instructs flyway to run migrations from `classpath:/seed/db/migration/` in addition to the standard location
* The migration script, `R__Seed_Data.sql` clears and then populates the application's database tables with seed data
* The docker compose target `hmpps-accredited-programmes-api` defined in file docker-compose.yml has been updated to run with the seed profile enabled.

Result: `docker-compose up` launches the api application with seed data installed.
