### PR TITLE
2023 06 27 minor improvements

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesController.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.CoursesApiD
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Course
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseOffering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseRecord
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.LineError
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.LineMessage
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.OfferingRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.PrerequisiteRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseEntity
@@ -32,10 +32,10 @@ class CoursesController(
     return ResponseEntity.noContent().build()
   }
 
-  override fun coursesPrerequisitesPut(prerequisiteRecords: List<PrerequisiteRecord>): ResponseEntity<List<LineError>> =
+  override fun coursesPrerequisitesPut(prerequisiteRecords: List<PrerequisiteRecord>): ResponseEntity<List<LineMessage>> =
     ResponseEntity.ok(courseService.replaceAllPrerequisites(prerequisiteRecords))
 
-  override fun coursesOfferingsPut(offeringRecord: List<OfferingRecord>): ResponseEntity<List<LineError>> =
+  override fun coursesOfferingsPut(offeringRecord: List<OfferingRecord>): ResponseEntity<List<LineMessage>> =
     ResponseEntity.ok(courseService.replaceAllOfferings(offeringRecord))
 
   override fun coursesCourseIdGet(courseId: UUID): ResponseEntity<Course> =

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -61,7 +61,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/LineError'
+                  $ref: '#/components/schemas/LineMessage'
 
         400:
           description: Bad input
@@ -115,7 +115,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/LineError'
+                  $ref: '#/components/schemas/LineMessage'
         400:
           description: Bad input
           content:
@@ -328,18 +328,24 @@ components:
         - id
         - value
 
-    LineError:
-      description: "Information about why a line in an uploaded CSV file could not be added."
+    LineMessage:
+      description: "warnings and errors for a line in an uploaded CSV file."
       type: object
       properties:
         lineNumber:
           type: integer
           example: 20
           description: "The number of the line in the CSV file that was rejected. The header line is lineNumber 1, the first line of CSV data is lineNumber 2."
-        error:
+        level:
+          type: string
+          enum:
+            - Warning
+            - Error
+          description: "One of 'Error' or 'Warning'.  If a line has an Error then the data was not added. If it is a Warning then the line was added but there was a problem that should be corrected."
+        message:
           type: string
           example: "No match for course 'Kaizen', prisonId 'BWI'"
-          description: "Why the line was rejected."
+          description: "Useful information about the Error or Warning."
 
     ErrorResponse:
       type: object

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -41,7 +41,10 @@ paths:
     put:
       tags:
         - Course prerequisites bulk upload / replace
-      summary: Upload a CVS format file containing a full set of prerequisites data for a set of courses.
+      summary: Upload a CSV format file containing a full set of prerequisites data for the current set of courses.
+      description: "Accepts a CSV format file of data representing the desired state of all prerequisite data attached to the current set of courses.
+      <p>Pre-existing prerequisite data will be removed before the new data is applied.
+      <p>The first row of CSV data is treated as a header row.  The column headings in the header row must much the names of the fields in the PrerequisiteRecord schema. Column order is not important."
       requestBody:
         required: true
         content:
@@ -93,6 +96,9 @@ paths:
       tags:
         - Course offerings bulk upload / replace
       summary: Upload a CVS format file containing a full set of offerings data for a set of courses.
+      description: "Accepts a CSV format file of data representing the desired state of all offerings data attached to the current set of courses.
+      <p>Pre-existing offering data will be removed before the new data is applied.
+      <p>The first row of CSV data is treated as a header row.  The column headings in the header row must much the names of the fields in the OfferingRecord schema. Column order is not important."
       requestBody:
         required: true
         content:
@@ -249,10 +255,16 @@ components:
       properties:
         name:
           type: string
+          example: "age"
+          description: "The name of this Course Prerequisite"
         description:
           type: string
+          example: "18+"
+          description: "The value of this Course Prerequisite"
         course:
           type: string
+          example: "Kaizen"
+          description: "The name of the Course to which this Prerequisite applies. The name must match a course name exactly for this Prerequisite to be added to the Course."
         comments:
           type: string
       required:
@@ -268,7 +280,7 @@ components:
         organisationId:
           type: string
           example: "MDI"
-          description: "The unique HPMMS identifier associated with the prison hosting the offering"
+          description: "The unique identifier associated with the location hosting the offering. For prisons this is the PrisonId which is usually three capital letters."
         contactEmail:
           type: string
           format: email
@@ -286,12 +298,19 @@ components:
       properties:
         course:
           type: string
+          example: "Kaizen"
+          description: "The name of the Course to which this Offering applies. The name must match a course name exactly for this Offering to be added to the Course."
         organisation:
           type: string
         "contact email":
           type: string
+          format: email
+          example: "ap-admin@digital.justice.gov.uk"
+          description: "The email address of the contact for this offering"
         prisonId:
           type: string
+          example: "MDI"
+          description: "The prison id for the prison associated with this Offering. This is usually three capital letters"
       required:
         - course
         - prisonId
@@ -310,12 +329,17 @@ components:
         - value
 
     LineError:
+      description: "Information about why a line in an uploaded CSV file could not be added."
       type: object
       properties:
         lineNumber:
           type: integer
+          example: 20
+          description: "The number of the line in the CSV file that was rejected. The header line is lineNumber 1, the first line of CSV data is lineNumber 2."
         error:
           type: string
+          example: "No match for course 'Kaizen', prisonId 'BWI'"
+          description: "Why the line was rejected."
 
     ErrorResponse:
       type: object


### PR DESCRIPTION
## Context

This PR is a follow-up to  [this PR (59)](https://github.com/ministryofjustice/hmpps-accredited-programmes-api/pull/60). It:
* Contains minor corrections and improvements to the documentation contained in the OpenApi spec at `api.yml`
* Extends the scope of the response body for the offerings bulk upload (PUT /courses/offerings) to warn about rows that lack a value for the `contactEmail` field.

## Changes in this PR
As described above. The first commit contains the open api documentation improvements, the second adds warning messages for offerings that lack a contactEmail.
