### PR TITLE
333 document release process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,27 @@
 <!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->
 
 ## Changes in this PR
+
+## Release checklist
+
+[Release process documentation](../doc/how-to/perform-a-release.md)
+
+As part of our continuous deployment strategy we must ensure that this work is
+ready to be released once merged.
+
+### Pre-merge
+
+- [ ] There are changes required to the Accredited Programmes UI for this change to work...
+  - [ ] ... and they been released to production already
+
+### Post-merge
+
+- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment)
+  release to preprod
+- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment)
+  release to prod
+
+<!-- Should a release fail at any step, you as the author should now lead the work to
+fix it as soon as possible. You can monitor deployment failures in CircleCI
+itself and application errors are found in
+[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->

--- a/doc/adr/0003-release-with-continuous-deployment.md
+++ b/doc/adr/0003-release-with-continuous-deployment.md
@@ -1,0 +1,73 @@
+# 4. Release with continuous deployment
+
+Date: 2023-06-22
+
+## Status
+
+Accepted
+
+## Context
+
+The Accredited Programmes service is about to launch a private beta,
+piloting with a small number of prisons, and as such we are focused on
+delivering quickly which requires as little release overhead as possible.
+
+MOJ provide the [tools for continuous
+deployment](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/using-circleci-for-continuous-deployment.html),
+configured as part of the
+[TypeScript](https://github.com/ministryofjustice/hmpps-template-typescript/blob/eac50e97924df530e1649dc4ccd4339f4491789d/.circleci/config.yml#L148)
+and
+[Kotlin](https://github.com/ministryofjustice/hmpps-template-kotlin/blob/4c7bc649f8bf8deb8dc49af58c90fd1e9e085437/.circleci/config.yml#L66)
+template repositories. This is an approach taken by other projects at MOJ.
+
+As an (at the time of writing) external team we need to be mindful that when
+handing over the project there will be advantages to having a release process
+consistent with other MOJ services.
+
+We have seen other teams that [have diverged from continuous
+deployment](https://dsdmoj.atlassian.net/wiki/spaces/MRD/pages/4228547717/Release+process)
+and are releasing in batches. We are concerned that adding a heavier process
+like this while we’re still in private beta may introduce overheads that will
+slow down delivery.
+
+## Decision
+
+We will release using continuous deployment. The author of a pull request should
+be responsible for releasing their change through to production before
+considering the work done. We'll perform both manual and automated testing on
+the development environment before releasing changes to production to ensure
+everything is working as expected.
+
+This will be done through manual approval of a release to each environment when
+a change is merged to the `main` branch.
+
+## Consequences
+
+There will be no big bang releases for the team to organise and navigate.
+
+The author of a piece of work has the most context around the work and when
+shipping it in isolation they should be best placed to ship any fixes quickly.
+
+By treating each change as a smaller, releasable piece of work and shipping them
+quickly we can deliver to users and catch bugs earlier. Once caught we are then
+set up to release fixes quickly.
+
+We'll follow the convention found in MOJ which should make it more familiar when
+we exit and hand the project back to MOJ.
+
+We'll need to make sure all changes to the codebase are backwards compatible,
+across both sides of the service (UI and API). For example, if we are working on
+a feature that depends a new API integration or a new piece of infrastructure
+like a database, then those must be released ahead of the work that depends on
+it. That work is not ready to be merged into main until the dependencies are
+ready.
+
+To help the team with this we propose extending our pull request template to
+include release prompts. If we can increase our confidence when releasing small
+parts then we should be able to release at any point.
+
+For larger new features that we don't want to release in an incomplete state,
+we'll need to decide on a way of ensuring `main` is unblocked while allowing
+unrelated branches to continue being merged to `main` before the whole feature
+is ready to be used by users. We'll likely use a combination of feature flags
+and feature branches for this.

--- a/doc/how-to/perform-a-release.md
+++ b/doc/how-to/perform-a-release.md
@@ -1,0 +1,74 @@
+# Perform a release
+
+## Prerequisites
+
+- Be a part of the Ministry of Justice GitHub organisation. This should be done
+  as part of your team onboarding process.
+- Be a part of the `accredited-programmes-team` team. This should be done as
+  part of your team onboarding process.
+
+## Releasing to the development environment
+
+This will be performed automatically on a merge to the `main` branch providing
+the `helm_lint` and `validate` jobs pass on CI.
+
+## Releasing to the preprod environment
+
+Once the `deploy_dev` CI job has passed on CI after merging a branch to `main`,
+the pipeline will hold and await manual approval (as documented in the Circle CI
+documentation
+[here](https://circleci.com/docs/workflows/#holding-a-workflow-for-a-manual-approval))
+at the `deploy_preprod` step.
+
+Perform any necessary manual testing on the development environment and ensure
+your changes are backwards compatible. For example, if we are working on a
+feature that depends a new API integration or a new piece of infrastructure like
+a database, then those must be released ahead of the work that depends on it.
+Also consider how the service would behave if we needed to roll back that
+release - would anything break?
+
+Clicking on that step of the workflow and selecting "Approve" will deploy the
+latest version of the code to the preprod environment.
+
+## Releasing to the production environment
+
+Once the `deploy_preprod` CI job has passed on CI after performing the above
+step, the pipeline will hold again and await manual approval at the
+`deploy_prod` step.
+
+Clicking on that step of the workflow and selecting "Approve" will deploy the
+latest version of the code to the production environment.
+
+## Rolling back a release
+
+To rollback a release, you'll need to open a new PR that reverts your previous
+release PR. This should then be deployed in the same way as outlined in the
+steps above.
+
+If you need to roll back a change urgently you can do this using the Helm
+command line client. This is quick and buys you time to back out your change (or
+fix forward) via GitHub and CircleCI.
+
+To do this, first get the deployment history:
+
+```
+helm history hmpps-accredited-programmes-api
+```
+
+This gives you something like:
+
+| REVISION | UPDATED                  | STATUS     | CHART                                | APP VERSION              | DESCRIPTION      |
+|----------|--------------------------|------------|--------------------------------------|--------------------------|------------------|
+| 79       | Thu Jun 22 10:32:17 2023 | superseded | hmpps-accredited-programmes-api-0.2.0 | 2023-06-22.2240.dd4d7ae | Upgrade complete |
+| 80       | Thu Jun 22 13:10:02 2023 | superseded | hmpps-accredited-programmes-api-0.2.0 | 2023-06-22.2240.dd4d7ae | Upgrade complete |
+| 81       | Thu Jun 22 13:31:16      | superseded | hmpps-accredited-programmes-api-0.2.0 | 2023-06-22.2240.dd4d7ae | Upgrade complete |
+
+Then roll back to a previous deployment using the revision number:
+
+```
+helm rollback hmpps-accredited-programmes-api 80
+```
+
+After this, you'll need to go back and revert your PR to ensure the latest
+version of the codebase lines up with the latest version of the code to ensure
+that the service is in a clean state to be deployed.

--- a/doc/how-to/view-application-logs.md
+++ b/doc/how-to/view-application-logs.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 - Be a part of the Ministry of Justice GitHub organisation. This should be done
-  as part of your your team onboarding process.
+  as part of your team onboarding process.
 
 ## Kibana
 


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/NBRchTqI/333-decide-and-document-an-approach-for-production-deployments

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

This PR adds an ADR to document our decision to release with continuous deployment (if accepted).

It also adds documentation for how to actually perform a release.

It's essentially a mirror image of [the UI PR](https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/pull/83) with a couple of tweaks to make it more appropriate for the API.
