### PR TITLE
Add identifier to Course record

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseEntity.kt
@@ -21,6 +21,7 @@ class CourseEntity(
   @Column(name = "course_id")
   val id: UUID? = null,
 
+  var identifier: String,
   var name: String,
   var description: String? = null,
   var alternateName: String? = null,
@@ -49,5 +50,5 @@ class CourseEntity(
 
   override fun hashCode(): Int = 1756406093
 
-  override fun toString(): String = "CourseEntity($name, $description, $audiences, $id)"
+  override fun toString(): String = "CourseEntity($name, $description, $audiences, $id, $identifier)"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseService.kt
@@ -32,6 +32,7 @@ class CourseService(
     courseData.map {
       CourseEntity(
         name = it.name,
+        identifier = it.identifier,
         description = it.description,
         alternateName = it.alternateName,
         audiences = audienceStrings(it.audience).mapNotNull { audienceName -> allAudiences[audienceName] }.toMutableSet(),

--- a/src/main/resources/db/migration/V7__add_course_identifier.sql
+++ b/src/main/resources/db/migration/V7__add_course_identifier.sql
@@ -1,0 +1,1 @@
+ALTER TABLE course add column identifier text;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -223,6 +223,8 @@ components:
           type: string
         alternateName:
           type: string
+        identifier:
+          type: string
         description:
           type: string
         audience:
@@ -231,6 +233,7 @@ components:
           type: string
       required:
         - name
+        - identifier
         - description
         - audience
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseServiceTest.kt
@@ -37,14 +37,30 @@ class CourseServiceTest {
 
       service.replaceAllCourses(
         listOf(
-          CourseRecord(name = "Course", description = "Description", audience = "Audience 1", alternateName = "CCC", comments = "A comment"),
+          CourseRecord(
+            name = "Course",
+            description = "Description",
+            identifier = "BNM-SO",
+            audience = "Audience 1",
+            alternateName = "CCC",
+            comments = "A comment",
+          ),
         ),
       )
 
       verify { repository.clear() }
       verify { repository.saveAudiences(setOf(Audience(a1.value))) }
       verify {
-        repository.saveCourse(eqCourse(CourseEntity(name = "Course", description = "Description", audiences = mutableSetOf(a1))))
+        repository.saveCourse(
+          eqCourse(
+            CourseEntity(
+              name = "Course",
+              identifier = "C-VO",
+              description = "Description",
+              audiences = mutableSetOf(a1),
+            ),
+          ),
+        )
       }
     }
 
@@ -58,15 +74,51 @@ class CourseServiceTest {
 
       service.replaceAllCourses(
         listOf(
-          CourseRecord(name = "Course 1", description = "Description 1", audience = "${a1.value}, ${a2.value} ", alternateName = "111", comments = "A comment for 1"),
-          CourseRecord(name = "Course 2", description = "Description 2", audience = "${a1.value}, ${a3.value}", alternateName = "222", comments = "A comment for 2"),
+          CourseRecord(
+            name = "Course 1",
+            identifier = "BNM-SO",
+            description = "Description 1",
+            audience = "${a1.value}, ${a2.value} ",
+            alternateName = "111",
+            comments = "A comment for 1",
+          ),
+          CourseRecord(
+            name = "Course 2",
+            identifier = "BNM-VO",
+            description = "Description 2",
+            audience = "${a1.value}, ${a3.value}",
+            alternateName = "222",
+            comments = "A comment for 2",
+          ),
         ),
       )
 
       verify { repository.clear() }
       verify { repository.saveAudiences(setOf(Audience(a1.value), Audience(a2.value), Audience(a3.value))) }
-      verify { repository.saveCourse(eqCourse(CourseEntity(name = "Course 1", description = "Description 1", audiences = mutableSetOf(a1, a2)))) }
-      verify { repository.saveCourse(eqCourse(CourseEntity(name = "Course 2", description = "Description 2", audiences = mutableSetOf(a1, a3)))) }
+      verify {
+        repository.saveCourse(
+          eqCourse(
+            CourseEntity(
+              name = "Course 1",
+              identifier = "BNM-SO",
+              description = "Description 1",
+              audiences = mutableSetOf(a1, a2),
+            ),
+          ),
+        )
+      }
+      verify {
+        repository.saveCourse(
+          eqCourse(
+            CourseEntity(
+              name = "Course 2",
+              identifier = "BNM-VO",
+              description = "Description 2",
+              audiences = mutableSetOf(a1, a3),
+            ),
+          ),
+        )
+      }
     }
 
     @Test
@@ -79,10 +131,38 @@ class CourseServiceTest {
 
       service.replaceAllCourses(
         listOf(
-          CourseRecord(name = "Course 1", description = "Description 1", audience = "${a1.value}, ${a2.value} ", alternateName = "111", comments = "A comment for 1"),
-          CourseRecord(name = "Course 2", description = "Description 2", audience = "${a1.value}, ${a3.value}", alternateName = "222", comments = "A comment for 2"),
-          CourseRecord(name = "Course 3", description = "Description 3", audience = a1.value, alternateName = "333", comments = "A comment for 3"),
-          CourseRecord(name = "Course 4", description = "Description 4", audience = a1.value, alternateName = "444", comments = "A comment for 4"),
+          CourseRecord(
+            name = "Course 1",
+            identifier = "BNM-S1",
+            description = "Description 1",
+            audience = "${a1.value}, ${a2.value} ",
+            alternateName = "111",
+            comments = "A comment for 1",
+          ),
+          CourseRecord(
+            name = "Course 2",
+            identifier = "BNM-S2",
+            description = "Description 2",
+            audience = "${a1.value}, ${a3.value}",
+            alternateName = "222",
+            comments = "A comment for 2",
+          ),
+          CourseRecord(
+            name = "Course 3",
+            identifier = "BNM-S3",
+            description = "Description 3",
+            audience = a1.value,
+            alternateName = "333",
+            comments = "A comment for 3",
+          ),
+          CourseRecord(
+            name = "Course 4",
+            identifier = "BNM-S4",
+            description = "Description 4",
+            audience = a1.value,
+            alternateName = "444",
+            comments = "A comment for 4",
+          ),
         ),
       )
 
@@ -103,6 +183,7 @@ class CourseServiceTest {
       val allCourses = listOf(
         CourseEntity(
           name = "Course 1",
+          identifier = "C-VO",
           description = "Description 1",
           prerequisites = mutableSetOf(
             Prerequisite(name = "PR 1", description = " PR Desc 1 "),
@@ -121,6 +202,7 @@ class CourseServiceTest {
       val allCourses = listOf(
         CourseEntity(
           name = "Course 1",
+          identifier = "C-VO",
           prerequisites = mutableSetOf(Prerequisite(name = "PR 1", description = " PR 1 Desc")),
         ),
       )
@@ -138,8 +220,8 @@ class CourseServiceTest {
     @Test
     fun `multiple courses and prerequisites - all match`() {
       val allCourses = listOf(
-        CourseEntity(name = "Course 1"),
-        CourseEntity(name = "Course 2"),
+        CourseEntity(name = "Course 1", identifier = "C-VO"),
+        CourseEntity(name = "Course 2", identifier = "C-VO"),
       )
       every { repository.allCourses() } returns allCourses
 
@@ -165,8 +247,8 @@ class CourseServiceTest {
     @Test
     fun `course name mismatch - record ignored`() {
       val allCourses = listOf(
-        CourseEntity(name = "Course 1"),
-        CourseEntity(name = "Course 2"),
+        CourseEntity(name = "Course 1", identifier = "C-VO"),
+        CourseEntity(name = "Course 2", identifier = "C-VO"),
       )
       every { repository.allCourses() } returns allCourses
 
@@ -200,6 +282,7 @@ class CourseServiceTest {
       val allCourses = listOf(
         CourseEntity(
           name = "Course 1",
+          identifier = "C-VO",
           description = "Description 1",
           offerings = mutableSetOf(
             Offering(organisationId = "BWI", contactEmail = "a@b.com"),
@@ -218,6 +301,7 @@ class CourseServiceTest {
       val allCourses = listOf(
         CourseEntity(
           name = "Course 1",
+          identifier = "C-VO",
           offerings = mutableSetOf(
             Offering(organisationId = "BWI", contactEmail = "a@b.com"),
           ),
@@ -237,8 +321,8 @@ class CourseServiceTest {
     @Test
     fun `multiple courses and offerings - all match`() {
       val allCourses = listOf(
-        CourseEntity(name = "Course 1"),
-        CourseEntity(name = "Course 2"),
+        CourseEntity(name = "Course 1", identifier = "C-VO"),
+        CourseEntity(name = "Course 2", identifier = "C-VO"),
       )
       every { repository.allCourses() } returns allCourses
 
@@ -264,8 +348,8 @@ class CourseServiceTest {
     @Test
     fun `course name mismatch - record ignored`() {
       val allCourses = listOf(
-        CourseEntity(name = "Course 1"),
-        CourseEntity(name = "Course 2"),
+        CourseEntity(name = "Course 1", identifier = "C-VO"),
+        CourseEntity(name = "Course 2", identifier = "C-VO"),
       )
       every { repository.allCourses() } returns allCourses
 
@@ -289,8 +373,8 @@ class CourseServiceTest {
     @Test
     fun `Missing contactEmail - Warning LineMessage produced`() {
       val allCourses = listOf(
-        CourseEntity(name = "Course 1"),
-        CourseEntity(name = "Course 2"),
+        CourseEntity(name = "Course 1", identifier = "C-VO"),
+        CourseEntity(name = "Course 2", identifier = "C-VO"),
       )
       every { repository.allCourses() } returns allCourses
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/inmemoryrepo/InMemoryCourseRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/inmemoryrepo/InMemoryCourseRepository.kt
@@ -29,6 +29,7 @@ class InMemoryCourseRepository : CourseRepository {
     private val tsp = CourseEntity(
       id = UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"),
       name = "Lime Course",
+      identifier = "LC-VO",
       description = "Explicabo exercitationem non asperiores corrupti accusamus quidem autem amet modi. Mollitia tenetur fugiat quo aperiam quasi error consectetur. Fugit neque rerum velit rem laboriosam. Atque nostrum quam aspernatur excepturi laborum harum officia eveniet porro.",
       prerequisites = mutableSetOf(
         Prerequisite(name = "Setting", description = "Custody"),
@@ -46,6 +47,7 @@ class InMemoryCourseRepository : CourseRepository {
     private val bnm = CourseEntity(
       id = UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"),
       name = "Azure Course",
+      identifier = "AC-SO",
       description = "Similique laborum incidunt sequi rem quidem incidunt incidunt dignissimos iusto. Explicabo nihil atque quod culpa animi quia aspernatur dolorem consequuntur.",
       prerequisites = mutableSetOf(
         Prerequisite(name = "Setting", description = "Custody"),
@@ -59,6 +61,7 @@ class InMemoryCourseRepository : CourseRepository {
     private val nms = CourseEntity(
       id = UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"),
       name = "Violet Course",
+      identifier = "VC-VO",
       description = "Tenetur a quisquam facilis amet illum voluptas error. Eaque eum sunt odit dolor voluptatibus eius sint impedit. Illo voluptatem similique quod voluptate laudantium. Ratione suscipit tempore amet autem quam dolorum. Necessitatibus tenetur recusandae aliquam recusandae temporibus voluptate velit similique fuga. Id tempora doloremque.",
       prerequisites = mutableSetOf(
         Prerequisite(name = "Setting", description = "Custody"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/jparepo/CourseAudienceRelationshipTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/jparepo/CourseAudienceRelationshipTest.kt
@@ -20,9 +20,9 @@ constructor(
   fun `can add audience values to courses`() {
     courseRepository.saveAll(
       listOf(
-        CourseEntity(name = "Course 1", description = "A course"),
-        CourseEntity(name = "Course 2", description = "Another course"),
-        CourseEntity(name = "Course 3", description = "Yet another course"),
+        CourseEntity(name = "Course 1", identifier = "C-VO", description = "A course"),
+        CourseEntity(name = "Course 2", identifier = "C-SO", description = "Another course"),
+        CourseEntity(name = "Course 3", identifier = "C-IPVO", description = "Yet another course"),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/jparepo/CourseEntityRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/jparepo/CourseEntityRepositoryTest.kt
@@ -25,6 +25,7 @@ constructor(
   fun `save and load behaves as expected`() {
     val transientEntity = CourseEntity(
       name = "A Course",
+      identifier = "C-VO",
       description = "A representative Approved Programme for testing",
     )
 
@@ -54,6 +55,7 @@ constructor(
 
     val course = CourseEntity(
       name = "A Course",
+      identifier = "C-VO",
       description = "A representative Approved Programme for testing",
     ).apply {
       prerequisites.addAll(samples)
@@ -83,16 +85,20 @@ constructor(
   fun `offering life-cycle`() {
     val course1 = CourseEntity(
       name = "A Course",
+      identifier = "C-VO",
       description = "A description",
     ).apply {
       offerings.add(Offering(organisationId = "BWI", contactEmail = "bwi@a.com"))
       offerings.add(Offering(organisationId = "MDI", contactEmail = "mdi@a.com"))
       offerings.add(Offering(organisationId = "BXI", contactEmail = "bxi@a.com"))
     }
-    val course2 = CourseEntity(name = "Another Course", description = "Another description")
-      .apply {
-        offerings.add(Offering(organisationId = "MDI", contactEmail = "mdi@a.com"))
-      }
+    val course2 = CourseEntity(
+      name = "Another Course",
+      description = "Another description",
+      identifier = "C-VO",
+    ).apply {
+      offerings.add(Offering(organisationId = "MDI", contactEmail = "mdi@a.com"))
+    }
 
     repository.save(course1)
     repository.save(course2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/jparepo/JpaCourseRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/jparepo/JpaCourseRepositoryTest.kt
@@ -17,6 +17,7 @@ constructor(
     repository.saveCourse(
       CourseEntity(
         name = "Course 1",
+        identifier = "C-VO",
         description = "A course",
         audiences = mutableSetOf(
           Audience("Male"),
@@ -32,6 +33,7 @@ constructor(
     repository.saveCourse(
       CourseEntity(
         name = "Course 1",
+        identifier = "C-VO",
         description = "A course",
         audiences = mutableSetOf(
           Audience("Male"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CsvTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CsvTestData.kt
@@ -8,27 +8,37 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 
 object CsvTestData {
-  val courseRecords: List<CourseRecord> by lazy {
+  private fun courseRecord(name: String, identifier: String, audience: String, alternateName: String) =
+    CourseRecord(
+      name = name,
+      identifier = identifier,
+      audience = audience,
+      alternateName = alternateName,
+      description = LoremIpsum.words(1..10),
+      comments = LoremIpsum.words(0..20),
+    )
+
+  val courseRecords: List<CourseRecord> =
     listOf(
-      CourseRecord(name = "Becoming New Me Plus", description = "Lorem ipsum dolor sit amet, Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.", audience = "Sexual offence, Intimate partner violence, Non-intimate partner violence", alternateName = "BNM+", comments = "General comment: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. "),
-      CourseRecord(name = "Building Better Relationships", description = "Lorem ipsum dolor sit amet, Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. ", audience = "Intimate partner violence ", alternateName = "BBR", comments = ""),
-      CourseRecord(name = "Healthy Identity Intervention", description = "Lorem ipsum dolor sit amet, Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", audience = "Extremism offence", alternateName = "HI", comments = ""),
-      CourseRecord(name = "Healthy Sex Programme", description = "Lorem ipsum dolor sit amet, Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", audience = "Sexual offence", alternateName = "HSP", comments = ""),
-      CourseRecord(name = "Horizon", description = "Lorem ipsum dolor sit amet, Consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", audience = "Sexual offence", alternateName = "", comments = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."),
-      CourseRecord(name = "iHorizon", description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. ", audience = "Sexual offence", alternateName = "", comments = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."),
-      CourseRecord(name = "Identity Matters", description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. ", audience = "Gang offence, Extremism offence", alternateName = "IM", comments = ""),
-      CourseRecord(name = "Kaizen", description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", audience = "Violent offence", alternateName = "", comments = ""),
-      CourseRecord(name = "Kaizen", description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", audience = "Intimate partner violence", alternateName = "", comments = ""),
-      CourseRecord(name = "Kaizen", description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", audience = "Sexual offence", alternateName = "", comments = ""),
-      CourseRecord(name = "Living as New Me (custody)", description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", audience = "Violent offence, Sexual offence, Intimate partner violence ", alternateName = "LNM", comments = ""),
-      CourseRecord(name = "Living as New Me (community)", description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", audience = "Sexual offence", alternateName = "LNM", comments = ""),
-      CourseRecord(name = "Motivation and Engagement", description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", audience = "Violent offence, Sexual offence, Intimate partner violence ", alternateName = "M&E", comments = ""),
-      CourseRecord(name = "New Me MOT", description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. ", audience = "Violent offence, Sexual offence, Intimate partner violence ", alternateName = "NMM", comments = ""),
-      CourseRecord(name = "New Me Strengths", description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", audience = "Violent offence, Sexual offence, Intimate partner violence ", alternateName = "NMS", comments = ""),
-      CourseRecord(name = "Thinking Skills Programme", description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.", audience = "Violent offence, Intimate partner violence", alternateName = "TSP", comments = ""),
-    ).map { it.copy(description = LoremIpsum.words(1..10), comments = LoremIpsum.words(0..20)) }
-  }
-  val prerequisiteRecords: List<PrerequisiteRecord> by lazy {
+      courseRecord(name = "Becoming New Me Plus", identifier = "BNM+-SO", audience = "Sexual offence, Intimate partner violence, Non-intimate partner violence", alternateName = "BNM+"),
+      courseRecord(name = "Building Better Relationships", identifier = "BBR-IPVO", audience = "Intimate partner violence ", alternateName = "BBR"),
+      courseRecord(name = "Healthy Identity Intervention", identifier = "HI-EO", audience = "Extremism offence", alternateName = "HI"),
+      courseRecord(name = "Healthy Sex Programme", identifier = "HSP-SO", audience = "Sexual offence", alternateName = "HSP"),
+      courseRecord(name = "Horizon", identifier = "H-SO", audience = "Sexual offence", alternateName = ""),
+      courseRecord(name = "iHorizon", identifier = "iH-SO", audience = "Sexual offence", alternateName = ""),
+      courseRecord(name = "Identity Matters", identifier = "IM-GO", audience = "Gang offence, Extremism offence", alternateName = "IM"),
+      courseRecord(name = "Kaizen", identifier = "K-VO", audience = "Violent offence", alternateName = ""),
+      courseRecord(name = "Kaizen", identifier = "K-IPVO", audience = "Intimate partner violence", alternateName = ""),
+      courseRecord(name = "Kaizen", identifier = "K-SO", audience = "Sexual offence", alternateName = ""),
+      courseRecord(name = "Living as New Me (custody)", identifier = "LNM-VO", audience = "Violent offence, Sexual offence, Intimate partner violence ", alternateName = "LNM"),
+      courseRecord(name = "Living as New Me (community)", identifier = "LNM-SO", audience = "Sexual offence", alternateName = "LNM"),
+      courseRecord(name = "Motivation and Engagement", identifier = "M&E-VO", audience = "Violent offence, Sexual offence, Intimate partner violence ", alternateName = "M&E"),
+      courseRecord(name = "New Me MOT", identifier = "NMM-VO", audience = "Violent offence, Sexual offence, Intimate partner violence ", alternateName = "NMM"),
+      courseRecord(name = "New Me Strengths", identifier = "NMS-VO", audience = "Violent offence, Sexual offence, Intimate partner violence ", alternateName = "NMS"),
+      courseRecord(name = "Thinking Skills Programme", identifier = "TSP-VO", audience = "Violent offence, Intimate partner violence", alternateName = "TSP"),
+    )
+
+  val prerequisiteRecords: List<PrerequisiteRecord> =
     listOf(
       PrerequisiteRecord(name = "gender", course = "Becoming New Me Plus"),
       PrerequisiteRecord(name = "age", course = "Becoming New Me Plus"),
@@ -266,7 +276,6 @@ object CsvTestData {
       PrerequisiteRecord(name = "need requirements", course = "Thinking Skills Programme"),
       PrerequisiteRecord(name = "criminogenic needs", course = "Thinking Skills Programme"),
     ).map { it.copy(description = LoremIpsum.words(1..5), comments = LoremIpsum.words(0..20)) }
-  }
 
   val offeringsRecords: List<OfferingRecord> by lazy {
     listOf(
@@ -510,6 +519,7 @@ object CsvTestData {
   }
 
   fun coursesCsvInputStream(): InputStream = ByteArrayInputStream(coursesCsvText.toByteArray())
+
   val coursesCsvText: String by lazy {
     courseRecords
       .joinToString(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/transformer/TransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/transformer/TransformerTest.kt
@@ -16,6 +16,7 @@ class TransformerTest {
   fun `transform course entity to api missing description, alternateName and no prerequisites`() {
     val entity = CourseEntity(
       id = UUID.randomUUID(),
+      identifier = "C-VO",
       name = "A Course",
       prerequisites = mutableSetOf(),
       audiences = mutableSetOf(),
@@ -34,6 +35,7 @@ class TransformerTest {
   fun `transform course entity to api with description and alternateName`() {
     val entity = CourseEntity(
       id = UUID.randomUUID(),
+      identifier = "C-VO",
       name = "A Course",
       description = "A description",
       alternateName = "AA++",
@@ -52,6 +54,7 @@ class TransformerTest {
     val entity = CourseEntity(
       id = UUID.randomUUID(),
       name = "A Course",
+      identifier = "C-VO",
       prerequisites = mutableSetOf(
         Prerequisite(name = "gender", description = "female"),
         Prerequisite(name = "risk score", description = "ORGS: 50+"),

--- a/src/test/resources/db/migration/R__test_data.sql
+++ b/src/test/resources/db/migration/R__test_data.sql
@@ -1,10 +1,10 @@
 INSERT INTO audience(audience_id, audience_value)
 VALUES ('7fffcc6a-11f8-4713-be35-cf5ff1aee517', 'Sexual violence');
 
-INSERT INTO course(course_id, name, description, alternate_name)
-VALUES ('d3abc217-75ee-46e9-a010-368f30282367', 'Lime Course', 'Explicabo exercitationem non asperiores corrupti accusamus quidem autem amet modi. Mollitia tenetur fugiat quo aperiam quasi error consectetur. Fugit neque rerum velit rem laboriosam. Atque nostrum quam aspernatur excepturi laborum harum officia eveniet porro.', 'LC'),
-       ('28e47d30-30bf-4dab-a8eb-9fda3f6400e8', 'Azure Course', 'Similique laborum incidunt sequi rem quidem incidunt incidunt dignissimos iusto. Explicabo nihil atque quod culpa animi quia aspernatur dolorem consequuntur.', 'AC++'),
-       ('1811faa6-d568-4fc4-83ce-41118b90242e', 'Violet Course', 'Tenetur a quisquam facilis amet illum voluptas error. Eaque eum sunt odit dolor voluptatibus eius sint impedit. Illo voluptatem similique quod voluptate laudantium. Ratione suscipit tempore amet autem quam dolorum. Necessitatibus tenetur recusandae aliquam recusandae temporibus voluptate velit similique fuga. Id tempora doloremque.', null);
+INSERT INTO course(course_id, name, identifier, description, alternate_name)
+VALUES ('d3abc217-75ee-46e9-a010-368f30282367', 'Lime Course', 'LC-VO', 'Explicabo exercitationem non asperiores corrupti accusamus quidem autem amet modi. Mollitia tenetur fugiat quo aperiam quasi error consectetur. Fugit neque rerum velit rem laboriosam. Atque nostrum quam aspernatur excepturi laborum harum officia eveniet porro.', 'LC'),
+       ('28e47d30-30bf-4dab-a8eb-9fda3f6400e8', 'Azure Course', 'AC-VO', 'Similique laborum incidunt sequi rem quidem incidunt incidunt dignissimos iusto. Explicabo nihil atque quod culpa animi quia aspernatur dolorem consequuntur.', 'AC++'),
+       ('1811faa6-d568-4fc4-83ce-41118b90242e', 'Violet Course', 'VC-VO', 'Tenetur a quisquam facilis amet illum voluptas error. Eaque eum sunt odit dolor voluptatibus eius sint impedit. Illo voluptatem similique quod voluptate laudantium. Ratione suscipit tempore amet autem quam dolorum. Necessitatibus tenetur recusandae aliquam recusandae temporibus voluptate velit similique fuga. Id tempora doloremque.', null);
 
 INSERT INTO prerequisite(course_id, name, description)
 VALUES ('d3abc217-75ee-46e9-a010-368f30282367', 'Setting', 'Custody'),


### PR DESCRIPTION
For some reason this is failing tests due to the CSV upload - I'd like to get the upload to ignore this field in this commit, then add the new functionality for creating it from the CSV in the next commit, but things are failing due to the identifier being `NULL`.

## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
