### PR TITLE
Revert junit5spring to 4.6.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
   testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")
   testImplementation("io.jsonwebtoken:jjwt-impl:0.11.5")
   testImplementation("io.jsonwebtoken:jjwt-orgjson:0.11.5")
-  testImplementation("au.com.dius.pact.provider:junit5spring:4.6.1")
+  testImplementation("au.com.dius.pact.provider:junit5spring:4.6.0")
 }
 
 java {


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/U0gghZBi/563-fix-api-pact-issue

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We're currently seeing builds failing when tagging a Pact version on `main` due to the deployed version not being published.

I'm not 100% sure if this is the culprit, but this commit was the first one in which the `main` build started to fail, so I wanted to check this first.

## Changes in this PR

This reverts junit5spring back down to 4.6.1 to see if this fixes the issue or changes anything.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
