### PR TITLE
Re-enable disabled Pact tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/PactContractTest.kt
@@ -7,7 +7,6 @@ import au.com.dius.pact.provider.junitsupport.VerificationReports
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker
 import au.com.dius.pact.provider.spring.junit5.PactVerificationSpringProvider
 import org.apache.hc.core5.http.HttpRequest
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.TestTemplate
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -42,7 +41,6 @@ class PactContractTest {
   @State("An offering exists with ID 20f3abc8-dd92-43ae-b88e-5797a0ad3f4b")
   fun ensureOfferingExists() {}
 
-  @Disabled
   @TestTemplate
   @ExtendWith(PactVerificationSpringProvider::class)
   fun template(context: PactVerificationContext, request: HttpRequest) {


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/U0gghZBi/563-fix-api-pact-issue
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

Re-enables disabled Pact tests that were turned off to help speed up development.

Now that we have a more stable `dev` environment, this should help us catch any breaking changes.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes UI for this change to work...
  - [x] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
