### PR TITLE
Eliminate inefficient Hibernate N+1 queries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,10 @@ java {
   toolchain.languageVersion.set(JavaLanguageVersion.of(19))
 }
 
+kotlin {
+  kotlinDaemonJvmArgs = listOf("-Xmx486m")
+}
+
 tasks {
   withType<KotlinCompile> {
     kotlinOptions {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseEntity.kt
@@ -11,6 +11,8 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.JoinTable
 import jakarta.persistence.ManyToMany
 import jakarta.persistence.Table
+import org.hibernate.annotations.Fetch
+import org.hibernate.annotations.FetchMode.SUBSELECT
 import java.util.*
 
 @Entity
@@ -27,14 +29,17 @@ class CourseEntity(
   var alternateName: String? = null,
 
   @ElementCollection
+  @Fetch(SUBSELECT)
   @CollectionTable(name = "prerequisite", joinColumns = [JoinColumn(name = "course_id")])
   val prerequisites: MutableSet<Prerequisite> = mutableSetOf(),
 
   @ElementCollection
+  @Fetch(SUBSELECT)
   @CollectionTable(name = "offering", joinColumns = [JoinColumn(name = "course_id")])
   val offerings: MutableSet<Offering> = mutableSetOf(),
 
   @ManyToMany(cascade = [CascadeType.PERSIST, CascadeType.MERGE])
+  @Fetch(SUBSELECT)
   @JoinTable(
     name = "course_audience",
     joinColumns = [JoinColumn(name = "course_id")],

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
 
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
-    open-in-view: true # TODO: Hide the domain model from the view layer and stop using open-in-view.
+    open-in-view: false
     generate-ddl: false
     hibernate:
       ddl-auto: none


### PR DESCRIPTION

## Context

Invoking some api end-points results in Hibernate running 'N+1' queries to populate courses with their `audiences` and `prerequisites` collections.  Although the datasets are small this is still inefficient and is easily fixed.

## Changes in this PR

* Disable the Spring JPA 'open session in view' setting. 
* Set the fetch type for course.prerequisites, course.offerings and course.audiences to `FetchType.SUBSELECT `
* Selectively initialise collections in `JpaCourseRepository`

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
