### PR TITLE
Fix Sentry installation and logging.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ configurations {
 dependencies {
   val kotestVersion = "5.6.2"
   val springdocVersion = "1.7.0"
-  val sentryVersion = "6.25.1"
+  val sentryVersion = "6.25.2"
 
   runtimeOnly("org.postgresql:postgresql:42.6.0")
 
@@ -27,7 +27,7 @@ dependencies {
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.15.2")
   implementation("com.google.guava:guava:32.1.1-jre")
 
-  implementation("io.sentry:sentry-spring-boot-starter:$sentryVersion")
+  implementation("io.sentry:sentry-spring-boot-starter-jakarta:$sentryVersion")
   implementation("io.sentry:sentry-logback:$sentryVersion")
 
   implementation("org.springdoc:springdoc-openapi-data-rest:$springdocVersion")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/HmppsAccreditedProgrammesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/HmppsAccreditedProgrammesApiExceptionHandler.kt
@@ -42,8 +42,8 @@ class HmppsAccreditedProgrammesApiExceptionHandler {
       )
   }
 
-  @ExceptionHandler(java.lang.Exception::class)
-  fun handleException(e: java.lang.Exception): ResponseEntity<ErrorResponse?>? {
+  @ExceptionHandler(Throwable::class)
+  fun handleException(e: Throwable): ResponseEntity<ErrorResponse?>? {
     Sentry.captureException(e)
     log.error("Unexpected exception", e)
     return ResponseEntity

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -24,7 +24,10 @@
         </appender>
     </springProfile>
 
-    <logger name="uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.Application" additivity="false" level="DEBUG">
+    <appender name="sentry" class="io.sentry.logback.SentryAppender"/>
+
+    <logger name="uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.Application" additivity="false"
+            level="DEBUG">
         <appender-ref ref="logAppender"/>
         <appender-ref ref="consoleAppender"/>
     </logger>
@@ -53,6 +56,7 @@
 
     <root level="INFO">
         <appender-ref ref="logAppender"/>
+        <appender-ref ref="sentry"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
## Context

Trello [558 Check API is logging errors](https://trello.com/c/QsqGgSG6/558-check-api-is-logging-errors-to-sentry)
 
## Changes in this PR

Use a version of the Sentry API that is compatible with Spring Boot 3.
Log uncaught `Throwable`s, not just `Exception`s.
Add a Sentry logging appender to the Logback configuration in `logback-spring.xml`

### Post-merge

Prior to deploying to prod/preprod the Sentry DSN that is stored in the Kubernetes secrets for the API should be changed. Currently the API DSN is the same as the one used by the UI.  This is incorrect. There is a separate DSN for the API which can be obtained from the Sentry console.  This value should be replace the current value found in the kubernetes API secrets.
Update: DSNs have been corrected in dev, preprod and prod environments.

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
