### PR TITLE
Refactor: Simplify Repository code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseRepository.kt
@@ -1,11 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain
 
-import java.util.*
+import java.util.UUID
 
 interface CourseRepository {
   fun allCourses(): List<CourseEntity>
   fun course(courseId: UUID): CourseEntity?
+  fun saveCourse(courseEntity: CourseEntity)
   fun offeringsForCourse(courseId: UUID): List<Offering>
   fun courseOffering(courseId: UUID, offeringId: UUID): Offering?
   fun allAudiences(): Set<Audience>
+  fun saveAudiences(audiences: Set<Audience>)
+  fun clear()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseService.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 @Transactional
 class CourseService(
   @Autowired
-  val courseRepository: MutableCourseRepository,
+  val courseRepository: CourseRepository,
 ) {
   fun allCourses(): List<CourseEntity> = courseRepository.allCourses()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/MutableCourseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/MutableCourseRepository.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain
-
-interface MutableCourseRepository : CourseRepository {
-  fun clear()
-  fun saveCourse(courseEntity: CourseEntity)
-  fun saveAudiences(audiences: Set<Audience>)
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/jparepo/AudienceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/jparepo/AudienceRepository.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.jparepo
 
-import org.springframework.data.repository.CrudRepository
+import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Audience
 import java.util.UUID
 
-interface AudienceRepository : CrudRepository<Audience, UUID>
+interface AudienceRepository : JpaRepository<Audience, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/jparepo/CourseEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/jparepo/CourseEntityRepository.kt
@@ -1,9 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.jparepo
 
-import org.springframework.data.repository.ListCrudRepository
+import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseEntity
 import java.util.UUID
 
 @Repository
-interface CourseEntityRepository : ListCrudRepository<CourseEntity, UUID>
+interface CourseEntityRepository : JpaRepository<CourseEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/jparepo/JpaCourseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/jparepo/JpaCourseRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Audience
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.MutableCourseRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Offering
 import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
@@ -18,7 +18,7 @@ constructor(
   private val courseRepository: CourseEntityRepository,
   private val audienceRepository: AudienceRepository,
   private val entityManager: EntityManager,
-) : MutableCourseRepository {
+) : CourseRepository {
   override fun allCourses(): List<CourseEntity> = courseRepository
     .findAll()
     .onEach {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/CourseServiceTest.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.LineM
 import java.util.UUID
 
 class CourseServiceTest {
-  private val repository = mockk<MutableCourseRepository>(relaxed = true)
+  private val repository = mockk<CourseRepository>(relaxed = true)
   private val service = CourseService(repository)
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/CoursesControllerTest.kt
@@ -20,7 +20,6 @@ import org.springframework.test.web.servlet.put
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.OfferingRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.PrerequisiteRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseService
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.inmemoryrepo.InMemoryCourseRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.transformer.toDomain
 import java.util.UUID

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/InMemoryCourseRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/InMemoryCourseRepository.kt
@@ -1,27 +1,24 @@
-package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.inmemoryrepo
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi
 
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Audience
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.CourseRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Offering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.Prerequisite
 import java.util.UUID
 
 @Component
-class InMemoryCourseRepository : CourseRepository {
+class InMemoryCourseRepository {
 
-  override fun allCourses(): List<CourseEntity> = courses.toList()
+  fun allCourses(): List<CourseEntity> = courses.toList()
 
-  override fun course(courseId: UUID): CourseEntity? = courses.find { it.id == courseId }
+  fun course(courseId: UUID): CourseEntity? = courses.find { it.id == courseId }
 
-  override fun offeringsForCourse(courseId: UUID): List<Offering> =
+  fun offeringsForCourse(courseId: UUID): List<Offering> =
     courses.find { it.id == courseId }?.offerings?.toList() ?: emptyList()
 
-  override fun courseOffering(courseId: UUID, offeringId: UUID): Offering? =
+  fun courseOffering(courseId: UUID, offeringId: UUID): Offering? =
     courses.find { it.id == courseId }?.offerings?.find { it.id == offeringId }
-
-  override fun allAudiences(): Set<Audience> = audiences
 
   private companion object {
     private val audiences = setOf(Audience(value = "Sexual violence", id = UUID.randomUUID()))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/InMemoryCourseRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/InMemoryCourseRepositoryTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.inmemoryrepo
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi
 
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldHaveSize


### PR DESCRIPTION
## Context

Trello: [Remove/simplify `InMemoryCourseRepository` in the API](https://trello.com/c/vdftAilZ/618-remove-simplify-inmemorycourserepository-in-the-api)

## Changes in this PR

This PR contains a refactoring.  The application's functionality does not change.

The application initially implemented a read-only API. The domain model from which the API responses were constructed relied on a domain model containing instances of `CourseEntity`, `Offering` and `Prerequisite` classes. These entities were retrieved from a `CourseRepository`, an interface initially implemented wholly in memory as `InMemoryCourseRepository`.

Further development introduced a database as a long term store for these entities and a `JpaCourseRepository` implementation of `CourseRepository` as the replacement for `InMemoryCourseRepository`. `JpaCourseRepository` uses the Spring Data JPA support for Hibernate to implement the behaviour required of `CourseRepository`.

Subsequent iterations introduced a means of updating the data stored by the API. The necessary extensions to the `CourseRepository` interface were added to the domain as a separate interface, `MutableCourseRepository` which extended `CourseRepository`, and `JPACourseRepository` provided implementations of these new methods.  `InMemoryCourseRepository` was left unchanged but moved to the 'test' code tree as it provided a convenient source of data for certain tests.

This refactoring:
* Retains `InMemoryCourseRepository` for testing purposes.  It does not implement the `CourseRepository` interface, but its functionality is unchanged. `InMemoryCourseRepistoryTest` is untouched and all the tests still pass.
* Merges the `MutableCourseRepository` into the `CourseRepository` interface and updates `JpaCourseRepository` and its dependencies 'CourseService` etc accordingly.
* Moves `InMemoryCourseRepository` and its test class `InMemoryCourseRepositoryTest` from the `inmemoryrepo` package to the `restapi` package:  `InMemoryCourseRepository` is now only used by the `CourseControllerTest` class in the `restapi` package so it makes sense for the classes to sit along side each other.

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
