### PR TITLE
(543) Add service account for IRSA

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-api/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-api/values.yaml
@@ -1,6 +1,7 @@
 ---
 generic-service:
   nameOverride: hmpps-accredited-programmes-api
+  serviceAccountName: hmpps-accredited-programmes-service-account
 
   replicaCount: 4
 


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/QemJ66J5/543-switch-to-short-lived-credentials-for-accessing-cloud-platform-services
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We've now moved to using service accounts rather than long-lived credentials in [this PR](https://github.com/ministryofjustice/cloud-platform-environments/pull/15283)

## Changes in this PR

This change will add the `serviceAccountName` to our deployments, following instructions here:
https://dsdmoj.atlassian.net/wiki/spaces/NOM/pages/4413030459/Migrate+to+using+IRSA#Step-2---App-Changes-(Kotlin)

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
