### PR TITLE
Fix inadvertent incompatibility in `referral` PK and FK column types

### DIFF
--- a/src/main/resources/db/migration/V10__create_referral_table.sql
+++ b/src/main/resources/db/migration/V10__create_referral_table.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS referral
 (
-    referral_id TEXT NOT NULL,
-    offering_id TEXT NOT NULL,
+    referral_id UUID NOT NULL,
+    offering_id UUID NOT NULL,
     prison_number TEXT NOT NULL,
     referrer_id TEXT NOT NULL,
     CONSTRAINT referral_pk PRIMARY KEY (referral_id),


### PR DESCRIPTION
Change 'id' column types from TEXT to UUID

## Context

New Postgresql table `referral` has defined the PK and FK column types for `referral_id` and `offering_id` as TEXT.
These column types should be UUID.  The `offering_id` column must have type UUID to satisfy the type constraints on the FK constraint to `offering.offering_id` which has type UUID. The PK column could remain as TEXT, but should be changed to UUID for consistency.

## Changes in this PR

Changed the type of the `referral_id` and `offering_id` columns of new table 'referral' from TEXT to UUID in Flyway migration script `V10__create_referral_table.sql`. This is a valid change because the previous definition of this migration was rejected and so this migration has not been applied.

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
