### PR TITLE
687 add get course by offering id endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseRepository.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 interface CourseRepository {
   fun allCourses(): List<CourseEntity>
   fun course(courseId: UUID): CourseEntity?
+  fun findCourseByOfferingId(offeringId: UUID): CourseEntity?
   fun saveCourse(courseEntity: CourseEntity)
   fun offeringsForCourse(courseId: UUID): List<Offering>
   fun courseOffering(courseId: UUID, offeringId: UUID): Offering?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseService.kt
@@ -16,6 +16,8 @@ class CourseService(
 
   fun course(courseId: UUID): CourseEntity? = courseRepository.course(courseId)
 
+  fun getCourseForOfferingId(offeringId: UUID): CourseEntity? = courseRepository.findCourseByOfferingId(offeringId)
+
   fun offeringsForCourse(courseId: UUID): List<Offering> = courseRepository.offeringsForCourse(courseId)
 
   fun courseOffering(courseId: UUID, offeringId: UUID): Offering? = courseRepository.courseOffering(courseId, offeringId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/jparepo/CourseEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/jparepo/CourseEntityRepository.kt
@@ -6,4 +6,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.C
 import java.util.UUID
 
 @Repository
-interface CourseEntityRepository : JpaRepository<CourseEntity, UUID>
+interface CourseEntityRepository : JpaRepository<CourseEntity, UUID> {
+  fun findByOfferings_id(offeringId: UUID): CourseEntity?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/jparepo/JpaCourseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/jparepo/JpaCourseRepository.kt
@@ -34,6 +34,13 @@ constructor(
       Hibernate.initialize(it.prerequisites)
     }
 
+  override fun findCourseByOfferingId(offeringId: UUID): CourseEntity? = courseRepository
+    .findByOfferings_id(offeringId)
+    ?.also {
+      Hibernate.initialize(it.audiences)
+      Hibernate.initialize(it.prerequisites)
+    }
+
   override fun offeringsForCourse(courseId: UUID): List<Offering> = courseRepository
     .findById(courseId)
     .getOrNull()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
@@ -55,5 +55,5 @@ class CoursesController(
   override fun coursesCourseIdOfferingsOfferingIdGet(courseId: UUID, offeringId: UUID): ResponseEntity<CourseOffering> =
     courseService.courseOffering(courseId, offeringId)?.let {
       ResponseEntity.ok(it.toApi())
-    } ?: throw NotFoundException("No CourseOffering  found at /courses/$courseId/offerings/$offeringId")
+    } ?: throw NotFoundException("No CourseOffering found at /courses/$courseId/offerings/$offeringId")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/OfferingsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/OfferingsController.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.restapi
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.OfferingsApiDelegate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Course
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.transformer.toApi
+import java.util.UUID
+
+@Service
+class OfferingsController(private val courseService: CourseService) : OfferingsApiDelegate {
+
+  override fun offeringsIdCourseGet(id: UUID): ResponseEntity<Course> =
+    courseService.getCourseForOfferingId(id)?.let {
+      ResponseEntity.ok(it.toApi())
+    } ?: throw NotFoundException("No Course found at /offerings/$id/course")
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -226,6 +226,29 @@ paths:
         404:
           description: No referral has the supplied id (Not Found)
 
+  /offerings/{id}/course:
+    get:
+      tags:
+        - Courses
+      summary: Retrieve the course that owns an offering
+      parameters:
+        - name: id
+          in: path
+          description: The id (UUID) of an offering
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: Information about the Course that owns the offering
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Course'
+        404:
+          description: No offering has the supplied id (Not Found)
+
 components:
   schemas:
     Course:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesControllerTest.kt
@@ -123,8 +123,8 @@ class CoursesControllerTest(
           contentType(MediaType.APPLICATION_JSON)
           jsonPath("$.status") { value(404) }
           jsonPath("$.errorCode") { isEmpty() }
-          jsonPath("$.userMessage") { prefix("Not Found: No Course found at /courses/$randomId") }
-          jsonPath("$.developerMessage") { prefix("No Course found at /courses/$randomId") }
+          jsonPath("$.userMessage") { value("Not Found: No Course found at /courses/$randomId") }
+          jsonPath("$.developerMessage") { value("No Course found at /courses/$randomId") }
           jsonPath("$.moreInfo") { isEmpty() }
         }
       }
@@ -210,8 +210,8 @@ class CoursesControllerTest(
           contentType(MediaType.APPLICATION_JSON)
           jsonPath("$.status") { value(404) }
           jsonPath("$.errorCode") { isEmpty() }
-          jsonPath("$.userMessage") { prefix("Not Found: No CourseOffering  found at /courses/") }
-          jsonPath("$.developerMessage") { prefix("No CourseOffering  found at /courses/") }
+          jsonPath("$.userMessage") { value("Not Found: No CourseOffering found at /courses/$randomUuid/offerings/$randomUuid") }
+          jsonPath("$.developerMessage") { value("No CourseOffering found at /courses/$randomUuid/offerings/$randomUuid") }
           jsonPath("$.moreInfo") { isEmpty() }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesIntegrationTest.kt
@@ -87,6 +87,20 @@ class CoursesIntegrationTest
   }
 
   @Test
+  fun `get a course by offering id`() {
+    webTestClient
+      .get()
+      .uri("/offerings/$courseOfferingId/course")
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody()
+      .jsonPath("$.id").isEqualTo(courseId)
+  }
+
+  @Test
   fun `get all offerings for a course`() {
     webTestClient
       .get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesIntegrationTest.kt
@@ -153,8 +153,8 @@ class CoursesIntegrationTest
       .expectBody()
       .jsonPath("$.status").isEqualTo(404)
       .jsonPath("$.errorCode").isEmpty
-      .jsonPath("$.userMessage").value(startsWith("Not Found: No CourseOffering  found at /courses/"))
-      .jsonPath("$.developerMessage").value(startsWith("No CourseOffering  found at /courses/"))
+      .jsonPath("$.userMessage").value(startsWith("Not Found: No CourseOffering found at /courses/"))
+      .jsonPath("$.developerMessage").value(startsWith("No CourseOffering found at /courses/"))
       .jsonPath("$.moreInfo").isEmpty
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/OfferingsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/OfferingsControllerTest.kt
@@ -1,0 +1,89 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.restapi
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders.AUTHORIZATION
+import org.springframework.http.MediaType
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
+import java.util.UUID
+
+@WebMvcTest
+@ContextConfiguration(classes = [OfferingsControllerTest::class])
+@ComponentScan(
+  basePackages = [
+    "uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.restapi",
+    "uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.config",
+    "uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api",
+  ],
+)
+@Import(JwtAuthHelper::class)
+class OfferingsControllerTest(
+  @Autowired val mockMvc: MockMvc,
+  @Autowired val jwtAuthHelper: JwtAuthHelper,
+) {
+  private val repository = InMemoryCourseRepository()
+
+  @MockkBean
+  private lateinit var coursesService: CourseService
+
+  @Test
+  fun `get a course by offering id - happy path`() {
+    val courseId = repository.allCourses().first().id
+    val courseOfferingId = repository.offeringsForCourse(courseId!!).first().id
+
+    every { coursesService.getCourseForOfferingId(any()) } returns repository.course(courseId)
+
+    mockMvc.get(COURSE_BY_OFFERING_ID_TEMPLATE, courseOfferingId) {
+      accept = MediaType.APPLICATION_JSON
+      header(AUTHORIZATION, jwtAuthHelper.bearerToken())
+    }.andExpect {
+      status { isOk() }
+      content {
+        jsonPath("$.id") { value(courseId.toString()) }
+      }
+    }
+  }
+
+  @Test
+  fun `get a course by offering id - not found`() {
+    val offeringId = UUID.randomUUID()
+    every { coursesService.getCourseForOfferingId(any()) } returns null
+
+    mockMvc.get(COURSE_BY_OFFERING_ID_TEMPLATE, offeringId) {
+      accept = MediaType.APPLICATION_JSON
+      header(AUTHORIZATION, jwtAuthHelper.bearerToken())
+    }.andExpect {
+      status { isNotFound() }
+      content {
+        contentType(MediaType.APPLICATION_JSON)
+        jsonPath("$.status") { value(404) }
+        jsonPath("$.errorCode") { isEmpty() }
+        jsonPath("$.userMessage") { value("Not Found: No Course found at /offerings/$offeringId/course") }
+        jsonPath("$.developerMessage") { value("No Course found at /offerings/$offeringId/course") }
+        jsonPath("$.moreInfo") { isEmpty() }
+      }
+    }
+  }
+
+  @Test
+  fun `get a course by offering id - no token`() {
+    mockMvc.get(COURSE_BY_OFFERING_ID_TEMPLATE, UUID.randomUUID()) {
+      accept = MediaType.APPLICATION_JSON
+    }.andExpect {
+      status { isUnauthorized() }
+    }
+  }
+
+  private companion object {
+    private const val COURSE_BY_OFFERING_ID_TEMPLATE = "/offerings/{offeringId}/course"
+  }
+}


### PR DESCRIPTION
## Context

Trello: [687 Add a GET course y offering id endpoint](https://trello.com/c/HQjspnDx/687-add-offerings-offeringid-course-endpoint)

## Changes in this PR
* Added `GET /offerings/{offeringId}/course` endpoint to OpenApi definition
* Created method `findByOfferings_id` on the `CourseEntityRepository` class
* Provided an implementation of the new endpoint  in a new class `OfferingsController` 
* Fixed a message layout and improved `CourseController` tests 

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
