### PR TITLE
:bug: A successful invocation of the `POST /referrals` endpoint should return HTTP status code 201 not 200.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsController.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.restapi
 
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.ReferralsApiDelegate
@@ -22,7 +23,7 @@ class ReferralsController(
       referrerId = startReferral.referrerId,
       offeringId = startReferral.offeringId,
     )?.let {
-      ResponseEntity.ok(ReferralStarted(it))
+      ResponseEntity.status(HttpStatus.CREATED).body(ReferralStarted(it))
     } ?: throw Exception("Unable to start referral")
 
   override fun referralsIdGet(id: UUID): ResponseEntity<Referral> =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsControllerTest.kt
@@ -57,7 +57,7 @@ constructor(
         "referrerId": "$referrerId"
       }"""
     }.andExpect {
-      status { isOk() }
+      status { isCreated() }
       content {
         contentType(MediaType.APPLICATION_JSON)
         json("""{ "referralId": "$referralId" }""")


### PR DESCRIPTION
## Context
Fixing response code bug spotted by Ynda.
## Changes in this PR

A successful invocation of the `POST /referrals` endpoint now returns HTTP status code 201 (Created). 
Previously it returned 200 (Ok).

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
