### PR TITLE
Extend API to enable updates to a Referral

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/HmppsAccreditedProgrammesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/HmppsAccreditedProgrammesApiExceptionHandler.kt
@@ -6,6 +6,7 @@ import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.CONFLICT
 import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
@@ -52,6 +53,20 @@ class HmppsAccreditedProgrammesApiExceptionHandler {
         ErrorResponse(
           status = NOT_FOUND,
           userMessage = "Not Found: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(IllegalArgumentException::class)
+  fun handleIllegalArgumentException(e: IllegalArgumentException): ResponseEntity<ErrorResponse> {
+    log.info("Conflict", e)
+    return ResponseEntity
+      .status(CONFLICT)
+      .body(
+        ErrorResponse(
+          status = CONFLICT,
+          userMessage = "Conflict: ${e.message}",
           developerMessage = e.message,
         ),
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/HmppsAccreditedProgrammesApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/HmppsAccreditedProgrammesApiExceptionHandler.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.config
 
 import io.sentry.Sentry
+import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -16,7 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.restapi.
 class HmppsAccreditedProgrammesApiExceptionHandler {
   @ExceptionHandler(ValidationException::class)
   fun handleValidationException(e: Exception): ResponseEntity<ErrorResponse> {
-    log.info("Validation exception: {}", e.message)
+    log.info("Not valid", e)
     return ResponseEntity
       .status(BAD_REQUEST)
       .body(
@@ -30,7 +31,21 @@ class HmppsAccreditedProgrammesApiExceptionHandler {
 
   @ExceptionHandler(NotFoundException::class)
   fun handleNotFoundException(e: NotFoundException): ResponseEntity<ErrorResponse> {
-    log.info("Not found exception: {}", e.message)
+    log.info("Not found", e)
+    return ResponseEntity
+      .status(NOT_FOUND)
+      .body(
+        ErrorResponse(
+          status = NOT_FOUND,
+          userMessage = "Not Found: ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
+
+  @ExceptionHandler(EntityNotFoundException::class)
+  fun handleEntityNotFoundException(e: EntityNotFoundException): ResponseEntity<ErrorResponse> {
+    log.info("Entity not found", e)
     return ResponseEntity
       .status(NOT_FOUND)
       .body(
@@ -45,7 +60,7 @@ class HmppsAccreditedProgrammesApiExceptionHandler {
   @ExceptionHandler(Throwable::class)
   fun handleException(e: Throwable): ResponseEntity<ErrorResponse?>? {
     Sentry.captureException(e)
-    log.error("Unexpected exception", e)
+    log.error("Unexpected error", e)
     return ResponseEntity
       .status(INTERNAL_SERVER_ERROR)
       .body(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/Referral.kt
@@ -2,8 +2,11 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domai
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType.STRING
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.REFERRAL_STARTED
 import java.util.UUID
 
 @Entity
@@ -16,4 +19,13 @@ class Referral(
   val offeringId: UUID,
   val prisonNumber: String,
   val referrerId: String,
-)
+  var reason: String? = null,
+  var oasysConfirmed: Boolean = false,
+  @Enumerated(STRING)
+  val status: Status = REFERRAL_STARTED,
+) {
+
+  enum class Status {
+    REFERRAL_STARTED, REFERRAL_SUBMITTED, AWAITING_ASSESSMENT, ASSESSMENT_STARTED,
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/Referral.kt
@@ -6,7 +6,12 @@ import jakarta.persistence.EnumType.STRING
 import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.ASSESSMENT_STARTED
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.AWAITING_ASSESSMENT
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.REFERRAL_STARTED
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.REFERRAL_SUBMITTED
+import java.util.EnumMap
+import java.util.EnumSet
 import java.util.UUID
 
 @Entity
@@ -22,10 +27,27 @@ class Referral(
   var reason: String? = null,
   var oasysConfirmed: Boolean = false,
   @Enumerated(STRING)
-  val status: Status = REFERRAL_STARTED,
+  var status: Status = REFERRAL_STARTED,
 ) {
 
   enum class Status {
-    REFERRAL_STARTED, REFERRAL_SUBMITTED, AWAITING_ASSESSMENT, ASSESSMENT_STARTED,
+    REFERRAL_STARTED,
+    REFERRAL_SUBMITTED,
+    AWAITING_ASSESSMENT,
+    ASSESSMENT_STARTED,
+    ;
+
+    fun isValidTransition(nextStatus: Status?): Boolean = validTransitions[this]?.contains(nextStatus) ?: false
+  }
+
+  companion object {
+    private val validTransitions = EnumMap(
+      mapOf(
+        REFERRAL_STARTED to EnumSet.of(REFERRAL_STARTED, REFERRAL_SUBMITTED),
+        REFERRAL_SUBMITTED to EnumSet.of(REFERRAL_SUBMITTED, AWAITING_ASSESSMENT),
+        AWAITING_ASSESSMENT to EnumSet.of(AWAITING_ASSESSMENT, ASSESSMENT_STARTED),
+        ASSESSMENT_STARTED to EnumSet.of(ASSESSMENT_STARTED),
+      ),
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/ReferralService.kt
@@ -3,13 +3,14 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domai
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.jparepo.JpaReferralRepository
 import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
 
 @Service
 @Transactional
-class ReferralsService(
+class ReferralService(
   @Autowired val referralRepository: JpaReferralRepository,
 ) {
   fun startReferral(
@@ -24,5 +25,14 @@ class ReferralsService(
     val referral = referralRepository.getReferenceById(referralId)
     referral.reason = reason
     referral.oasysConfirmed = oasysConfirmed
+  }
+
+  fun updateReferralStatus(referralId: UUID, nextStatus: Status) {
+    val referral = referralRepository.getReferenceById(referralId)
+    if (referral.status.isValidTransition(nextStatus)) {
+      referral.status = nextStatus
+    } else {
+      throw IllegalArgumentException("Transition from ${referral.status} to $nextStatus is not valid")
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/ReferralsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/ReferralsService.kt
@@ -19,4 +19,10 @@ class ReferralsService(
   ): UUID? = referralRepository.save(Referral(offeringId = offeringId, prisonNumber = prisonNumber, referrerId = referrerId)).id
 
   fun getReferral(referralId: UUID) = referralRepository.findById(referralId).getOrNull()
+
+  fun updateReferral(referralId: UUID, reason: String?, oasysConfirmed: Boolean) {
+    val referral = referralRepository.getReferenceById(referralId)
+    referral.reason = reason
+    referral.oasysConfirmed = oasysConfirmed
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsController.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.ReferralsApiDelegate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Referral
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStarted
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.StartReferral
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.restapi.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.ReferralsService
@@ -31,4 +32,9 @@ class ReferralsController(
       .getReferral(id)
       ?.let { ResponseEntity.ok(it.toApi()) }
       ?: throw NotFoundException("No Referral found at /referrals/$id")
+
+  override fun referralsIdPut(id: UUID, referralUpdate: ReferralUpdate): ResponseEntity<Unit> = with(referralUpdate) {
+    referralsService.updateReferral(id, reason, oasysConfirmed)
+    ResponseEntity.noContent().build()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/transformer/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/transformer/Transformers.kt
@@ -8,4 +8,7 @@ fun DomainReferral.toApi(): ApiReferral = ApiReferral(
   offeringId = offeringId,
   prisonNumber = prisonNumber,
   referrerId = referrerId,
+  oasysConfirmed = false,
+  reason = null,
+  status = ApiReferral.Status.rEFERRALSTARTED,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/transformer/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/transformer/Transformers.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.trans
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Referral as ApiReferral
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus as ApiReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral as DomainReferral
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status as DomainReferralStatus
 
 fun DomainReferral.toApi(): ApiReferral = ApiReferral(
   id = id!!,
@@ -15,8 +16,15 @@ fun DomainReferral.toApi(): ApiReferral = ApiReferral(
 )
 
 fun DomainReferral.Status.toApi(): ApiReferralStatus = when (this) {
-  DomainReferral.Status.ASSESSMENT_STARTED -> ApiReferralStatus.assessmentStarted
-  DomainReferral.Status.REFERRAL_STARTED -> ApiReferralStatus.referralStarted
-  DomainReferral.Status.REFERRAL_SUBMITTED -> ApiReferralStatus.referralSubmitted
-  DomainReferral.Status.AWAITING_ASSESSMENT -> ApiReferralStatus.awaitingAssessment
+  DomainReferralStatus.ASSESSMENT_STARTED -> ApiReferralStatus.assessmentStarted
+  DomainReferralStatus.REFERRAL_STARTED -> ApiReferralStatus.referralStarted
+  DomainReferralStatus.REFERRAL_SUBMITTED -> ApiReferralStatus.referralSubmitted
+  DomainReferralStatus.AWAITING_ASSESSMENT -> ApiReferralStatus.awaitingAssessment
+}
+
+fun ApiReferralStatus.toDomain(): DomainReferralStatus = when (this) {
+  ApiReferralStatus.referralStarted -> DomainReferralStatus.REFERRAL_STARTED
+  ApiReferralStatus.referralSubmitted -> DomainReferralStatus.REFERRAL_SUBMITTED
+  ApiReferralStatus.awaitingAssessment -> DomainReferralStatus.AWAITING_ASSESSMENT
+  ApiReferralStatus.assessmentStarted -> DomainReferralStatus.ASSESSMENT_STARTED
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/transformer/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/transformer/Transformers.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.transformer
 
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Referral as ApiReferral
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus as ApiReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral as DomainReferral
 
 fun DomainReferral.toApi(): ApiReferral = ApiReferral(
@@ -8,7 +9,14 @@ fun DomainReferral.toApi(): ApiReferral = ApiReferral(
   offeringId = offeringId,
   prisonNumber = prisonNumber,
   referrerId = referrerId,
-  oasysConfirmed = false,
-  reason = null,
-  status = ApiReferral.Status.rEFERRALSTARTED,
+  oasysConfirmed = oasysConfirmed,
+  reason = reason,
+  status = status.toApi(),
 )
+
+fun DomainReferral.Status.toApi(): ApiReferralStatus = when (this) {
+  DomainReferral.Status.ASSESSMENT_STARTED -> ApiReferralStatus.assessmentStarted
+  DomainReferral.Status.REFERRAL_STARTED -> ApiReferralStatus.referralStarted
+  DomainReferral.Status.REFERRAL_SUBMITTED -> ApiReferralStatus.referralSubmitted
+  DomainReferral.Status.AWAITING_ASSESSMENT -> ApiReferralStatus.awaitingAssessment
+}

--- a/src/main/resources/db/migration/V11__extend_referral_table.sql
+++ b/src/main/resources/db/migration/V11__extend_referral_table.sql
@@ -1,0 +1,6 @@
+ALTER TABLE referral
+    ADD COLUMN reason TEXT;
+ALTER TABLE referral
+    ADD COLUMN oasys_confirmed BOOLEAN NOT NULL DEFAULT false;
+    ALTER TABLE referral
+    ADD COLUMN status TEXT NOT NULL DEFAULT 'REFERRAL_STARTED';

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -223,6 +223,10 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Referral'
+        401:
+          description: The request was unauthorized
+        403:
+          description: Forbidden.  The client is not authorised to access this referral
         404:
           description: No referral has the supplied id (Not Found)
 
@@ -506,12 +510,7 @@ components:
           type: boolean
           default: false
         status:
-          type: string
-          enum:
-            - REFERRAL_STARTED
-            - REFERRAL_SUBMITTED
-            - AWAITING_ASSESSMENT
-            - ASSESSMENT_STARTED
+          $ref: "#/components/schemas/ReferralStatus"
       required:
         - id
         - offeringId
@@ -519,3 +518,11 @@ components:
         - referrerId
         - oasysConfirmed
         - status
+
+    ReferralStatus:
+      type: string
+      enum:
+        - referral_started
+        - referral_submitted
+        - awaiting_assessment
+        - assessment_started

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -21,7 +21,7 @@ paths:
                   $ref: '#/components/schemas/Course'
     put:
       tags:
-        - Courses bulk upload / replace
+        - Courses
       summary: Upload a CSV format file containing a full set of Courses data.
       requestBody:
         required: true
@@ -40,7 +40,7 @@ paths:
   /courses/prerequisites:
     put:
       tags:
-        - Course prerequisites bulk upload / replace
+        - Course Prerequisites
       summary: Upload a CSV format file containing a full set of prerequisites data for the current set of courses.
       description: "Accepts a CSV format file of data representing the desired state of all prerequisite data attached to the current set of courses.
       <p>Pre-existing prerequisite data will be removed before the new data is applied.
@@ -94,8 +94,8 @@ paths:
   /courses/offerings:
     put:
       tags:
-        - Course offerings bulk upload / replace
-      summary: Upload a CVS format file containing a full set of offerings data for a set of courses.
+        - Course Offerings
+      summary: Upload a CSV format file containing a full set of offerings data for a set of courses.
       description: "Accepts a CSV format file of data representing the desired state of all offerings data attached to the current set of courses.
       <p>Pre-existing offering data will be removed before the new data is applied.
       <p>The first row of CSV data is treated as a header row.  The column headings in the header row must much the names of the fields in the OfferingRecord schema. Column order is not important."
@@ -150,7 +150,7 @@ paths:
   /courses/{courseId}/offerings/{offeringId}:
     get:
       tags:
-        - Course Offering
+        - Course Offerings
       summary: Details for a single course offering
 
       parameters:
@@ -177,6 +177,10 @@ paths:
             'application/json':
               schema:
                   $ref: '#/components/schemas/CourseOffering'
+        401:
+          description: Unauthorized. The request was unauthorized
+        403:
+          description: Forbidden.  The client is not authorised to access this offering
         404:
           description: invalid course and/or course offering id
           content:
@@ -203,6 +207,52 @@ paths:
               schema:
                 $ref: '#/components/schemas/ReferralStarted'
 
+    get:
+      summary: Retrieve some referrals
+      tags:
+        - Referrals
+      parameters:
+        - name: status
+          in: query
+          description: If present only return referrals in the given state
+          required: false
+          schema:
+            $ref: "#/components/schemas/ReferralStatus"
+        - name: offeringId
+          in: query
+          description: The id (UUID) of an active offering. If present only return referrals for that offering
+          required: false
+          schema:
+            type: string
+            format: uuid
+        - name: prisonNumber
+          in: query
+          description: The prison number of the person who is being referred. If present only return referrals for the person.
+          example: "A1234AA"
+          required: false
+          schema:
+            type: string
+        - name: referrerId
+          in: query
+          description: A permanent identifier for the person creating the referral. StaffId for prison staff. If present only return referrals for that referrer
+          required: false
+          schema:
+            type: string
+
+      responses:
+        200:
+          description: Returns information about matching referrals
+          content:
+            'application/json':
+                schema:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Referral'
+        401:
+          description: The request was unauthorized
+        403:
+          description: Forbidden.  The client is not authorised to access referrals
+
   /referrals/{id}:
     get:
       tags:
@@ -228,7 +278,66 @@ paths:
         403:
           description: Forbidden.  The client is not authorised to access this referral
         404:
-          description: No referral has the supplied id (Not Found)
+         description: The referral does not exist
+
+    put:
+      tags:
+        - Referrals
+      summary: Update a referral
+      parameters:
+        - name: id
+          in: path
+          description: The id (UUID) of a referral
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          'application/json':
+            schema:
+              $ref: "#/components/schemas/ReferralUpdate"
+      responses:
+        204:
+          description: The referral was updated
+        401:
+          description: The request was unauthorized
+        403:
+          description: Forbidden.  The client is not authorised to access this referral
+        404:
+          description: The referral does not exist
+
+  /referrals/{id}/state:
+    post:
+      summary: Change a referral's state
+      tags:
+        - Referrals
+      parameters:
+        - name: id
+          in: path
+          description: The id (UUID) of a referral
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/ReferralStatus'
+      responses:
+        204:
+          description: The referral is now in the requested state
+        401:
+          description: The request was unauthorized
+        403:
+          description: Forbidden.  The client is not authorised to access this referral
+        404:
+          description: The referral does not exist
+        409:
+          description: The POSTed state conflicts with the current state of the referral
 
   /offerings/{id}/course:
     get:
@@ -250,6 +359,10 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Course'
+        401:
+          description: The request was unauthorized
+        403:
+          description: Forbidden.  The client is not authorised to access this offering
         404:
           description: No offering has the supplied id (Not Found)
 
@@ -518,6 +631,17 @@ components:
         - referrerId
         - oasysConfirmed
         - status
+
+    ReferralUpdate:
+      type: object
+      properties:
+        reason:
+          type: string
+        oasysConfirmed:
+          type: boolean
+          default: false
+      required:
+        - oasysConfirmed
 
     ReferralStatus:
       type: string

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -498,9 +498,24 @@ components:
           example: "A1234AA"
           type: string
         referrerId:
+          description: A permanent identifier for the person creating the referral. StaffId for prison staff
           type: string
+        reason:
+          type: string
+        oasysConfirmed:
+          type: boolean
+          default: false
+        status:
+          type: string
+          enum:
+            - REFERRAL_STARTED
+            - REFERRAL_SUBMITTED
+            - AWAITING_ASSESSMENT
+            - ASSESSMENT_STARTED
       required:
         - id
         - offeringId
         - prisonNumber
         - referrerId
+        - oasysConfirmed
+        - status

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -308,9 +308,9 @@ paths:
         404:
           description: The referral does not exist
 
-  /referrals/{id}/state:
-    post:
-      summary: Change a referral's state
+  /referrals/{id}/status:
+    put:
+      summary: Change a referral's status
       tags:
         - Referrals
       parameters:
@@ -326,10 +326,10 @@ paths:
         content:
           'application/json':
             schema:
-              $ref: '#/components/schemas/ReferralStatus'
+              $ref: '#/components/schemas/StatusUpdate'
       responses:
         204:
-          description: The referral is now in the requested state
+          description: The referral now has the requested status
         401:
           description: The request was unauthorized
         403:
@@ -337,7 +337,7 @@ paths:
         404:
           description: The referral does not exist
         409:
-          description: The POSTed state conflicts with the current state of the referral
+          description: The referral may not change its status to the supplied value
 
   /offerings/{id}/course:
     get:
@@ -642,6 +642,14 @@ components:
           default: false
       required:
         - oasysConfirmed
+
+    StatusUpdate:
+      type: object
+      properties:
+        status:
+          $ref: "#/components/schemas/ReferralStatus"
+      required:
+        - status
 
     ReferralStatus:
       type: string

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/ReferralStatusTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/ReferralStatusTest.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.ASSESSMENT_STARTED
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.AWAITING_ASSESSMENT
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.REFERRAL_STARTED
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.REFERRAL_SUBMITTED
+import java.util.stream.Stream
+
+class ReferralStatusTest {
+  @ParameterizedTest
+  @MethodSource
+  fun `confirm status transition validity`(from: Status, to: Status, expected: Boolean) {
+    from.isValidTransition(to) shouldBe expected
+  }
+
+  companion object {
+    private val validTransitions = mapOf(
+      REFERRAL_STARTED to setOf(REFERRAL_STARTED, REFERRAL_SUBMITTED),
+      REFERRAL_SUBMITTED to setOf(REFERRAL_SUBMITTED, AWAITING_ASSESSMENT),
+      AWAITING_ASSESSMENT to setOf(AWAITING_ASSESSMENT, ASSESSMENT_STARTED),
+      ASSESSMENT_STARTED to setOf(ASSESSMENT_STARTED),
+    )
+
+    @JvmStatic
+    fun `confirm status transition validity`(): Stream<Arguments> =
+      Status.entries.flatMap { from ->
+        Status.entries.map { to ->
+          arguments(from, to, validTransitions[from]!!.contains(to))
+        }
+      }.stream()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsControllerTest.kt
@@ -88,7 +88,10 @@ constructor(
           { 
             "offeringId": "$offeringId",
             "prisonNumber": "$prisonNumber",
-            "referrerId": "$referrerId"          
+            "referrerId": "$referrerId",
+            "status": "referral_started",
+            "oasysConfirmed": false,
+            "reason": null
           }
           """,
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsControllerTest.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.restapi
 
 import com.ninjasquad.springmockk.MockkBean
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -14,10 +16,14 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.restapi.CoursesControllerTest
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.ReferralsService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.AWAITING_ASSESSMENT
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.REFERRAL_STARTED
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.REFERRAL_SUBMITTED
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.ReferralService
 import java.util.UUID
 
 @WebMvcTest
@@ -38,7 +44,7 @@ constructor(
 ) {
 
   @MockkBean
-  private lateinit var referralsService: ReferralsService
+  private lateinit var referralsService: ReferralService
 
   @Test
   fun `start a referral`() {
@@ -123,5 +129,39 @@ constructor(
     }
 
     verify { referralsService.getReferral(referralId) }
+  }
+
+  @Test
+  fun `successful referral status update`() {
+    val referralId = UUID.randomUUID()
+
+    every { referralsService.updateReferralStatus(any(), any()) } just Runs
+
+    mockMvc.put("/referrals/$referralId/status") {
+      contentType = MediaType.APPLICATION_JSON
+      header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      content = """{ "status": "referral_submitted" }"""
+    }.andExpect {
+      status { isNoContent() }
+    }
+
+    verify { referralsService.updateReferralStatus(referralId, REFERRAL_SUBMITTED) }
+  }
+
+  @Test
+  fun `referral status update - invalid transition`() {
+    val referralId = UUID.randomUUID()
+
+    every { referralsService.updateReferralStatus(any(), any()) } throws (IllegalArgumentException("Transition from $REFERRAL_STARTED to $AWAITING_ASSESSMENT is not valid"))
+
+    mockMvc.put("/referrals/$referralId/status") {
+      contentType = MediaType.APPLICATION_JSON
+      header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      content = """{ "status": "awaiting_assessment" }"""
+    }.andExpect {
+      status { isConflict() }
+    }
+
+    verify { referralsService.updateReferralStatus(referralId, AWAITING_ASSESSMENT) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsIntegrationTest.kt
@@ -13,6 +13,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Course
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseOffering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStarted
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.StartReferral
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
 import java.util.UUID
@@ -64,7 +65,7 @@ constructor(
       offeringId = offeringId,
       referrerId = "MWX0001",
       prisonNumber = "AB1234A",
-      status = ApiReferral.Status.rEFERRALSTARTED,
+      status = ReferralStatus.referralStarted,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsIntegrationTest.kt
@@ -12,11 +12,11 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Course
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseOffering
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Referral
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStarted
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.StartReferral
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
 import java.util.UUID
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Referral as ApiReferral
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -54,16 +54,17 @@ constructor(
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().is2xxSuccessful
-      .expectBody(Referral::class.java)
+      .expectBody(ApiReferral::class.java)
       .returnResult().responseBody
 
     referral.shouldNotBeNull()
 
-    referral shouldBeEqual Referral(
+    referral shouldBeEqual ApiReferral(
       id = referralStarted.referralId,
       offeringId = offeringId,
       referrerId = "MWX0001",
       prisonNumber = "AB1234A",
+      status = ApiReferral.Status.rEFERRALSTARTED,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/transformer/TransformersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/transformer/TransformersTest.kt
@@ -3,19 +3,39 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.trans
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.assessmentStarted
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.awaitingAssessment
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.referralStarted
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.referralSubmitted
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.ASSESSMENT_STARTED
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.AWAITING_ASSESSMENT
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.REFERRAL_STARTED
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.REFERRAL_SUBMITTED
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus as ApiReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status as DomainReferralStatus
 
 class TransformersTest {
-  @ParameterizedTest()
+  @ParameterizedTest
   @EnumSource
   fun `maps status from domain to api`(domainStatus: DomainReferralStatus) {
     val apiStatus = domainStatus.toApi()
     when (domainStatus) {
-      DomainReferralStatus.REFERRAL_STARTED -> apiStatus shouldBe ApiReferralStatus.referralStarted
-      DomainReferralStatus.REFERRAL_SUBMITTED -> apiStatus shouldBe ApiReferralStatus.referralSubmitted
-      DomainReferralStatus.AWAITING_ASSESSMENT -> apiStatus shouldBe ApiReferralStatus.awaitingAssessment
-      DomainReferralStatus.ASSESSMENT_STARTED -> apiStatus shouldBe ApiReferralStatus.assessmentStarted
+      REFERRAL_STARTED -> apiStatus shouldBe referralStarted
+      REFERRAL_SUBMITTED -> apiStatus shouldBe referralSubmitted
+      AWAITING_ASSESSMENT -> apiStatus shouldBe awaitingAssessment
+      ASSESSMENT_STARTED -> apiStatus shouldBe assessmentStarted
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource
+  fun `maps status from api to domain`(apiStatus: ApiReferralStatus) {
+    val domainStatus = apiStatus.toDomain()
+    when (apiStatus) {
+      referralStarted -> domainStatus shouldBe REFERRAL_STARTED
+      referralSubmitted -> domainStatus shouldBe REFERRAL_SUBMITTED
+      awaitingAssessment -> domainStatus shouldBe AWAITING_ASSESSMENT
+      assessmentStarted -> domainStatus shouldBe ASSESSMENT_STARTED
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/transformer/TransformersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/transformer/TransformersTest.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.transformer
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus as ApiReferralStatus
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status as DomainReferralStatus
+
+class TransformersTest {
+  @ParameterizedTest()
+  @EnumSource
+  fun `maps status from domain to api`(domainStatus: DomainReferralStatus) {
+    val apiStatus = domainStatus.toApi()
+    when (domainStatus) {
+      DomainReferralStatus.REFERRAL_STARTED -> apiStatus shouldBe ApiReferralStatus.referralStarted
+      DomainReferralStatus.REFERRAL_SUBMITTED -> apiStatus shouldBe ApiReferralStatus.referralSubmitted
+      DomainReferralStatus.AWAITING_ASSESSMENT -> apiStatus shouldBe ApiReferralStatus.awaitingAssessment
+      DomainReferralStatus.ASSESSMENT_STARTED -> apiStatus shouldBe ApiReferralStatus.assessmentStarted
+    }
+  }
+}


### PR DESCRIPTION
## Context

* Trello: [Add PUT `/referral/{referralId} endpoint](https://trello.com/c/66GNllNO/705-add-update-referral-put-endpoint-api)
* Trello: [Add PUT /referrla/{referralId}/status` endpoint](https://trello.com/c/SGdEhubR/746-add-referrals-id-submit-endpoint-to-mark-a-referral-as-submitted-true-api)

A `Referral` resource holds information about a referral.  Over time the `Referral`'s status will change and it will acquire management information about the referral, its assessment and participation in a course offering.

Additional endpoints are required to enable clients to update the referral itself and to update its status.

## Changes in this PR
* Added new endpoint definitions to `api.yml` for `PUT /referrals/{referralId}` and `PUT /referrals/{referralId}/status`
* Implemented the endpoint behaviour
* Minor renaming and other tweaks for readability, comprehension etc

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
