### PR TITLE
677 add referable property to course

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseEntity.kt
@@ -29,6 +29,7 @@ class CourseEntity(
   var identifier: String,
   var description: String? = null,
   var alternateName: String? = null,
+  var referable: Boolean = true,
 
   @ElementCollection
   @Fetch(SUBSELECT)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseService.kt
@@ -36,6 +36,7 @@ class CourseService(
         description = it.description,
         alternateName = it.alternateName,
         audiences = audienceStrings(it.audience).mapNotNull { audienceName -> allAudiences[audienceName] }.toMutableSet(),
+        referable = it.referable,
       )
     }.forEach(courseRepository::saveCourse)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/NewCourse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/NewCourse.kt
@@ -6,4 +6,5 @@ data class NewCourse(
   val identifier: String,
   val audience: String,
   val alternateName: String? = null,
+  val referable: Boolean = true,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/transformer/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/transformer/Transformers.kt
@@ -21,7 +21,8 @@ fun CourseEntity.toApi(): Course = Course(
   description = description,
   alternateName = alternateName,
   coursePrerequisites = prerequisites.map(Prerequisite::toApi),
-  audiences = audiences.map(uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.Audience::toApi),
+  audiences = audiences.map(Audience::toApi),
+  referable = referable,
 )
 
 fun Prerequisite.toApi(): CoursePrerequisite = CoursePrerequisite(
@@ -47,6 +48,7 @@ fun CourseRecord.toDomain(): NewCourse = NewCourse(
   description = description.trim(),
   audience = audience,
   alternateName = alternateName?.trim(),
+  referable = referable,
 )
 
 fun OfferingRecord.toDomain(): NewOffering = NewOffering(

--- a/src/main/resources/db/migration/V13__add_referable_boolean_to_course.sql
+++ b/src/main/resources/db/migration/V13__add_referable_boolean_to_course.sql
@@ -1,0 +1,2 @@
+ALTER TABLE course
+    ADD COLUMN referable BOOLEAN NOT NULL DEFAULT true;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -576,11 +576,15 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CourseAudience'
+        referable:
+          type: boolean
+          default: true
       required:
         - id
         - name
         - coursePrerequisites
         - audiences
+        - referable
 
     CourseRecord:
       title: 'CourseRecord'
@@ -598,11 +602,15 @@ components:
           type: string
         comments:
           type: string
+        referable:
+          type: boolean
+          default: true
       required:
         - name
         - identifier
         - description
         - audience
+        - referable
 
     CoursePrerequisite:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseServiceTest.kt
@@ -34,14 +34,14 @@ class CourseServiceTest {
 
       service.replaceAllCourses(
         listOf(
-          NewCourse(name = "Course", identifier = "C", description = "Description", audience = "Audience 1", alternateName = "CCC"),
+          NewCourse(name = "Course", identifier = "C", description = "Description", audience = "Audience 1", alternateName = "CCC", referable = true),
         ),
       )
 
       verify { repository.clear() }
       verify { repository.saveAudiences(setOf(Audience(a1.value))) }
       verify {
-        repository.saveCourse(eqCourse(CourseEntity(name = "Course", identifier = "C", description = "Description", audiences = mutableSetOf(a1))))
+        repository.saveCourse(eqCourse(CourseEntity(name = "Course", identifier = "C", description = "Description", audiences = mutableSetOf(a1), referable = true)))
       }
     }
 
@@ -55,14 +55,14 @@ class CourseServiceTest {
 
       service.replaceAllCourses(
         listOf(
-          NewCourse(name = "Course 1", identifier = "C1", description = "Description 1", audience = "${a1.value}, ${a2.value} ", alternateName = "111"),
-          NewCourse(name = "Course 2", identifier = "C2", description = "Description 2", audience = "${a1.value}, ${a3.value}", alternateName = "222"),
+          NewCourse(name = "Course 1", identifier = "C1", description = "Description 1", audience = "${a1.value}, ${a2.value} ", alternateName = "111", referable = true),
+          NewCourse(name = "Course 2", identifier = "C2", description = "Description 2", audience = "${a1.value}, ${a3.value}", alternateName = "222", referable = true),
         ),
       )
       verify { repository.clear() }
       verify { repository.saveAudiences(setOf(Audience(a1.value), Audience(a2.value), Audience(a3.value))) }
-      verify { repository.saveCourse(eqCourse(CourseEntity(name = "Course 1", identifier = "C1", description = "Description 1", audiences = mutableSetOf(a1, a2)))) }
-      verify { repository.saveCourse(eqCourse(CourseEntity(name = "Course 2", identifier = "C2", description = "Description 2", audiences = mutableSetOf(a1, a3)))) }
+      verify { repository.saveCourse(eqCourse(CourseEntity(name = "Course 1", identifier = "C1", description = "Description 1", audiences = mutableSetOf(a1, a2), referable = true))) }
+      verify { repository.saveCourse(eqCourse(CourseEntity(name = "Course 2", identifier = "C2", description = "Description 2", audiences = mutableSetOf(a1, a3), referable = true))) }
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/MockkMatchers.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/MockkMatchers.kt
@@ -14,7 +14,8 @@ fun CourseEntity.eqByFields(other: CourseEntity) =
     description == other.description &&
     audiences.refEq(other.audiences) &&
     offerings == other.offerings &&
-    prerequisites == other.prerequisites
+    prerequisites == other.prerequisites &&
+    referable == other.referable
 
 fun Set<Audience>.refEq(other: Set<Audience>) =
   this.size == other.size &&

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/jparepo/OfferingRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/jparepo/OfferingRepositoryTest.kt
@@ -24,15 +24,21 @@ constructor(
       name = "A Course",
       identifier = "AC",
       description = "A description",
+      referable = true,
     ).apply {
       addOffering(Offering(organisationId = "BWI", contactEmail = "bwi@a.com"))
       addOffering(Offering(organisationId = "MDI", contactEmail = "mdi@a.com"))
       addOffering(Offering(organisationId = "BXI", contactEmail = "bxi@a.com"))
     }
-    val course2 = CourseEntity(name = "Another Course", identifier = "ACANO", description = "Another description")
-      .apply {
-        addOffering(Offering(organisationId = "MDI", contactEmail = "mdi@a.com"))
-      }
+
+    val course2 = CourseEntity(
+      name = "Another Course",
+      identifier = "ACANO",
+      description = "Another description",
+      referable = false,
+    ).apply {
+      addOffering(Offering(organisationId = "MDI", contactEmail = "mdi@a.com"))
+    }
 
     val offering = courseRepository.save(course1).offerings.first()
     courseRepository.save(course2)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesControllerTest.kt
@@ -59,9 +59,9 @@ class CoursesControllerTest(
           this.json(
             """
           [
-            { "name": "Lime Course", "alternateName": "LC" },
-            { "name": "Azure Course", "alternateName": "AC++" },
-            { "name": "Violet Course" }
+            { "name": "Lime Course", "alternateName": "LC", "referable": true },
+            { "name": "Azure Course", "alternateName": "AC++", "referable": true },
+            { "name": "Violet Course", "referable": true }
         ]
         """,
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesIntegrationTest.kt
@@ -12,10 +12,10 @@ import org.springframework.http.MediaType
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Course
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseOffering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
 import java.util.*
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Course as ApiCourse
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -44,9 +44,9 @@ class CoursesIntegrationTest
       .json(
         """
         [
-          { "name": "Lime Course", "alternateName": "LC" },
-          { "name": "Azure Course", "alternateName": "AC++" },
-          { "name": "Violet Course" }
+          { "name": "Lime Course", "alternateName": "LC", "referable": true },
+          { "name": "Azure Course", "alternateName": "AC++", "referable": true },
+          { "name": "Violet Course", "referable": true }
         ]
         """,
       )
@@ -252,13 +252,13 @@ class CoursesIntegrationTest
       .expectBody()
       .jsonPath("$.size()").isEqualTo(0)
 
-    val courses: List<Course> = webTestClient
+    val courses: List<ApiCourse> = webTestClient
       .get()
       .uri("/courses")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
-      .expectBody(object : ParameterizedTypeReference<List<Course>>() {})
+      .expectBody(object : ParameterizedTypeReference<List<ApiCourse>>() {})
       .returnResult().responseBody!!
 
     val allOfferings: List<List<CourseOffering>> = courses.map {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/InMemoryCourseRepository.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/InMemoryCourseRepository.kt
@@ -41,6 +41,7 @@ class InMemoryCourseRepository {
       ),
       alternateName = "LC",
       audiences = mutableSetOf(),
+      referable = true,
     ).apply {
       addOffering(offering(organisationId = "MDI", contactEmail = "nobody-mdi@digital.justice.gov.uk"))
       addOffering(offering(organisationId = "BWN", contactEmail = "nobody-bwn@digital.justice.gov.uk"))
@@ -59,6 +60,7 @@ class InMemoryCourseRepository {
       ),
       alternateName = "AC++",
       audiences = audiences.toMutableSet(),
+      referable = true,
     ).apply { addOffering(offering(organisationId = "MDI", contactEmail = "nobody-mdi@digital.justice.gov.uk")) }
 
     private val nms = CourseEntity(
@@ -72,6 +74,7 @@ class InMemoryCourseRepository {
         Prerequisite(name = "Criminogenic needs", description = "Relationships, Thinking and Behaviour, Attitudes, Lifestyle"),
       ),
       audiences = mutableSetOf(),
+      referable = true,
     ).apply { addOffering(offering(organisationId = "BWN", contactEmail = "nobody-bwn@digital.justice.gov.uk")) }
 
     private val courses: Set<CourseEntity> = setOf(tsp, bnm, nms)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/transformer/TransformerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/transformer/TransformerTest.kt
@@ -20,6 +20,7 @@ class TransformerTest {
       identifier = "AC",
       prerequisites = mutableSetOf(),
       audiences = mutableSetOf(),
+      referable = true,
     )
 
     with(entity.toApi()) {
@@ -28,6 +29,7 @@ class TransformerTest {
       description shouldBe null
       alternateName shouldBe null
       coursePrerequisites.shouldBeEmpty()
+      referable.shouldBe(true)
     }
   }
 
@@ -41,6 +43,7 @@ class TransformerTest {
       alternateName = "AA++",
       prerequisites = mutableSetOf(),
       audiences = mutableSetOf(),
+      referable = true,
     )
 
     with(entity.toApi()) {
@@ -64,6 +67,7 @@ class TransformerTest {
         Audience(value = "B", id = UUID.randomUUID()),
         Audience(value = "C", id = UUID.randomUUID()),
       ),
+      referable = true,
     )
 
     with(entity.toApi()) {


### PR DESCRIPTION
## Context

> [see ticket #677 on the Accredited Programmes Trello board.](https://trello.com/c/EaDLACLz/677-add-referable-property-to-course-api)

## Changes in this PR

We needed a new boolean value for determining whether users can refer people onto various course offerings.
Rather than include this as a property of `Offering`, I have added the new `referable` field to `Course`, which defaults to `true`.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod
