### PR TITLE
779 Remove old courses/{courseId}/offerings/{offeringId} endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
@@ -51,9 +51,4 @@ class CoursesController(
           .offeringsForCourse(courseId)
           .map(Offering::toApi),
       )
-
-  override fun coursesCourseIdOfferingsOfferingIdGet(courseId: UUID, offeringId: UUID): ResponseEntity<CourseOffering> =
-    courseService.courseOffering(courseId, offeringId)?.let {
-      ResponseEntity.ok(it.toApi())
-    } ?: throw NotFoundException("No CourseOffering found at /courses/$courseId/offerings/$offeringId")
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -146,47 +146,6 @@ paths:
                 items:
                   $ref: '#/components/schemas/CourseOffering'
 
-  /courses/{courseId}/offerings/{offeringId}:
-    get:
-      tags:
-        - Course Offerings
-      summary: Details for a single course offering
-
-      parameters:
-        - name: courseId
-          in: path
-          description: A course identifier
-          required: true
-          schema:
-            type: string
-            format: uuid
-
-        - name: offeringId
-          in: path
-          description: A course offering identifier
-          required: true
-          schema:
-            type: string
-            format: uuid
-
-      responses:
-        200:
-          description: successful operation
-          content:
-            'application/json':
-              schema:
-                  $ref: '#/components/schemas/CourseOffering'
-        401:
-          description: Unauthorized. The request was unauthorized
-        403:
-          description: Forbidden.  The client is not authorised to access this offering
-        404:
-          description: invalid course and/or course offering id
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-
   /offerings/{offeringId}:
     get:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesControllerTest.kt
@@ -194,59 +194,6 @@ class CoursesControllerTest(
         status { isUnauthorized() }
       }
     }
-
-    @Test
-    fun `get a course offering - happy path`() {
-      val courseId = repository.allCourses().first().id
-      val courseOfferingId = repository.offeringsForCourse(courseId!!).first().id!!
-
-      every { coursesService.courseOffering(courseId, courseOfferingId) } returns repository.courseOffering(courseId, courseOfferingId)
-
-      mockMvc.get("/courses/$courseId/offerings/$courseOfferingId") {
-        accept = MediaType.APPLICATION_JSON
-        header(AUTHORIZATION, jwtAuthHelper.bearerToken())
-      }.andExpect {
-        status { isOk() }
-        content {
-          jsonPath("$.id") { value(courseOfferingId.toString()) }
-          jsonPath("$.organisationId") { isNotEmpty() }
-          jsonPath("$.contactEmail") { isNotEmpty() }
-        }
-      }
-    }
-
-    @Test
-    fun `get a course offering - not found`() {
-      val randomUuid = UUID.randomUUID()
-
-      every { coursesService.courseOffering(randomUuid, randomUuid) } returns null
-
-      mockMvc.get("/courses/$randomUuid/offerings/$randomUuid") {
-        accept = MediaType.APPLICATION_JSON
-        header(AUTHORIZATION, jwtAuthHelper.bearerToken())
-      }.andExpect {
-        status { isNotFound() }
-        content {
-          contentType(MediaType.APPLICATION_JSON)
-          jsonPath("$.status") { value(404) }
-          jsonPath("$.errorCode") { isEmpty() }
-          jsonPath("$.userMessage") { value("Not Found: No CourseOffering found at /courses/$randomUuid/offerings/$randomUuid") }
-          jsonPath("$.developerMessage") { value("No CourseOffering found at /courses/$randomUuid/offerings/$randomUuid") }
-          jsonPath("$.moreInfo") { isEmpty() }
-        }
-      }
-    }
-
-    @Test
-    fun `get a course offering - no token`() {
-      val randomUuid = UUID.randomUUID()
-
-      mockMvc.get("/courses/$randomUuid/offerings/$randomUuid") {
-        accept = MediaType.APPLICATION_JSON
-      }.andExpect {
-        status { isUnauthorized() }
-      }
-    }
   }
 
   @Nested

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesIntegrationTest.kt
@@ -123,22 +123,6 @@ class CoursesIntegrationTest
   }
 
   @Test
-  fun `get a course offering - happy path`() {
-    webTestClient
-      .get()
-      .uri("/courses/$courseId/offerings/$courseOfferingId")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
-      .accept(MediaType.APPLICATION_JSON)
-      .exchange()
-      .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody()
-      .jsonPath("$.id").isEqualTo(courseOfferingId)
-      .jsonPath("$.organisationId").isNotEmpty
-      .jsonPath("$.contactEmail").isNotEmpty
-  }
-
-  @Test
   fun `get a course offering using short url - happy path`() {
     webTestClient
       .get()
@@ -152,26 +136,6 @@ class CoursesIntegrationTest
       .jsonPath("$.id").isEqualTo(courseOfferingId)
       .jsonPath("$.organisationId").isNotEmpty
       .jsonPath("$.contactEmail").isNotEmpty
-  }
-
-  @Test
-  fun `get a course offering - not found`() {
-    val randomUuid = UUID.randomUUID()
-
-    webTestClient
-      .get()
-      .uri("/courses/$randomUuid/offerings/$randomUuid")
-      .accept(MediaType.APPLICATION_JSON)
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
-      .exchange()
-      .expectStatus().isNotFound
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody()
-      .jsonPath("$.status").isEqualTo(404)
-      .jsonPath("$.errorCode").isEmpty
-      .jsonPath("$.userMessage").value(startsWith("Not Found: No CourseOffering found at /courses/"))
-      .jsonPath("$.developerMessage").value(startsWith("No CourseOffering found at /courses/"))
-      .jsonPath("$.moreInfo").isEmpty
   }
 
   @DirtiesContext


### PR DESCRIPTION
## Context

> [see ticket #779 on the Accredited Programmes Trello board.](https://trello.com/c/fYmioX3S/779-remove-old-courses-courseid-offerings-offeringid-endpoint-api)

## Changes in this PR

We previously used a slightly unintuitive way to access course offerings via the API, using an essentially nested endpoint of `/courses/:courseId/offerings/:offeringId`. [We recently implemented an `/offerings/:offeringId endpoint` in #718](https://trello.com/c/yxmFMhl9/718-add-offerings-id-endpoint-api-ui), which the UI is now using. Therefore, we can now safely remove the old endpoint and associated tests, which are essentially duplicates.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod
