### PR TITLE
614 add soft delete for offerings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseService.kt
@@ -18,10 +18,13 @@ class CourseService(
 
   fun getCourseForOfferingId(offeringId: UUID): CourseEntity? = courseRepository.findCourseByOfferingId(offeringId)
 
-  fun offeringsForCourse(courseId: UUID): List<Offering> = courseRepository.offeringsForCourse(courseId)
+  fun offeringsForCourse(courseId: UUID): List<Offering> = courseRepository
+    .offeringsForCourse(courseId)
+    .filterNot(Offering::withdrawn)
 
-  fun courseOffering(courseId: UUID, offeringId: UUID): Offering? = courseRepository.courseOffering(courseId, offeringId)
-  fun courseOffering(offeringId: UUID): Offering? = courseRepository.courseOffering(offeringId)
+  fun courseOffering(offeringId: UUID): Offering? = courseRepository
+    .courseOffering(offeringId)
+    ?.takeIf { !it.withdrawn }
 
   fun replaceAllCourses(courseData: List<NewCourse>) {
     courseRepository.clear()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/Offering.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/Offering.kt
@@ -19,7 +19,9 @@ class Offering(
   val organisationId: String,
   var contactEmail: String,
   var secondaryContactEmail: String? = null,
+  var withdrawn: Boolean = false,
 ) {
+
   @ManyToOne(fetch = FetchType.LAZY, optional = false)
   @JoinColumn(name = "course_id")
   lateinit var course: CourseEntity

--- a/src/main/resources/db/migration/V14__add_withdrawn_to_offering.sql
+++ b/src/main/resources/db/migration/V14__add_withdrawn_to_offering.sql
@@ -1,0 +1,2 @@
+ALTER TABLE offering
+ADD COLUMN withdrawn boolean not null default false;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseServiceTest.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -326,6 +328,38 @@ class CourseServiceTest {
             message = "Missing contactEmail for offering with identifier 'C1' at prisonId 'MDI'",
           ),
         )
+    }
+  }
+
+  @Nested
+  @DisplayName("Handle withdrawn Offerings")
+  inner class WithdrawnOfferingsTests {
+    @Test
+    fun `withdrawn Offerings should not be returned from offeringsForCourse`() {
+      val withdrawnOffering = Offering(withdrawn = true, organisationId = "BWI", contactEmail = "a@b.com")
+      val offering = Offering(organisationId = "MDI", contactEmail = "a@b.com")
+
+      every { repository.offeringsForCourse(any()) } returns listOf(withdrawnOffering, offering)
+
+      service.offeringsForCourse(UUID.randomUUID()).shouldContainExactly(offering)
+    }
+
+    @Test
+    fun `withdrawn Offering should not be returned from courseOffering`() {
+      val withdrawnOffering = Offering(withdrawn = true, organisationId = "BWI", contactEmail = "a@b.com")
+
+      every { repository.courseOffering(any()) } returns withdrawnOffering
+
+      service.courseOffering(UUID.randomUUID()).shouldBeNull()
+    }
+
+    @Test
+    fun `Active Offering be returned from courseOffering`() {
+      val offering = Offering(organisationId = "MDI", contactEmail = "a@b.com")
+
+      every { repository.courseOffering(any()) } returns offering
+
+      service.courseOffering(UUID.randomUUID()) shouldBe offering
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/jparepo/OfferingRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/jparepo/OfferingRepositoryTest.kt
@@ -50,4 +50,37 @@ constructor(
     persistentOffering.shouldNotBeNull()
     persistentOffering shouldBeEqualToComparingFields offering
   }
+
+  @Test
+  fun `find withdrawn offering by id`() {
+    val course1 = CourseEntity(
+      name = "A Course",
+      identifier = "AC",
+      description = "A description",
+      referable = true,
+    ).apply {
+      addOffering(Offering(organisationId = "BWI", contactEmail = "bwi@a.com", withdrawn = true))
+      addOffering(Offering(organisationId = "MDI", contactEmail = "mdi@a.com", withdrawn = true))
+      addOffering(Offering(organisationId = "BXI", contactEmail = "bxi@a.com", withdrawn = true))
+    }
+
+    val course2 = CourseEntity(
+      name = "Another Course",
+      identifier = "ACANO",
+      description = "Another description",
+      referable = false,
+    ).apply {
+      addOffering(Offering(organisationId = "MDI", contactEmail = "mdi@a.com"))
+    }
+
+    val offering = courseRepository.save(course1).offerings.first()
+    courseRepository.save(course2)
+
+    commitAndStartNewTx()
+
+    val persistentOffering = offeringRepository.findById(offering.id!!).getOrNull()
+
+    persistentOffering.shouldNotBeNull()
+    persistentOffering shouldBeEqualToComparingFields offering
+  }
 }


### PR DESCRIPTION
## Context

Trello: [Update Courses, Prerequisites, Offerings instead of replacing](https://trello.com/c/sooyolH2/614-add-scripts-for-updating-course-offering-data-in-the-service)

## Changes in this PR

* Added a `withdrawn` property to `Offering`
* Exclude withdrawn `Offering`s from course offering resources

## Release checklist

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
