### PR TITLE
614 update offerings instead of replacing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/OfferingUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/OfferingUpdate.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain
 
-data class NewOffering(
+data class OfferingUpdate(
   val prisonId: String,
   val identifier: String,
   val contactEmail: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
@@ -37,7 +37,7 @@ class CoursesController(
     ResponseEntity.ok(courseService.replaceAllPrerequisites(prerequisiteRecord.map(PrerequisiteRecord::toDomain)))
 
   override fun coursesOfferingsPut(offeringRecord: List<OfferingRecord>): ResponseEntity<List<LineMessage>> =
-    ResponseEntity.ok(courseService.replaceAllOfferings(offeringRecord.map(OfferingRecord::toDomain)))
+    ResponseEntity.ok(courseService.updateOfferings(offeringRecord.map(OfferingRecord::toDomain)))
 
   override fun coursesCourseIdGet(courseId: UUID): ResponseEntity<Course> =
     courseService.course(courseId)?.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/transformer/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/transformer/Transformers.kt
@@ -10,9 +10,9 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Prere
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.Audience
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.NewCourse
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.NewOffering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.NewPrerequisite
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.Offering
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.OfferingUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.Prerequisite
 
 fun CourseEntity.toApi(): Course = Course(
@@ -51,7 +51,7 @@ fun CourseRecord.toDomain(): NewCourse = NewCourse(
   referable = referable,
 )
 
-fun OfferingRecord.toDomain(): NewOffering = NewOffering(
+fun OfferingRecord.toDomain(): OfferingUpdate = OfferingUpdate(
   prisonId = prisonId.trim(),
   identifier = identifier.trim(),
   contactEmail = contactEmail?.trim(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesControllerTest.kt
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.put
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.OfferingRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.PrerequisiteRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.OfferingUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.transformer.toDomain
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
 import java.util.UUID
@@ -240,7 +241,7 @@ class CoursesControllerTest(
   inner class PutOfferingsTests {
     @Test
     fun `put offerings csv`() {
-      every { coursesService.replaceAllOfferings(any()) } returns emptyList()
+      every { coursesService.updateOfferings(any<List<OfferingUpdate>>()) } returns emptyList()
 
       mockMvc.put("/courses/offerings") {
         contentType = MediaType("text", "csv")
@@ -254,7 +255,7 @@ class CoursesControllerTest(
         }
       }
 
-      verify { coursesService.replaceAllOfferings(CsvTestData.offeringsRecords.map(OfferingRecord::toDomain)) }
+      verify { coursesService.updateOfferings(CsvTestData.offeringsRecords.map(OfferingRecord::toDomain)) }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CsvTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CsvTestData.kt
@@ -78,12 +78,16 @@ object CsvTestData {
   val offeringsCsvText: String by lazy {
     offeringsRecords
       .joinToString(
-        prefix = "course,identifier,organisation,contact email,secondary contact email,prisonId\n",
+        prefix = OFFERINGS_PREFIX,
         separator = "\n",
         transform = { """"${it.course}","${it.identifier}","${it.organisation}","${it.contactEmail}",${asQuotedStringIfNotNull(it.secondaryContactEmail)},${it.prisonId}""" },
         postfix = "\n",
       )
   }
 
+  val emptyOfferingsCsvText: String = OFFERINGS_PREFIX
+
   private fun asQuotedStringIfNotNull(stringOrNull: String?) = stringOrNull?.let { "\"$it\"" } ?: ""
 }
+
+private const val OFFERINGS_PREFIX = "course,identifier,organisation,contact email,secondary contact email,prisonId\n"


### PR DESCRIPTION
## Context
Currently the only way to update Courses, Offerings, Prerequistes etc is using the bulk update mechanism.
This consists of POSTing CSV files to the `PUT /courses`, `PUT /offerings` and `PUT /prerequisites` endpoints.

Before this PR Offerings were updated by:
* Deleting all offerings
* Inserting an Offering for each valid record in the uploaded offerings CSV file.

This becomes a problem when referrals are linked to offerings because replacing an Offering changes the Offering's ID.
The solution is to add a soft delete option to Offerings (done) and then update Offerings in place.
Matches are determined by Course identifier and OrganistionId (PrisonId).

This is what happens when a set of offering records is uploaded:
* The new offerings are grouped by CourseId.
* The current offerings and the new offerings for each course are compared
* Every offering that matches an update is updated in place and its withdrawn flag set false
* Every new offering that has no match is added the course's offerings
* Every  course offering that is absent from the new offerings is withdrawn

Trello: [Update Courses, Prerequisites, Offerings instead of replacing](https://trello.com/c/sooyolH2/614-add-scripts-for-updating-course-offering-data-in-the-service)

## Changes in this PR

* The `CourseService` `replaceAllOfferings` method has been renamed to `updateOfferings`. 
* The data class that represents updates has been renamed from `NewOffering` to `OfferingUpdate`
* The logic in the `CourseService` `updateOfferings` method to perform updates in place as outlined above
* `CourseService` tests updated and extended to assert that the new behaviour is correct

## Release checklist

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
