### PR TITLE
614 add bulk csv download endpoints for round trips

### DIFF
--- a/doc/how-to/replace-all-api-data.md
+++ b/doc/how-to/replace-all-api-data.md
@@ -141,7 +141,7 @@ On a Mac these tools may be installed using Homebrew: https://brew.sh/
 For example, to replace the data served by the 'dev' instance of the API:
 
 ```shell
-script/kubernetes-scripts/upload-csv -ns dev
+script/kubernetes-scripts/upload-csvs -ns dev
 ```
 
 There is a companion script `script/kubernetes-scripts/get-courses` that queries the `GET /courses` end-point and

--- a/script/kubernetes-scripts/download-csvs
+++ b/script/kubernetes-scripts/download-csvs
@@ -28,9 +28,9 @@ confirm() {
 
 confirm
 
-echo Uploading Course.csv
-curl --upload-file Course.csv             --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" ${API_URL}/courses                > courseMessages.json
-echo Uploading Offering.csv
-curl --upload-file Offering.csv           --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" ${API_URL}/courses/offerings      > offeringMessages.json
-echo Uploading CoursePrerequiste.csv
-curl --upload-file CoursePrerequisite.csv --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" ${API_URL}/courses/prerequisites  > prerequisiteMessages.json
+echo Downloading Course.csv from "${NS_KEY}"
+curl --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" ${API_URL}/courses/csv                > Course.csv
+echo Downloading Offering.csv from "${NS_KEY}"
+curl --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" ${API_URL}/courses/offerings/csv      > Offering.csv
+echo Downloading CoursePrerequiste.csv from "${NS_KEY}"
+curl --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" ${API_URL}/courses/prerequisites/csv  > CoursePrerequisite.csv

--- a/script/kubernetes-scripts/upload-csvs
+++ b/script/kubernetes-scripts/upload-csvs
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+declare -A API_URLS
+API_URLS['dev']=https://accredited-programmes-api-dev.hmpps.service.justice.gov.uk
+API_URLS['preprod']=https://accredited-programmes-api-preprod.hmpps.service.justice.gov.uk
+API_URLS['prod']=https://accredited-programmes-api.hmpps.service.justice.gov.uk
+
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
+
+. "$DIR/.namespace"
+TOKEN=$("$DIR/get-token" -ns ${NS_KEY})
+API_URL=${API_URLS[$NS_KEY]}
+
+confirm() {
+  if [[ ${NS_KEY} == "prod" ]]; then
+    local confirm=""
+    echo "WARNING: This is the PRODUCTION namespace"
+    while [[ ${confirm} != "Y" ]] && [[ ${confirm} != "n" ]]; do
+      read -p 'Continue? Y/n: ' -n 1 confirm
+      echo
+    done
+    if [[ ${confirm} != "Y" ]]; then
+      exit
+    fi
+  fi
+}
+
+confirm
+
+echo Uploading Course.csv to "${NS_LEY}"
+curl --upload-file Course.csv             --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" ${API_URL}/courses/csv                > courseMessages.json
+echo Uploading Offering.csv to "${NS_LEY}"
+curl --upload-file Offering.csv           --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" ${API_URL}/courses/offerings/csv      > offeringMessages.json
+echo Uploading CoursePrerequiste.csv to "${NS_LEY}"
+curl --upload-file CoursePrerequisite.csv --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" ${API_URL}/courses/prerequisites/csv  > prerequisiteMessages.json

--- a/script/local-scripts/README.md
+++ b/script/local-scripts/README.md
@@ -9,6 +9,25 @@ The scripts are:
 * put-courses - Expects a CSV file in the spreadsheet Courses format on stdin and invokes the `PUT /courses` end-point with this data. N.B. invoking this end-point deletes all data from the api before inserting the new data.
 * put-offerings - Expects a CSV file in the spreadsheet CourseOfferings format on stdin and invokes the `PUT /courses/offerings` end-point with this data.
 * put-prereq - Expects a CSV file in the spreadsheet Prerequisites format on stdin and invokes the `PUT /courses/preprequisites` end-point with this data.
+* all-courses-csv - Retrieves the current set of courses in CSV format. The response can be fed to `put-courses`. eg `./all-courses-csv | ./put-courses`
+* all-offerings-csv - Retrieves the current set of offerings in CSV format. The response can be fed to `put-offerings`. eg `./all-offerings-csv | ./put-offerings`
+* all-prereq-csv - Retrieves the current set of prerequisites in CSV format. The response can be fed to `put-prereq`. eg `./all-prereq-csv | ./put-prereq`
 
 The final script `get-token` is used by the other scripts. It retrieves a valid token from the hmpps-auth instance 
 running in docker and prints it to stdout.
+
+The `all-courses-csv`, `all-offerings-csv` and `all-prereq-csv` scripts provide a convenient way
+to update course, offering and prerequisite information in the application. To do so
+download the CSV data to files,  edit in a spreadsheet program and ensure the changes are save
+in CSV format. Upload the modified file(s) using the corresponding `put-courses`, `put-offerings` or `put-prereq`
+scripts.  Courses variants and Offerings are soft-deleted when absent from the uploaded CSV.
+Returning a Course variant or Offering to the CSV will restore the soft-deleted course/offering in the application.
+
+Courses are distinguished by the value in the `identifier` column. All other values may be changed
+and will be applied to the course having that identifier.
+
+Offerings are distinguished by course identifier and prisonId.  All other values may be changed and will
+be applied to the offering having that identifier and prisonId.
+
+Prerequisites are hard-deleted.
+This is not a problem because in prerequisites do not have unique UUIDs that must be preserved in the application.

--- a/script/local-scripts/all-courses-csv
+++ b/script/local-scripts/all-courses-csv
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# GET a CSV representation of all courses from http://localhost:8080/courses/csv and output to stdout
+# Requires the hmpps-auth app to be running and accessible to the application. (See docker-compose.yml)
+
+DIR="$(dirname "$(realpath "$0")")"
+TOKEN=$("$DIR"/get-token)
+curl -v --header "Authorization: Bearer $TOKEN" http://localhost:8080/courses/csv

--- a/script/local-scripts/all-offerings-csv
+++ b/script/local-scripts/all-offerings-csv
@@ -4,4 +4,4 @@
 # The data is accepted on stdin
 DIR="$(dirname "$(realpath "$0")")"
 TOKEN=$("$DIR"/get-token)
-curl -v --header "Authorization: Bearer $TOKEN" --header "Accept: text/csv" http://localhost:8080/offerings
+curl -v --header "Authorization: Bearer $TOKEN" --header "Accept: text/csv" http://localhost:8080/offerings/csv

--- a/script/local-scripts/all-offerings-csv
+++ b/script/local-scripts/all-offerings-csv
@@ -4,4 +4,4 @@
 # The data is accepted on stdin
 DIR="$(dirname "$(realpath "$0")")"
 TOKEN=$("$DIR"/get-token)
-curl -v --upload-file - --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" http://localhost:8080/offerings
+curl -v --header "Authorization: Bearer $TOKEN" --header "Accept: text/csv" http://localhost:8080/offerings

--- a/script/local-scripts/all-prereq-csv
+++ b/script/local-scripts/all-prereq-csv
@@ -4,4 +4,4 @@
 # The data is output to stdin
 DIR="$(dirname "$(realpath "$0")")"
 TOKEN=$("$DIR"/get-token)
-curl -v --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" http://localhost:8080/courses/prerequisites
+curl -v --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" http://localhost:8080/courses/prerequisites/csv

--- a/script/local-scripts/all-prereq-csv
+++ b/script/local-scripts/all-prereq-csv
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Download Prerequisite data in CSV format from the GET /courses/prerequisites endpoint.
+# The data is output to stdin
+DIR="$(dirname "$(realpath "$0")")"
+TOKEN=$("$DIR"/get-token)
+curl -v --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" http://localhost:8080/courses/prerequisites

--- a/script/local-scripts/put-courses
+++ b/script/local-scripts/put-courses
@@ -4,4 +4,4 @@
 # The data is accepted on stdin
 DIR="$(dirname "$(realpath "$0")")"
 TOKEN=$("$DIR"/get-token)
-curl -v --upload-file - --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" http://localhost:8080/courses
+curl -v --upload-file - --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" http://localhost:8080/courses/csv

--- a/script/local-scripts/put-offerings
+++ b/script/local-scripts/put-offerings
@@ -4,4 +4,4 @@
 # The data is accepted on stdin
 DIR="$(dirname "$(realpath "$0")")"
 TOKEN=$("$DIR"/get-token)
-curl -v --upload-file - --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" http://localhost:8080/offerings
+curl -v --upload-file - --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" http://localhost:8080/offerings/csv

--- a/script/local-scripts/put-prereq
+++ b/script/local-scripts/put-prereq
@@ -4,4 +4,4 @@
 # The data is accepted on stdin
 DIR="$(dirname "$(realpath "$0")")"
 TOKEN=$("$DIR"/get-token)
-curl -v --upload-file - --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" http://localhost:8080/courses/prerequisites
+curl -v --upload-file - --header "Authorization: Bearer $TOKEN" --header "Content-Type: text/csv" http://localhost:8080/courses/prerequisites/csv

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseRepository.kt
@@ -7,6 +7,7 @@ interface CourseRepository {
   fun course(courseId: UUID): CourseEntity?
   fun findCourseByOfferingId(offeringId: UUID): CourseEntity?
   fun saveCourse(courseEntity: CourseEntity)
+  fun allOfferings(): List<Offering>
   fun offeringsForCourse(courseId: UUID): List<Offering>
   fun courseOffering(courseId: UUID, offeringId: UUID): Offering?
   fun courseOffering(offeringId: UUID): Offering?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseService.kt
@@ -17,6 +17,8 @@ class CourseService(
   fun course(courseId: UUID): CourseEntity? = courseRepository.course(courseId)?.takeIf { !it.withdrawn }
   fun getCourseForOfferingId(offeringId: UUID): CourseEntity? = courseRepository.findCourseByOfferingId(offeringId)
 
+  fun allOfferings(): List<Offering> = courseRepository.allOfferings().filterNot(Offering::withdrawn)
+
   fun offeringsForCourse(courseId: UUID): List<Offering> = courseRepository
     .offeringsForCourse(courseId)
     .filterNot(Offering::withdrawn)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseService.kt
@@ -181,10 +181,6 @@ class CourseService(
         }
       }.filterNotNull()
 
-  private fun clearOfferings(courses: List<CourseEntity>) {
-    courses.forEach { it.clearOfferings() }
-  }
-
   companion object {
     private fun indexToCsvRowNumber(index: Int) = index + 2
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/jparepo/JpaCourseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/jparepo/JpaCourseRepository.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.jparepo
 
-import jakarta.persistence.EntityManager
 import org.hibernate.Hibernate
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -18,7 +17,6 @@ constructor(
   private val courseRepository: CourseEntityRepository,
   private val offeringRepository: OfferingRepository,
   private val audienceRepository: AudienceRepository,
-  private val entityManager: EntityManager,
 ) : CourseRepository {
   override fun allCourses(): List<CourseEntity> = courseRepository
     .findAll()
@@ -41,6 +39,10 @@ constructor(
       Hibernate.initialize(it.audiences)
       Hibernate.initialize(it.prerequisites)
     }
+
+  override fun allOfferings(): List<Offering> = offeringRepository
+    .findAll()
+    .onEach { Hibernate.initialize(it.course) }
 
   override fun offeringsForCourse(courseId: UUID): List<Offering> = courseRepository
     .findById(courseId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.C
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.Offering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.transformer.toApi
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.transformer.toCourseRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.transformer.toDomain
 import java.util.UUID
 
@@ -27,6 +28,13 @@ class CoursesController(
           .allCourses()
           .map(CourseEntity::toApi),
       )
+
+  override fun coursesCsvGet(): ResponseEntity<List<CourseRecord>> =
+    ResponseEntity.ok(
+      courseService
+        .allCourses()
+        .map(CourseEntity::toCourseRecord),
+    )
 
   override fun coursesPut(courseRecord: List<CourseRecord>): ResponseEntity<Unit> {
     courseService.updateCourses(courseRecord.map(CourseRecord::toDomain))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
@@ -35,15 +35,15 @@ class CoursesController(
         .map(CourseEntity::toCourseRecord),
     )
 
-  override fun coursesPut(courseRecord: List<CourseRecord>): ResponseEntity<Unit> {
+  override fun coursesCsvPut(courseRecord: List<CourseRecord>): ResponseEntity<Unit> {
     courseService.updateCourses(courseRecord.map(CourseRecord::toDomain))
     return ResponseEntity.noContent().build()
   }
 
-  override fun coursesPrerequisitesPut(prerequisiteRecord: List<PrerequisiteRecord>): ResponseEntity<List<LineMessage>> =
+  override fun coursesPrerequisitesCsvPut(prerequisiteRecord: List<PrerequisiteRecord>): ResponseEntity<List<LineMessage>> =
     ResponseEntity.ok(courseService.replaceAllPrerequisites(prerequisiteRecord.map(PrerequisiteRecord::toDomain)))
 
-  override fun coursesPrerequisitesGet(): ResponseEntity<List<PrerequisiteRecord>> =
+  override fun coursesPrerequisitesCsvGet(): ResponseEntity<List<PrerequisiteRecord>> =
     ResponseEntity.ok(
       courseService
         .allCourses()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
@@ -7,7 +7,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Cours
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseOffering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.LineMessage
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.OfferingRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.PrerequisiteRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseService
@@ -43,9 +42,6 @@ class CoursesController(
 
   override fun coursesPrerequisitesPut(prerequisiteRecord: List<PrerequisiteRecord>): ResponseEntity<List<LineMessage>> =
     ResponseEntity.ok(courseService.replaceAllPrerequisites(prerequisiteRecord.map(PrerequisiteRecord::toDomain)))
-
-  override fun coursesOfferingsPut(offeringRecord: List<OfferingRecord>): ResponseEntity<List<LineMessage>> =
-    ResponseEntity.ok(courseService.updateOfferings(offeringRecord.map(OfferingRecord::toDomain)))
 
   override fun coursesCourseIdGet(courseId: UUID): ResponseEntity<Course> =
     courseService.course(courseId)?.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesController.kt
@@ -43,6 +43,22 @@ class CoursesController(
   override fun coursesPrerequisitesPut(prerequisiteRecord: List<PrerequisiteRecord>): ResponseEntity<List<LineMessage>> =
     ResponseEntity.ok(courseService.replaceAllPrerequisites(prerequisiteRecord.map(PrerequisiteRecord::toDomain)))
 
+  override fun coursesPrerequisitesGet(): ResponseEntity<List<PrerequisiteRecord>> =
+    ResponseEntity.ok(
+      courseService
+        .allCourses()
+        .flatMap { course ->
+          course.prerequisites.map { prerequisite ->
+            PrerequisiteRecord(
+              name = prerequisite.name,
+              description = prerequisite.description,
+              course = course.name,
+              identifier = course.identifier,
+            )
+          }
+        },
+    )
+
   override fun coursesCourseIdGet(courseId: UUID): ResponseEntity<Course> =
     courseService.course(courseId)?.let {
       ResponseEntity.ok(it.toApi())

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CsvHttpMessageConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CsvHttpMessageConverter.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.restapi
 
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectReader
+import com.fasterxml.jackson.databind.ObjectWriter
 import com.fasterxml.jackson.dataformat.csv.CsvMapper
 import com.fasterxml.jackson.dataformat.csv.CsvParser
 import com.fasterxml.jackson.dataformat.csv.CsvSchema
@@ -13,7 +14,9 @@ import org.springframework.http.MediaType
 import org.springframework.http.converter.AbstractGenericHttpMessageConverter
 import org.springframework.stereotype.Component
 import java.io.InputStreamReader
+import java.io.OutputStreamWriter
 import java.io.Reader
+import java.io.Writer
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.nio.charset.StandardCharsets
@@ -40,7 +43,10 @@ class CsvHttpMessageConverter : AbstractGenericHttpMessageConverter<Iterable<Any
   private fun getCsvReader(type: Type): ObjectReader = csvMapper.reader(getSchema()).forType(getElementType(type))
 
   override fun writeInternal(instance: Iterable<Any>, type: Type?, outputMessage: HttpOutputMessage) {
+    getCsvWriter(type).writeValues(getOutputWriter(outputMessage)).writeAll(instance)
   }
+
+  private fun getCsvWriter(type: Type?): ObjectWriter = csvMapper.writer(csvMapper.schemaFor(getElementType(type!!)).withHeader())
 
   companion object {
     private val supportedSupertype = Iterable::class.java
@@ -58,6 +64,12 @@ class CsvHttpMessageConverter : AbstractGenericHttpMessageConverter<Iterable<Any
       InputStreamReader(
         inputMessage.body,
         inputMessage.headers.contentType?.charset ?: StandardCharsets.UTF_8,
+      )
+
+    private fun getOutputWriter(outputMessage: HttpOutputMessage): Writer =
+      OutputStreamWriter(
+        outputMessage.body,
+        outputMessage.headers.contentType?.charset ?: StandardCharsets.UTF_8,
       )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/OfferingsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/OfferingsController.kt
@@ -27,10 +27,10 @@ class OfferingsController(private val courseService: CourseService) : OfferingsA
       ResponseEntity.ok(it.toApi())
     } ?: throw NotFoundException("No Offering found at /offerings/$offeringId")
 
-  override fun offeringsPut(offeringRecord: List<OfferingRecord>): ResponseEntity<List<LineMessage>> =
+  override fun offeringsCsvPut(offeringRecord: List<OfferingRecord>): ResponseEntity<List<LineMessage>> =
     ResponseEntity.ok(courseService.updateOfferings(offeringRecord.map(OfferingRecord::toDomain)))
 
-  override fun offeringsGet(): ResponseEntity<List<OfferingRecord>> =
+  override fun offeringsCsvGet(): ResponseEntity<List<OfferingRecord>> =
     ResponseEntity.ok(
       courseService
         .allOfferings()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/OfferingsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/OfferingsController.kt
@@ -5,8 +5,13 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.OfferingsApiDelegate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Course
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseOffering
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.LineMessage
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.OfferingRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.Offering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.transformer.toApi
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.transformer.toDomain
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.transformer.toOfferingRecord
 import java.util.UUID
 
 @Service
@@ -21,4 +26,14 @@ class OfferingsController(private val courseService: CourseService) : OfferingsA
     courseService.courseOffering(offeringId)?.let {
       ResponseEntity.ok(it.toApi())
     } ?: throw NotFoundException("No Offering found at /offerings/$offeringId")
+
+  override fun offeringsPut(offeringRecord: List<OfferingRecord>): ResponseEntity<List<LineMessage>> =
+    ResponseEntity.ok(courseService.updateOfferings(offeringRecord.map(OfferingRecord::toDomain)))
+
+  override fun offeringsGet(): ResponseEntity<List<OfferingRecord>> =
+    ResponseEntity.ok(
+      courseService
+        .allOfferings()
+        .map(Offering::toOfferingRecord),
+    )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/transformer/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/transformer/Transformers.kt
@@ -25,6 +25,15 @@ fun CourseEntity.toApi(): Course = Course(
   referable = referable,
 )
 
+fun CourseEntity.toCourseRecord(): CourseRecord = CourseRecord(
+  name = name,
+  description = description ?: "",
+  alternateName = alternateName,
+  referable = referable,
+  identifier = identifier,
+  audience = audiences.joinToString { it.value },
+)
+
 fun Prerequisite.toApi(): CoursePrerequisite = CoursePrerequisite(
   name = name,
   description = description,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/transformer/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/transformer/Transformers.kt
@@ -46,6 +46,14 @@ fun Offering.toApi(): CourseOffering = CourseOffering(
   secondaryContactEmail = secondaryContactEmail,
 )
 
+fun Offering.toOfferingRecord() = OfferingRecord(
+  course = course.name,
+  identifier = course.identifier,
+  prisonId = organisationId,
+  contactEmail = contactEmail,
+  secondaryContactEmail = secondaryContactEmail,
+)
+
 fun Audience.toApi(): CourseAudience = CourseAudience(
   id = id!!,
   value = value,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -19,6 +19,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Course'
+
+  /courses/csv:
     put:
       tags:
         - Courses
@@ -36,8 +38,6 @@ paths:
           description: Successful update
         400:
           description: Bad input
-
-  /courses/csv:
     get:
       tags:
         - Courses
@@ -52,7 +52,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/CourseRecord'
 
-  /courses/prerequisites:
+  /courses/prerequisites/csv:
     get:
       tags:
         - Course Prerequisites
@@ -142,7 +142,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/CourseOffering'
 
-  /offerings:
+  /offerings/csv:
     get:
       tags:
         - Course Offerings

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -119,11 +119,34 @@ paths:
               schema:
                   $ref: '#/components/schemas/Course'
 
-  /courses/offerings:
+  /courses/{courseId}/offerings:
     get:
       tags:
         - Course Offerings
-      summary: Download a CSV format representation of those offerings that are not withdrawn.
+      summary: List all offerings for a course
+      parameters:
+        - name: courseId
+          in: path
+          description: A course identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CourseOffering'
+
+  /offerings:
+    get:
+      tags:
+        - Course Offerings
+      summary: Download all Offerings in CSV format
       responses:
         200:
           description: successful operation
@@ -136,7 +159,7 @@ paths:
     put:
       tags:
         - Course Offerings
-      summary: Upload a CSV format file containing a full set of offerings data for a set of courses.
+      summary: Upload all offerings in CSV format.
       description: "Accepts a CSV format file of data representing the desired state of all offerings data attached to the current set of courses.
       <p>Pre-existing offering data will be removed before the new data is applied.
       <p>The first row of CSV data is treated as a header row.  The column headings in the header row must much the names of the fields in the OfferingRecord schema. Column order is not important."
@@ -163,29 +186,6 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-
-  /courses/{courseId}/offerings:
-    get:
-      tags:
-        - Course Offerings
-      summary: List all offerings for a course
-      parameters:
-        - name: courseId
-          in: path
-          description: A course identifier
-          required: true
-          schema:
-            type: string
-            format: uuid
-      responses:
-        200:
-          description: successful operation
-          content:
-            'application/json':
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CourseOffering'
 
   /offerings/{offeringId}:
     get:
@@ -691,9 +691,10 @@ components:
         course:
           type: string
           example: "Kaizen"
-          description: "The name of the Course to which this Offering applies. The name must match a course name exactly for this Offering to be added to the Course."
+          description: "The name of the Course to which this Offering applies. This value is only present to help with comprehension. It is not used to match offerings with courses"
         identifier:
           type: string
+          description: "The unique identifier of the Course variant to which this Offering applies. The offering is added to the course having this identifier"
           example: "BNM-IPVO"
         organisation:
           type: string

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -12,7 +12,7 @@ paths:
       summary: List all courses
       responses:
         200:
-          description: successful operation
+          description: Return a JSON representation of all courses that are not withdrawn
           content:
             'application/json':
               schema:
@@ -37,7 +37,35 @@ paths:
         400:
           description: Bad input
 
+  /courses/csv:
+    get:
+      tags:
+        - Courses
+      summary: List all courses
+      responses:
+        200:
+          description: Return a CSV format representation of all courses that are not withdrawn. The data is compatible with the PUT /courses endpoint and may be round-tripped
+          content:
+            'text/csv;charset=UTF-8':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/CourseRecord'
+
   /courses/prerequisites:
+    get:
+      tags:
+        - Course Prerequisites
+      summary: Download a CSV format representation of the current set of prerequisites.
+      responses:
+        200:
+          description: The CSV formatted data is compatible the PUT operation and may be round-tripped
+          content:
+            'text/csv;charset=UTF-8':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PrerequisiteRecord'
     put:
       tags:
         - Course Prerequisites
@@ -92,6 +120,19 @@ paths:
                   $ref: '#/components/schemas/Course'
 
   /courses/offerings:
+    get:
+      tags:
+        - Course Offerings
+      summary: Download a CSV format representation of those offerings that are not withdrawn.
+      responses:
+        200:
+          description: successful operation
+          content:
+            'text/csv;charset=UTF-8':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OfferingRecord'
     put:
       tags:
         - Course Offerings

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesControllerTest.kt
@@ -204,7 +204,7 @@ class CoursesControllerTest(
         coursesService.updateCourses(any<List<CourseUpdate>>())
       } just Runs
 
-      mockMvc.put("/courses") {
+      mockMvc.put("/courses/csv") {
         contentType = MediaType("text", "csv")
         header(AUTHORIZATION, jwtAuthHelper.bearerToken())
         content = CsvTestData.coursesCsvText
@@ -224,7 +224,7 @@ class CoursesControllerTest(
     fun `put prerequisites csv`() {
       every { coursesService.replaceAllPrerequisites(any()) } returns emptyList()
 
-      mockMvc.put("/courses/prerequisites") {
+      mockMvc.put("/courses/prerequisites/csv") {
         contentType = MediaType("text", "csv")
         header(AUTHORIZATION, jwtAuthHelper.bearerToken())
         content = CsvTestData.prerequisitesCsvText

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesControllerTest.kt
@@ -17,11 +17,9 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.put
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.OfferingRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.PrerequisiteRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseUpdate
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.OfferingUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.transformer.toDomain
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
 import java.util.UUID
@@ -239,28 +237,6 @@ class CoursesControllerTest(
       }
 
       verify { coursesService.replaceAllPrerequisites(CsvTestData.prerequisiteRecords.map(PrerequisiteRecord::toDomain)) }
-    }
-  }
-
-  @Nested
-  inner class PutOfferingsTests {
-    @Test
-    fun `put offerings csv`() {
-      every { coursesService.updateOfferings(any<List<OfferingUpdate>>()) } returns emptyList()
-
-      mockMvc.put("/courses/offerings") {
-        contentType = MediaType("text", "csv")
-        header(AUTHORIZATION, jwtAuthHelper.bearerToken())
-        content = CsvTestData.offeringsCsvText
-      }.andExpect {
-        status { isOk() }
-        content {
-          contentType(MediaType.APPLICATION_JSON)
-          jsonPath("$.size()") { value(0) }
-        }
-      }
-
-      verify { coursesService.updateOfferings(CsvTestData.offeringsRecords.map(OfferingRecord::toDomain)) }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CoursesIntegrationTest.kt
@@ -270,7 +270,7 @@ class CoursesIntegrationTest
   private fun uploadCourses(csvData: String) {
     webTestClient
       .put()
-      .uri("/courses")
+      .uri("/courses/csv")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .contentType(MEDIA_TYPE_TEXT_CSV)
       .bodyValue(csvData)
@@ -281,7 +281,7 @@ class CoursesIntegrationTest
   private fun uploadOfferings(csvContent: String) {
     webTestClient
       .put()
-      .uri("/offerings")
+      .uri("/offerings/csv")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .contentType(MEDIA_TYPE_TEXT_CSV)
       .bodyValue(csvContent)
@@ -294,7 +294,7 @@ class CoursesIntegrationTest
   private fun uploadPrerequisites(csvContent: String) {
     webTestClient
       .put()
-      .uri("/courses/prerequisites")
+      .uri("/courses/prerequisites/csv")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .contentType(MEDIA_TYPE_TEXT_CSV)
       .bodyValue(csvContent)
@@ -340,7 +340,7 @@ class CoursesIntegrationTest
   private fun allOfferingsCsv(): String =
     webTestClient
       .get()
-      .uri("/offerings")
+      .uri("/offerings/csv")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MEDIA_TYPE_TEXT_CSV)
       .exchange()
@@ -351,7 +351,7 @@ class CoursesIntegrationTest
   private fun allPrerequisitesCsv(): String =
     webTestClient
       .get()
-      .uri("/courses/prerequisites")
+      .uri("/courses/prerequisites/csv")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MEDIA_TYPE_TEXT_CSV)
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CsvHttpMessageConverterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CsvHttpMessageConverterTest.kt
@@ -2,12 +2,16 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.restapi
 
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.MediaType
 import org.springframework.mock.http.MockHttpInputMessage
+import org.springframework.mock.http.MockHttpOutputMessage
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseRecord
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.transformer.toDomain
 import java.nio.charset.StandardCharsets
 
@@ -15,128 +19,186 @@ class CsvHttpMessageConverterTest {
 
   private val converter = CsvHttpMessageConverter()
 
-  @Test
-  fun `can read`() {
-    converter
-      .canRead(
-        listOf(MyBean("A", "B", "C"))::class.java,
-        MediaType("text", "csv", Charsets.UTF_8),
-      )
-      .shouldBeTrue()
+  @Nested
+  inner class ReaderTests {
+    @Test
+    fun `can read`() {
+      converter
+        .canRead(
+          listOf(MyBean("A", "B", "C"))::class.java,
+          MediaType("text", "csv", Charsets.UTF_8),
+        )
+        .shouldBeTrue()
+    }
+
+    @Test
+    fun `read csv to a List of MyBean`() {
+      val body = "name,description,comment\nA,Desc A,It's an A\nB,Desc B,It's a B\n"
+
+      val inputMessage = MockHttpInputMessage(body.byteInputStream(StandardCharsets.UTF_8))
+      inputMessage.headers.contentType = MediaType("text", "csv")
+      val result = converter.read(listOfBeanType, null, inputMessage)
+      val list = result.shouldBeInstanceOf<List<MyBean>>()
+      list shouldContainExactly (
+        listOf(
+          MyBean(name = "A", description = "Desc A", comment = "It's an A"),
+          MyBean(name = "B", description = "Desc B", comment = "It's a B"),
+        )
+        )
+    }
+
+    @Test
+    fun `Tolerant conversion - accept csv with extra columns`() {
+      val body = "name,description,comment,,,\nA,Desc A,It's an A,,,\nB,Desc B,It's a B,,,\n"
+
+      val inputMessage = MockHttpInputMessage(body.byteInputStream(StandardCharsets.UTF_8))
+      inputMessage.headers.contentType = MediaType("text", "csv")
+      val result = converter.read(listOfBeanType, null, inputMessage)
+      val list = result.shouldBeInstanceOf<List<MyBean>>()
+      list shouldContainExactly (
+        listOf(
+          MyBean(name = "A", description = "Desc A", comment = "It's an A"),
+          MyBean(name = "B", description = "Desc B", comment = "It's a B"),
+        )
+        )
+    }
+
+    @Test
+    fun `Tolerant conversion - accept csv with varying extra columns`() {
+      val body = "name,description,comment\nA,Desc A,It's an A,\nB,Desc B,It's a B,,\n"
+
+      val inputMessage = MockHttpInputMessage(body.byteInputStream(StandardCharsets.UTF_8))
+
+      inputMessage.headers.contentType = MediaType("text", "csv")
+      val result = converter.read(listOfBeanType, null, inputMessage)
+      val list = result.shouldBeInstanceOf<List<MyBean>>()
+      list shouldContainExactly (
+        listOf(
+          MyBean(name = "A", description = "Desc A", comment = "It's an A"),
+          MyBean(name = "B", description = "Desc B", comment = "It's a B"),
+        )
+        )
+    }
+
+    @Test
+    fun `Tolerant conversion - accept csv with re-ordered columns`() {
+      val body = ",comment,name,description\n,It's an A,A,Desc A,,\n,It's a B,B,Desc B,,\n"
+
+      val inputMessage = MockHttpInputMessage(body.byteInputStream(StandardCharsets.UTF_8))
+      inputMessage.headers.contentType = MediaType("text", "csv")
+      val result = converter.read(listOfBeanType, null, inputMessage)
+      val list = result.shouldBeInstanceOf<List<MyBean>>()
+      list shouldContainExactly (
+        listOf(
+          MyBean(name = "A", description = "Desc A", comment = "It's an A"),
+          MyBean(name = "B", description = "Desc B", comment = "It's a B"),
+        )
+        )
+    }
+
+    @Test
+    fun `Tolerant conversion - accept csv with unknown property name`() {
+      val body = "unknown1,comment,unknown2,name,description\n,It's an A,,A,Desc A,,\n,It's a B,,B,Desc B,,\n"
+
+      val inputMessage = MockHttpInputMessage(body.byteInputStream(StandardCharsets.UTF_8))
+      val result = converter.read(listOfBeanType, null, inputMessage)
+      val list = result.shouldBeInstanceOf<List<MyBean>>()
+      list shouldContainExactly (
+        listOf(
+          MyBean(name = "A", description = "Desc A", comment = "It's an A"),
+          MyBean(name = "B", description = "Desc B", comment = "It's a B"),
+        )
+        )
+    }
+
+    @Test
+    fun `Tolerant conversion - accept csv with empty columns`() {
+      val body = "name,description,comment,,,\n,Desc A,It's an A,,,\nB,,It's a B,,,\n"
+
+      val inputMessage = MockHttpInputMessage(body.byteInputStream(StandardCharsets.UTF_8))
+      inputMessage.headers.contentType = MediaType("text", "csv")
+      val result = converter.read(listOfBeanType, null, inputMessage)
+      val list = result.shouldBeInstanceOf<List<MyBean>>()
+      list shouldContainExactly (
+        listOf(
+          MyBean(name = "", description = "Desc A", comment = "It's an A"),
+          MyBean(name = "B", description = "", comment = "It's a B"),
+        )
+        )
+    }
+
+    @Test
+    fun `read courses csv to a List of CourseRecord`() {
+      val inputMessage = MockHttpInputMessage(CsvTestData.coursesCsvInputStream())
+      inputMessage.headers.contentType = MediaType("text", "csv")
+      val result = converter.read(listOfCourseRecordType, null, inputMessage)
+      val list = result.shouldBeInstanceOf<List<CourseRecord>>()
+      list.map(CourseRecord::toDomain).shouldContainExactly(CsvTestData.newCourses)
+    }
   }
 
-  @Test
-  fun `read csv to a List of MyBean`() {
-    val body = "name,description,comment\nA,Desc A,It's an A\nB,Desc B,It's a B\n"
+  @Nested
+  inner class WriterTests {
+    @Test
+    fun `can write empty list`() {
+      val outputMessage = MockHttpOutputMessage()
+      converter.write(emptyList<MyBean>(), listOfBeanType, MediaType("text", "csv"), outputMessage)
+      outputMessage.body.toString() shouldBe ""
+    }
 
-    val inputMessage = MockHttpInputMessage(body.byteInputStream(StandardCharsets.UTF_8))
-    inputMessage.headers.contentType = MediaType("text", "csv")
-    val beanList = object : ParameterizedTypeReference<List<MyBean>>() {}
-    val result = converter.read(beanList.type, null, inputMessage)
-    val list = result.shouldBeInstanceOf<List<MyBean>>()
-    list shouldContainExactly (
-      listOf(
-        MyBean(name = "A", description = "Desc A", comment = "It's an A"),
-        MyBean(name = "B", description = "Desc B", comment = "It's a B"),
-      )
-      )
-  }
-
-  @Test
-  fun `Tolerant conversion - accept csv with extra columns`() {
-    val body = "name,description,comment,,,\nA,Desc A,It's an A,,,\nB,Desc B,It's a B,,,\n"
-
-    val inputMessage = MockHttpInputMessage(body.byteInputStream(StandardCharsets.UTF_8))
-    inputMessage.headers.contentType = MediaType("text", "csv")
-    val beanList = object : ParameterizedTypeReference<List<MyBean>>() {}
-    val result = converter.read(beanList.type, null, inputMessage)
-    val list = result.shouldBeInstanceOf<List<MyBean>>()
-    list shouldContainExactly (
-      listOf(
-        MyBean(name = "A", description = "Desc A", comment = "It's an A"),
-        MyBean(name = "B", description = "Desc B", comment = "It's a B"),
-      )
-      )
-  }
-
-  @Test
-  fun `Tolerant conversion - accept csv with varying extra columns`() {
-    val body = "name,description,comment\nA,Desc A,It's an A,\nB,Desc B,It's a B,,\n"
-
-    val inputMessage = MockHttpInputMessage(body.byteInputStream(StandardCharsets.UTF_8))
-    inputMessage.headers.contentType = MediaType("text", "csv")
-    val beanList = object : ParameterizedTypeReference<List<MyBean>>() {}
-    val result = converter.read(beanList.type, null, inputMessage)
-    val list = result.shouldBeInstanceOf<List<MyBean>>()
-    list shouldContainExactly (
-      listOf(
-        MyBean(name = "A", description = "Desc A", comment = "It's an A"),
-        MyBean(name = "B", description = "Desc B", comment = "It's a B"),
-      )
-      )
-  }
-
-  @Test
-  fun `Tolerant conversion - accept csv with re-ordered columns`() {
-    val body = ",comment,name,description\n,It's an A,A,Desc A,,\n,It's a B,B,Desc B,,\n"
-
-    val inputMessage = MockHttpInputMessage(body.byteInputStream(StandardCharsets.UTF_8))
-    inputMessage.headers.contentType = MediaType("text", "csv")
-    val beanList = object : ParameterizedTypeReference<List<MyBean>>() {}
-    val result = converter.read(beanList.type, null, inputMessage)
-    val list = result.shouldBeInstanceOf<List<MyBean>>()
-    list shouldContainExactly (
-      listOf(
-        MyBean(name = "A", description = "Desc A", comment = "It's an A"),
-        MyBean(name = "B", description = "Desc B", comment = "It's a B"),
-      )
-      )
-  }
-
-  @Test
-  fun `Tolerant conversion - accept csv with unknown property name`() {
-    val body = "unknown1,comment,unknown2,name,description\n,It's an A,,A,Desc A,,\n,It's a B,,B,Desc B,,\n"
-
-    val inputMessage = MockHttpInputMessage(body.byteInputStream(StandardCharsets.UTF_8))
-    inputMessage.headers.contentType = MediaType("text", "csv")
-    val beanList = object : ParameterizedTypeReference<List<MyBean>>() {}
-    val result = converter.read(beanList.type, null, inputMessage)
-    val list = result.shouldBeInstanceOf<List<MyBean>>()
-    list shouldContainExactly (
-      listOf(
-        MyBean(name = "A", description = "Desc A", comment = "It's an A"),
-        MyBean(name = "B", description = "Desc B", comment = "It's a B"),
-      )
-      )
-  }
-
-  @Test
-  fun `Tolerant conversion - accept csv with empty columns`() {
-    val body = "name,description,comment,,,\n,Desc A,It's an A,,,\nB,,It's a B,,,\n"
-
-    val inputMessage = MockHttpInputMessage(body.byteInputStream(StandardCharsets.UTF_8))
-    inputMessage.headers.contentType = MediaType("text", "csv")
-    val beanList = object : ParameterizedTypeReference<List<MyBean>>() {}
-    val result = converter.read(beanList.type, null, inputMessage)
-    val list = result.shouldBeInstanceOf<List<MyBean>>()
-    list shouldContainExactly (
-      listOf(
+    @Test
+    fun `can write a list of two beans`() {
+      val outputMessage = MockHttpOutputMessage()
+      val beans = listOf(
         MyBean(name = "", description = "Desc A", comment = "It's an A"),
-        MyBean(name = "B", description = "", comment = "It's a B"),
+        MyBean(name = "B", description = "Desc B"),
       )
-      )
-  }
 
-  @Test
-  fun `read courses csv to a List of CourseRecord`() {
-    val inputMessage = MockHttpInputMessage(CsvTestData.coursesCsvInputStream())
-    inputMessage.headers.contentType = MediaType("text", "csv")
-    val beanList = object : ParameterizedTypeReference<List<CourseRecord>>() {}
-    val result = converter.read(beanList.type, null, inputMessage)
-    val list = result.shouldBeInstanceOf<List<CourseRecord>>()
-    list.map(CourseRecord::toDomain).shouldContainExactly(CsvTestData.newCourses)
+      converter.write(beans, listOfBeanType, MediaType("text", "csv"), outputMessage)
+
+      outputMessage.body.toString() shouldBe
+        """
+        comment,description,name
+        "It's an A","Desc A",
+        ,"Desc B",B
+        
+        """.trimIndent()
+    }
+
+    @Test
+    fun `A CourseRecords round trip should be the identity transformation`() {
+      val outputMessage = MockHttpOutputMessage()
+
+      converter.write(
+        CsvTestData.newCourseUpdates.toCourseRecords(),
+        listOfCourseRecordType,
+        MediaType("text", "csv"),
+        outputMessage,
+      )
+
+      val inputMessage = MockHttpInputMessage(outputMessage.bodyAsBytes)
+      inputMessage.headers.contentType = MediaType("text", "csv")
+
+      val result = converter.read(listOfCourseRecordType, null, inputMessage)
+      val roundTrippedCourseRecords = result.shouldBeInstanceOf<List<CourseRecord>>()
+      roundTrippedCourseRecords.map(CourseRecord::toDomain).shouldContainExactly(CsvTestData.newCourseUpdates)
+    }
   }
 }
+
+private fun List<CourseUpdate>.toCourseRecords() = map {
+  CourseRecord(
+    name = it.name,
+    description = it.description,
+    audience = it.audience,
+    identifier = it.identifier,
+    referable = it.referable,
+    alternateName = it.alternateName,
+  )
+}
+
+private val listOfBeanType = object : ParameterizedTypeReference<List<MyBean>>() {}.type
+private val listOfCourseRecordType = object : ParameterizedTypeReference<List<CourseRecord>>() {}.type
 
 data class MyBean(
   val name: String? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CsvTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CsvTestData.kt
@@ -20,7 +20,7 @@ object CsvTestData {
 
   val newCourseUpdates: List<CourseUpdate> = listOf(
     newCourse(name = "Becoming new me Plus", identifier = "BNM-SO", audience = "sexual offence", alternateName = "BNM+++"),
-    newCourse(name = "Becoming new me Plus", identifier = "BNM-VO", audience = "general violence offence", alternateName = "BNM+-", referable = false),
+    newCourse(name = "Becoming new me Plus", identifier = "BNM-VO", audience = "general violence offence, mystery offence", alternateName = "BNM+-", referable = false),
     newCourse(name = "Building Better Relationships", identifier = "BBR-IPVO", audience = "intimate partner violence offence", alternateName = "BBR-"),
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CsvTestData.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/CsvTestData.kt
@@ -68,7 +68,7 @@ object CsvTestData {
   val prerequisitesCsvText: String =
     prerequisiteRecords
       .joinToString(
-        prefix = "name,description,course,identifier,comments,,,,\n",
+        prefix = PREREQUISITES_PREFIX,
         separator = "\n",
         transform = { """"${it.name}","${it.description}","${it.course}","${it.identifier}","${it.comments}",,,,""" },
         postfix = "\n",
@@ -85,12 +85,14 @@ object CsvTestData {
 
   val emptyCoursesCsvText: String = COURSES_PREFIX
   val emptyOfferingsCsvText: String = OFFERINGS_PREFIX
+  val emmptyPrerequisitesCsvText: String = PREREQUISITES_PREFIX
 
   private fun asQuotedStringIfNotNull(stringOrNull: String?) = stringOrNull?.let { "\"$it\"" } ?: ""
 }
 
 private const val COURSES_PREFIX = "name,identifier,description,audience,referable,alternateName,comments\n"
 private const val OFFERINGS_PREFIX = "course,identifier,organisation,contact email,secondary contact email,prisonId\n"
+private const val PREREQUISITES_PREFIX = "name,description,course,identifier,comments,,,,\n"
 
 private fun List<CourseUpdate>.toCsvText() = joinToString(
   prefix = COURSES_PREFIX,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/OfferingsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/OfferingsControllerTest.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.restapi
 
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
+import io.mockk.verify
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -12,7 +14,11 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.put
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.OfferingRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.OfferingUpdate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.transformer.toDomain
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
 import java.util.UUID
 
@@ -100,6 +106,28 @@ class OfferingsControllerTest(
       accept = MediaType.APPLICATION_JSON
     }.andExpect {
       status { isUnauthorized() }
+    }
+  }
+
+  @Nested
+  inner class PutOfferingsTests {
+    @Test
+    fun `put offerings csv`() {
+      every { coursesService.updateOfferings(any<List<OfferingUpdate>>()) } returns emptyList()
+
+      mockMvc.put("/offerings") {
+        contentType = MediaType("text", "csv")
+        header(AUTHORIZATION, jwtAuthHelper.bearerToken())
+        content = CsvTestData.offeringsCsvText
+      }.andExpect {
+        status { isOk() }
+        content {
+          contentType(MediaType.APPLICATION_JSON)
+          jsonPath("$.size()") { value(0) }
+        }
+      }
+
+      verify { coursesService.updateOfferings(CsvTestData.offeringsRecords.map(OfferingRecord::toDomain)) }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/OfferingsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/restapi/OfferingsControllerTest.kt
@@ -115,7 +115,7 @@ class OfferingsControllerTest(
     fun `put offerings csv`() {
       every { coursesService.updateOfferings(any<List<OfferingUpdate>>()) } returns emptyList()
 
-      mockMvc.put("/offerings") {
+      mockMvc.put("/offerings/csv") {
         contentType = MediaType("text", "csv")
         header(AUTHORIZATION, jwtAuthHelper.bearerToken())
         content = CsvTestData.offeringsCsvText


### PR DESCRIPTION
## Context

Trello: 
* [Add scripts for updating course data](https://trello.com/c/sooyolH2/614-add-scripts-for-updating-course-offering-data-in-the-service)
* [Mark non-referrable courses as non-referrable](https://trello.com/c/DygFUaSW/837-mark-non-referable-courses-as-non-referable-api)

The API contains PUT endpoints for bulk add/update/delete operations on Courses, Offerings, Audience and Prerequisites.
This PR adds corresponding GET endpoints for downloading a CSV format representation of Courses, Offerings, Audience and Prerequisites.  The documents from these endpoints are compatible with their corresponding PUT endpoints so that the data can be round-tripped.  

These bulk downloads may be saved as CSV format files and modified in spreadsheet editing programmes such as Microsoft Excel or Google Sheets.  The modified files can then be uploaded to the API thereby applying the changes to the course related data stored in the API.

## Changes in this PR
* Add an implementation of the `writeInternal` method of the  `CsvHttpMessageConverter` class. Doing so makes it possible for Controller endpoints to serve CSV format documents from `List<T>` where T is any flat DTO-like class. (probably a data class)
* Extend `api.yml` to add the GET endpoints for CSV downloads
* Implement the `GET /courses` endpoint
* Implement the `GET /offerings` endpoint and move the existing `PUT /courses/offerings` endpoint to `PUT /offerings`
* Implement the `GET /courses/prerequisites` endpoint
* Add scripts to the `/script/local-scripts` directory that invoke the CSV download endpoints
* Update the README.md in `/script/local-scripts`

## Release checklist

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
