### PR TITLE
(865) Tweak course participation endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryController.kt
@@ -4,43 +4,35 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.CourseParticipationHistoryApiDelegate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.CourseParticipationsApiDelegate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CreateCourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.restapi.NotFoundException
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistoryService
 import java.util.UUID
 
 @Service
 class CourseParticipationHistoryController(
   @Autowired val service: CourseParticipationHistoryService,
-) : CourseParticipationHistoryApiDelegate {
-  override fun courseParticipationHistoryPost(createCourseParticipation: CreateCourseParticipation): ResponseEntity<CourseParticipation> =
+) : CourseParticipationsApiDelegate {
+  override fun courseParticipationsPost(createCourseParticipation: CreateCourseParticipation): ResponseEntity<CourseParticipation> =
     service.addCourseParticipation(createCourseParticipation.toDomain())
       ?.let {
         ResponseEntity.status(HttpStatus.CREATED).body(it.toApi())
       } ?: throw Exception("Unable to add to course participation history")
 
-  override fun courseParticipationHistoryHistoricCourseParticipationIdGet(historicCourseParticipationId: UUID): ResponseEntity<CourseParticipation> =
-    service.getCourseParticipationHistory(historicCourseParticipationId)
+  override fun courseParticipationsCourseParticipationIdGet(courseParticipationId: UUID): ResponseEntity<CourseParticipation> =
+    service.getCourseParticipationHistory(courseParticipationId)
       ?.let {
         ResponseEntity.ok(it.toApi())
-      } ?: throw NotFoundException("No course participation history found for id $historicCourseParticipationId")
+      } ?: throw NotFoundException("No course participation history found for id $courseParticipationId")
 
-  override fun courseParticipationHistoryHistoricCourseParticipationIdPut(historicCourseParticipationId: UUID, courseParticipationUpdate: CourseParticipationUpdate): ResponseEntity<CourseParticipation> =
-    ResponseEntity.ok(service.updateCourseParticipationHistory(historicCourseParticipationId, courseParticipationUpdate.toDomain()).toApi())
+  override fun courseParticipationsCourseParticipationIdPut(courseParticipationId: UUID, courseParticipationUpdate: CourseParticipationUpdate): ResponseEntity<CourseParticipation> =
+    ResponseEntity.ok(service.updateCourseParticipationHistory(courseParticipationId, courseParticipationUpdate.toDomain()).toApi())
 
-  override fun courseParticipationHistoryGet(prisonNumber: String): ResponseEntity<List<CourseParticipation>> =
-    ResponseEntity.ok(
-      service
-        .findByPrisonNumber(prisonNumber)
-        .map(CourseParticipationHistory::toApi),
-    )
-
-  override fun courseParticipationHistoryHistoricCourseParticipationIdDelete(historicCourseParticipationId: UUID): ResponseEntity<Unit> {
-    service.deleteCourseParticipation(historicCourseParticipationId)
+  override fun courseParticipationsCourseParticipationIdDelete(courseParticipationId: UUID): ResponseEntity<Unit> {
+    service.deleteCourseParticipation(courseParticipationId)
     return ResponseEntity.noContent().build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleController.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.restapi
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.PeopleApiDelegate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipation
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistoryService
+
+@Service
+class PeopleController(
+  @Autowired val service: CourseParticipationHistoryService,
+) : PeopleApiDelegate {
+  override fun peoplePrisonNumberCourseParticipationsGet(prisonNumber: String): ResponseEntity<List<CourseParticipation>> =
+    ResponseEntity.ok(
+      service
+        .findByPrisonNumber(prisonNumber)
+        .map(CourseParticipationHistory::toApi),
+    )
+}

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -365,11 +365,11 @@ paths:
         404:
           description: No offering has the supplied id (Not Found)
 
-  /course-participation-history:
+  /course-participations:
     post:
       tags:
-        - Course participation history
-      summary: Record information about a person's prior participation in a course that was not managed by this service
+        - Course participations
+      summary: Record information about a person's prior participation in a course
       requestBody:
         required: true
         content:
@@ -395,41 +395,14 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
-    get:
-      tags:
-        - Course participation history
-      summary: Retrieve course participation information for a person identified by their prison number
-      parameters:
-        - name: prisonNumber
-          in: query
-          description: The prison number of the person for whom the information should be retrieved
-          example: "A1234AA"
-          required: true
-          schema:
-            type: string
-      responses:
-        200:
-          description: All historic course participation information for the person.  Empty if none found
-          content:
-            'application/json':
-              schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/CourseParticipation"
-        401:
-          description: The client is not authorized to perform this operation
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
 
-  /course-participation-history/{historicCourseParticipationId}:
+  /course-participations/{courseParticipationId}:
     get:
       tags:
-        - Course participation history
+        - Course participations
       summary: Return information about a person's participation in a course. Selected by a unique identifier
       parameters:
-        - name: historicCourseParticipationId
+        - name: courseParticipationId
           in: path
           description: The unique identifier assigned to this record when it was created
           schema:
@@ -452,10 +425,10 @@ paths:
 
     put:
       tags:
-        - Course participation history
+        - Course participations
       summary: Update the information about a person's participation in a course.
       parameters:
-        - name: historicCourseParticipationId
+        - name: courseParticipationId
           in: path
           description: The unique identifier assigned to this record when it was created
           schema:
@@ -490,10 +463,10 @@ paths:
 
     delete:
       tags:
-        - Course participation history
+        - Course participations
       summary: Delete information about a person's participation in a course.
       parameters:
-        - name: historicCourseParticipationId
+        - name: courseParticipationId
           in: path
           description: The unique identifier assigned to this record when it was created
           schema:
@@ -503,6 +476,35 @@ paths:
       responses:
         204:
           description: The information about a person's participation in a course has been deleted
+        401:
+          description: The client is not authorized to perform this operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+  /people/{prisonNumber}/course-participations:
+    get:
+      tags:
+        - Course participations
+      summary: Retrieve course participation information for a person identified by their prison number
+      parameters:
+        - name: prisonNumber
+          in: path
+          description: The prison number of the person for whom the information should be retrieved
+          example: "A1234AA"
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: All historic course participation information for the person.  Empty if none found
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CourseParticipation"
         401:
           description: The client is not authorized to perform this operation
           content:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryControllerTest.kt
@@ -65,7 +65,7 @@ class CourseParticipationHistoryControllerTest(
           otherCourseName = null,
         )
 
-      mockMvc.post("/course-participation-history") {
+      mockMvc.post("/course-participations") {
         accept = MediaType.APPLICATION_JSON
         contentType = MediaType.APPLICATION_JSON
         header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
@@ -106,7 +106,7 @@ class CourseParticipationHistoryControllerTest(
 
     @Test
     fun `add participation history - bad content`() {
-      mockMvc.post("/course-participation-history") {
+      mockMvc.post("/course-participations") {
         accept = MediaType.APPLICATION_JSON
         contentType = MediaType.APPLICATION_JSON
         header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
@@ -129,7 +129,7 @@ class CourseParticipationHistoryControllerTest(
 
     @Test
     fun ` participation history - bad courseId`() {
-      mockMvc.post("/course-participation-history") {
+      mockMvc.post("/course-participations") {
         accept = MediaType.APPLICATION_JSON
         contentType = MediaType.APPLICATION_JSON
         header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
@@ -176,7 +176,7 @@ class CourseParticipationHistoryControllerTest(
         ),
       )
 
-      mockMvc.get("/course-participation-history/{id}", participationHistoryId) {
+      mockMvc.get("/course-participations/{id}", participationHistoryId) {
         accept = MediaType.APPLICATION_JSON
         header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       }.andExpect {
@@ -209,7 +209,7 @@ class CourseParticipationHistoryControllerTest(
 
       every { service.getCourseParticipationHistory(any()) } returns null
 
-      mockMvc.get("/course-participation-history/{id}", participationHistoryId) {
+      mockMvc.get("/course-participations/{id}", participationHistoryId) {
         accept = MediaType.APPLICATION_JSON
         header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       }.andExpect {
@@ -234,7 +234,7 @@ class CourseParticipationHistoryControllerTest(
     fun `get participation history by id - bad uuid`() {
       val historicCourseParticipationId = "bad-id"
 
-      mockMvc.get("/course-participation-history/$historicCourseParticipationId") {
+      mockMvc.get("/course-participations/$historicCourseParticipationId") {
         accept = MediaType.APPLICATION_JSON
         header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       }.andExpect {
@@ -250,73 +250,6 @@ class CourseParticipationHistoryControllerTest(
       }
 
       confirmVerified(service)
-    }
-  }
-
-  @Nested
-  inner class FindByPrisonNumber {
-    @Test
-    fun `find some results`() {
-      val participationHistoryId = UUID.randomUUID()
-      val courseId = UUID.randomUUID()
-
-      every { service.findByPrisonNumber(any()) } returns listOf(
-        CourseParticipationHistory(
-          id = participationHistoryId,
-          otherCourseName = null,
-          courseId = courseId,
-          yearStarted = Year.of(2020),
-          prisonNumber = "A1234BC",
-          source = "source",
-          setting = CourseSetting.COMMUNITY,
-          outcome = CourseOutcome(
-            status = CourseStatus.DESELECTED,
-            detail = "Detail",
-          ),
-        ),
-      )
-
-      mockMvc.get("/course-participation-history?prisonNumber={prisonNumber}", "A1234AA") {
-        accept = MediaType.APPLICATION_JSON
-        header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
-      }.andExpect {
-        status { isOk() }
-        content {
-          json(
-            """
-              [{ 
-                "id": "$participationHistoryId",
-                "otherCourseName": null,
-                "courseId": "$courseId",
-                "yearStarted": 2020,
-                "prisonNumber": "A1234BC",
-                "source": "source",
-                "setting": "community",
-                "outcome": {
-                        "status": "deselected",
-                        "detail": "Detail"
-                        }
-              }]""",
-          )
-        }
-      }
-
-      verify { service.findByPrisonNumber("A1234AA") }
-    }
-
-    @Test
-    fun `missing prison number`() {
-      every { service.findByPrisonNumber(any()) } returns emptyList()
-
-      mockMvc.get("/course-participation-history?prisonNumber=") {
-        accept = MediaType.APPLICATION_JSON
-        header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
-      }.andExpect {
-        status { isOk() }
-        content {
-          json("[]")
-        }
-      }
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryIntegrationTest.kt
@@ -40,7 +40,7 @@ constructor(
 
     val cpa = webTestClient
       .post()
-      .uri("/course-participation-history")
+      .uri("/course-participations")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
@@ -59,7 +59,7 @@ constructor(
 
     val courseParticipation = webTestClient
       .get()
-      .uri("/course-participation-history/{id}", cpa.id)
+      .uri("/course-participations/{id}", cpa.id)
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
@@ -80,7 +80,7 @@ constructor(
 
     val errorResponse = webTestClient
       .post()
-      .uri("/course-participation-history")
+      .uri("/course-participations")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
@@ -110,7 +110,7 @@ constructor(
 
     val cp = webTestClient
       .put()
-      .uri("/course-participation-history/{id}", courseParticipationId)
+      .uri("/course-participations/{id}", courseParticipationId)
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(
@@ -155,7 +155,7 @@ constructor(
 
     val courseIdsForPrisonNumber = webTestClient
       .get()
-      .uri("/course-participation-history?prisonNumber={prisonNumber}", "A1234AA")
+      .uri("/people/{prisonNumber}/course-participations", "A1234AA")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
@@ -172,7 +172,7 @@ constructor(
 
     webTestClient
       .get()
-      .uri("/course-participation-history?prisonNumber={prisonNumber}", "Z0000ZZ")
+      .uri("/people/{prisonNumber}/course-participations", "Z0000ZZ")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
@@ -188,7 +188,7 @@ constructor(
 
     webTestClient
       .delete()
-      .uri("/course-participation-history/{id}", id)
+      .uri("/course-participations/{id}", id)
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
@@ -198,7 +198,7 @@ constructor(
 
     webTestClient
       .delete()
-      .uri("/course-participation-history/{id}", id)
+      .uri("/course-participations/{id}", id)
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
@@ -220,7 +220,7 @@ constructor(
   private fun addCourseParticipationHistory(courseId: UUID, prisonNumber: String): UUID =
     webTestClient
       .post()
-      .uri("/course-participation-history")
+      .uri("/course-participations")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
@@ -237,7 +237,7 @@ constructor(
   private fun getCourseParticipation(id: UUID): CourseParticipation =
     webTestClient
       .get()
-      .uri("/course-participation-history/{id}", id)
+      .uri("/course-participations/{id}", id)
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
@@ -248,7 +248,7 @@ constructor(
   private fun getCourseParticipationStatusCode(id: UUID): HttpStatusCode =
     webTestClient
       .get()
-      .uri("/course-participation-history/{id}", id)
+      .uri("/course-participations/{id}", id)
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
@@ -1,0 +1,111 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.restapi
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import io.mockk.verify
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistoryService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseStatus
+import java.time.Year
+import java.util.*
+
+@WebMvcTest
+@ContextConfiguration(classes = [PeopleControllerTest::class])
+@ComponentScan(
+  basePackages = [
+    "uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.restapi",
+    "uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.config",
+    "uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api",
+  ],
+)
+@Import(JwtAuthHelper::class)
+class PeopleControllerTest(
+  @Autowired
+  val mockMvc: MockMvc,
+  @Autowired
+  val jwtAuthHelper: JwtAuthHelper,
+) {
+  @MockkBean
+  private lateinit var service: CourseParticipationHistoryService
+
+  @Nested
+  inner class FindByPrisonNumber {
+    @Test
+    fun `it returns an array of results when course participations are found`() {
+      val participationHistoryId = UUID.randomUUID()
+      val courseId = UUID.randomUUID()
+
+      every { service.findByPrisonNumber(any()) } returns listOf(
+        CourseParticipationHistory(
+          id = participationHistoryId,
+          otherCourseName = null,
+          courseId = courseId,
+          yearStarted = Year.of(2020),
+          prisonNumber = "A1234BC",
+          source = "source",
+          setting = CourseSetting.COMMUNITY,
+          outcome = CourseOutcome(
+            status = CourseStatus.DESELECTED,
+            detail = "Detail",
+          ),
+        ),
+      )
+
+      mockMvc.get("/people/{prisonNumber}/course-participations", "A1234AA") {
+        accept = MediaType.APPLICATION_JSON
+        header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      }.andExpect {
+        status { isOk() }
+        content {
+          json(
+            """
+            [{
+              "id": "$participationHistoryId",
+              "otherCourseName": null,
+              "courseId": "$courseId",
+              "yearStarted": 2020,
+              "prisonNumber": "A1234BC",
+              "source": "source",
+              "setting": "community",
+              "outcome": {
+                      "status": "deselected",
+                      "detail": "Detail"
+                      }
+            }]""",
+          )
+        }
+      }
+
+      verify { service.findByPrisonNumber("A1234AA") }
+    }
+
+    @Test
+    fun `it returns an empty array when no course participations are found`() {
+      every { service.findByPrisonNumber(any()) } returns emptyList()
+
+      mockMvc.get("/people/{prisonNumber}/course-participations", "A1234AA") {
+        accept = MediaType.APPLICATION_JSON
+        header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      }.andExpect {
+        status { isOk() }
+        content {
+          json("[]")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/n7qRBIHo/865-tweak-course-participation-endpoints
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

This tweaks the endpoints used for fetching course participations slightly to the following for ease of use on the frontend:

```
GET all by person: /people/:prisonNumber/course-participations

POST one /course-participations

GET one /course-participations/:courseParticipationId

PUT one /course-participations/:courseParticipationId

DELETE one /course-participations/:courseParticipationId
```

In doing this, OpenAPI has generated a new controller for us, so the endpoint for fetching `courseParticipations` has now been moved to its own `PeopleController`.

Once this is done, and Nick's refactoring PR is in, I'd like to rename these entities slightly.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
