### PR TITLE
862 add programme history fields - first step

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationHistory.kt
@@ -8,28 +8,31 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.Hibernate
+import org.hibernate.annotations.Formula
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.shareddomain.BusinessException
 import java.time.Year
 import java.util.UUID
 
 @Entity
+@Table(name = "course_participation")
 class CourseParticipationHistory(
   @Id
   @GeneratedValue
-  @Column(name = "course_participation_history_id")
+  @Column(name = "course_participation_id")
   val id: UUID? = null,
 
   val prisonNumber: String,
   var courseId: UUID? = null,
   var otherCourseName: String?,
-  var yearStarted: Year?,
   var source: String?,
 
-  @Enumerated(EnumType.STRING)
-  var setting: CourseSetting?,
+  @Embedded
+  var setting: CourseParticipationSetting,
 
   @Embedded
-  var outcome: CourseOutcome?,
+  val outcome: CourseOutcome,
 ) {
   fun assertOnlyCourseIdOrCourseNamePresent() {
     if (courseId == null && otherCourseName == null) {
@@ -39,7 +42,24 @@ class CourseParticipationHistory(
       throw BusinessException("Expected just one of courseId or otherCourseName but both values are present")
     }
   }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as CourseParticipationHistory
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = 1004284837
 }
+
+@Embeddable
+class CourseParticipationSetting(
+  var location: String?,
+
+  @Enumerated(EnumType.STRING)
+  var type: CourseSetting,
+)
 
 @Embeddable
 class CourseOutcome(
@@ -49,6 +69,12 @@ class CourseOutcome(
 
   @Column(name = "outcome_detail")
   var detail: String?,
+
+  var yearStarted: Year?,
+  var yearCompleted: Year?,
+
+  @Formula("0")
+  private val ignoreMe: Int = 0, // This unused, non-nullable field forces Hibernate to create an @Embedded instance when all fields are null.
 )
 
 enum class CourseSetting { CUSTODY, COMMUNITY }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationHistory.kt
@@ -52,4 +52,4 @@ class CourseOutcome(
 )
 
 enum class CourseSetting { CUSTODY, COMMUNITY }
-enum class CourseStatus { DESELECTED, INCOMPLETE, COMPLETE }
+enum class CourseStatus { INCOMPLETE, COMPLETE }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationHistoryService.kt
@@ -30,20 +30,20 @@ class CourseParticipationHistoryService(
   fun deleteCourseParticipation(historicCourseParticipationId: UUID) {
     repository.deleteById(historicCourseParticipationId)
   }
-
-  companion object {
-    private fun CourseParticipationHistory.applyUpdate(update: CourseParticipationHistoryUpdate): CourseParticipationHistory =
-      this.apply {
-        yearStarted = update.yearStarted
-        courseId = update.courseId
-        otherCourseName = update.otherCourseName
-        setting = update.setting
-        if (outcome == null) {
-          outcome = update.outcome?.let { CourseOutcome(status = it.status, detail = it.detail) }
-        } else {
-          outcome!!.status = update.outcome?.status
-          outcome!!.detail = update.outcome?.detail
-        }
-      }
-  }
 }
+
+private fun CourseParticipationHistory.applyUpdate(update: CourseParticipationHistoryUpdate): CourseParticipationHistory =
+  apply {
+    courseId = update.courseId
+    otherCourseName = update.otherCourseName
+    setting.run {
+      type = update.setting.type
+      location = update.setting.location
+    }
+    outcome.run {
+      status = update.outcome.status
+      detail = update.outcome.detail
+      yearStarted = update.outcome.yearStarted
+      yearCompleted = update.outcome.yearCompleted
+    }
+  }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationHistoryUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationHistoryUpdate.kt
@@ -1,12 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain
 
-import java.time.Year
 import java.util.UUID
 
 data class CourseParticipationHistoryUpdate(
   val courseId: UUID? = null,
   val otherCourseName: String?,
-  val yearStarted: Year?,
-  val setting: CourseSetting?,
-  val outcome: CourseOutcome?,
+  val setting: CourseParticipationSetting,
+  val outcome: CourseOutcome,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryController.kt
@@ -16,22 +16,22 @@ import java.util.UUID
 class CourseParticipationHistoryController(
   @Autowired val service: CourseParticipationHistoryService,
 ) : CourseParticipationsApiDelegate {
-  override fun courseParticipationsPost(createCourseParticipation: CreateCourseParticipation): ResponseEntity<CourseParticipation> =
+  override fun createCourseParticipation(createCourseParticipation: CreateCourseParticipation): ResponseEntity<CourseParticipation> =
     service.addCourseParticipation(createCourseParticipation.toDomain())
       ?.let {
         ResponseEntity.status(HttpStatus.CREATED).body(it.toApi())
       } ?: throw Exception("Unable to add to course participation history")
 
-  override fun courseParticipationsCourseParticipationIdGet(courseParticipationId: UUID): ResponseEntity<CourseParticipation> =
+  override fun getCourseParticipation(courseParticipationId: UUID): ResponseEntity<CourseParticipation> =
     service.getCourseParticipationHistory(courseParticipationId)
       ?.let {
         ResponseEntity.ok(it.toApi())
       } ?: throw NotFoundException("No course participation history found for id $courseParticipationId")
 
-  override fun courseParticipationsCourseParticipationIdPut(courseParticipationId: UUID, courseParticipationUpdate: CourseParticipationUpdate): ResponseEntity<CourseParticipation> =
+  override fun updateCourseParticipation(courseParticipationId: UUID, courseParticipationUpdate: CourseParticipationUpdate): ResponseEntity<CourseParticipation> =
     ResponseEntity.ok(service.updateCourseParticipationHistory(courseParticipationId, courseParticipationUpdate.toDomain()).toApi())
 
-  override fun courseParticipationsCourseParticipationIdDelete(courseParticipationId: UUID): ResponseEntity<Unit> {
+  override fun deleteCourseParticipation(courseParticipationId: UUID): ResponseEntity<Unit> {
     service.deleteCourseParticipation(courseParticipationId)
     return ResponseEntity.noContent().build()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleController.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhi
 class PeopleController(
   @Autowired val service: CourseParticipationHistoryService,
 ) : PeopleApiDelegate {
-  override fun peoplePrisonNumberCourseParticipationsGet(prisonNumber: String): ResponseEntity<List<CourseParticipation>> =
+  override fun getCourseParticipationsForPrisonNumber(prisonNumber: String): ResponseEntity<List<CourseParticipation>> =
     ResponseEntity.ok(
       service
         .findByPrisonNumber(prisonNumber)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
@@ -2,12 +2,14 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationh
 
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationOutcome
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSetting
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSettingType
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationUpdate
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CreateCourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistoryUpdate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseStatus
 import java.time.Year
 
@@ -19,38 +21,40 @@ fun CreateCourseParticipation.toDomain() =
     source = source,
     setting = setting?.toDomain(),
     outcome = outcome?.toDomain(),
-    yearStarted = yearStarted?.let(Year::of),
+    yearStarted = outcome?.yearStarted?.let(Year::of),
   )
 
 fun CourseParticipationUpdate.toDomain() = CourseParticipationHistoryUpdate(
   courseId = courseId,
-  yearStarted = yearStarted?.let(Year::of),
+  yearStarted = outcome?.yearStarted?.let(Year::of),
   setting = setting?.toDomain(),
   otherCourseName = otherCourseName,
   outcome = outcome?.toDomain(),
 )
 
-fun CourseSetting.toDomain() = when (this) {
-  CourseSetting.community -> uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting.COMMUNITY
-  CourseSetting.custody -> uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting.CUSTODY
+fun CourseParticipationSettingType.toDomain() = when (this) {
+  CourseParticipationSettingType.community -> CourseSetting.COMMUNITY
+  CourseParticipationSettingType.custody -> CourseSetting.CUSTODY
 }
 
-fun uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting.toApi() = when (this) {
-  uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting.CUSTODY -> CourseSetting.custody
-  uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting.COMMUNITY -> CourseSetting.community
-}
+fun CourseParticipationSetting.toDomain() = this.type?.toDomain()
+
+fun CourseSetting.toApi() = CourseParticipationSetting(
+  type = when (this) {
+    CourseSetting.CUSTODY -> CourseParticipationSettingType.custody
+    CourseSetting.COMMUNITY -> CourseParticipationSettingType.community
+  },
+)
 
 fun CourseParticipationOutcome.toDomain() = CourseOutcome(status = status?.toDomain(), detail = detail)
 
 fun CourseParticipationOutcome.Status.toDomain() = when (this) {
   CourseParticipationOutcome.Status.complete -> CourseStatus.COMPLETE
-  CourseParticipationOutcome.Status.deselected -> CourseStatus.DESELECTED
   CourseParticipationOutcome.Status.incomplete -> CourseStatus.INCOMPLETE
 }
 
 fun CourseStatus.toApi() = when (this) {
   CourseStatus.INCOMPLETE -> CourseParticipationOutcome.Status.incomplete
-  CourseStatus.DESELECTED -> CourseParticipationOutcome.Status.deselected
   CourseStatus.COMPLETE -> CourseParticipationOutcome.Status.complete
 }
 
@@ -60,12 +64,12 @@ fun CourseParticipationHistory.toApi() = CourseParticipation(
   setting = setting?.toApi(),
   courseId = courseId,
   otherCourseName = otherCourseName,
-  yearStarted = yearStarted?.value,
   source = source,
   outcome = outcome?.let {
     CourseParticipationOutcome(
       status = it.status?.toApi(),
       detail = it.detail,
+      yearStarted = yearStarted?.value,
     )
   },
 )

--- a/src/main/resources/db/migration/V17__course_participation_history_extension_and_rename.sql
+++ b/src/main/resources/db/migration/V17__course_participation_history_extension_and_rename.sql
@@ -1,0 +1,33 @@
+ALTER TABLE course_participation_history
+    RENAME TO course_participation;
+
+ALTER TABLE course_participation
+    RENAME COLUMN course_participation_history_id to course_participation_id;
+
+ALTER TABLE course_participation
+    ADD COLUMN year_completed integer;
+
+ALTER TABLE course_participation
+    RENAME COLUMN setting TO type;
+
+ALTER TABLE course_participation
+    ADD COLUMN location text;
+
+ALTER TABLE course_participation
+    ADD COLUMN created_by_username text NOT NULL default current_user;
+
+ALTER TABLE course_participation
+    ALTER COLUMN created_by_username SET NOT NULL;
+
+ALTER TABLE course_participation
+    ADD COLUMN created_date_time TIMESTAMP NOT NULL default NOW();
+
+ALTER TABLE course_participation
+    ALTER COLUMN created_date_time SET NOT NULL;
+
+ALTER TABLE course_participation
+    ADD COLUMN last_modified_by_username text;
+
+ALTER TABLE course_participation
+    ADD COLUMN last_modified_date_time TIMESTAMP;
+

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -411,6 +411,7 @@ paths:
       tags:
         - Course participations
       summary: Record information about a person's prior participation in a course.
+      operationId: createCourseParticipation
       requestBody:
         required: true
         content:
@@ -442,6 +443,7 @@ paths:
       tags:
         - Course participations
       summary: Return information about a person's participation in a course. Selected by a unique identifier.
+      operationId: getCourseParticipation
       parameters:
         - name: courseParticipationId
           in: path
@@ -468,6 +470,7 @@ paths:
       tags:
         - Course participations
       summary: Update the information about a person's participation in a course.
+      operationId: updateCourseParticipation
       parameters:
         - name: courseParticipationId
           in: path
@@ -506,6 +509,7 @@ paths:
       tags:
         - Course participations
       summary: Delete information about a person's participation in a course.
+      operationId: deleteCourseParticipation
       parameters:
         - name: courseParticipationId
           in: path
@@ -529,6 +533,7 @@ paths:
       tags:
         - Course participations
       summary: Retrieve course participation information for a person identified by their prison number.
+      operationId: getCourseParticipationsForPrisonNumber
       parameters:
         - name: prisonNumber
           in: path
@@ -785,65 +790,6 @@ components:
         - prisonNumber
         - referrerId
 
-    CourseParticipation:
-      type: object
-      properties:
-        id:
-          description: A unique identifier for this record of participation in a course
-          type: string
-          format: uuid
-        prisonNumber:
-          description: The prison number of the course participant
-          example: "A1234AA"
-          type: string
-        courseId:
-          description: "The identifier of a course currently or previously managed by this service.  
-                        Must be the unique identifier of a course. If the participant's course is not known to this service
-                        or cannot be identified then this field will be null while the otherCourseName
-                        property will be populated."
-          type: string
-          format: uuid
-        otherCourseName:
-          description: "The name of the course taken by the participant.  Only used if this course is not managed
-                        by this service or cannot be identified. See courseId."
-          type: string
-        setting:
-          $ref: '#/components/schemas/CourseParticipationSetting'
-        outcome:
-          $ref: '#/components/schemas/CourseParticipationOutcome'
-        source:
-          type: string
-      required:
-        - id
-        - prisonNumber
-
-    CreateCourseParticipation:
-      type: object
-      properties:
-        prisonNumber:
-          description: The prison number of the course participant
-          example: "A1234AA"
-          type: string
-        courseId:
-          description: "The identifier of a course currently or previously managed by this service.  
-                        Must be the unique identifier of a course. If the participant's course is not known to this service
-                        or cannot be identified then this field should not be supplied. Instead, add an arbitrary name 
-                        for the course in otherCourseName."
-          type: string
-          format: uuid
-        otherCourseName:
-          description: "The name of the course taken by the participant.  It should only be used when this course is not managed
-                        by this service or cannot be identified. See courseId."
-          type: string
-        setting:
-          $ref: '#/components/schemas/CourseParticipationSetting'
-        outcome:
-          $ref: '#/components/schemas/CourseParticipationOutcome'
-        source:
-          type: string
-      required:
-        - prisonNumber
-
     CourseParticipationUpdate:
       type: object
       properties:
@@ -864,6 +810,30 @@ components:
           $ref: '#/components/schemas/CourseParticipationOutcome'
         source:
           type: string
+
+    CreateCourseParticipation:
+      allOf:
+        - $ref: "#/components/schemas/CourseParticipationUpdate"
+        - type: object
+          properties:
+            prisonNumber:
+              description: The prison number of the course participant.
+              example: "A1234AA"
+              type: string
+          required:
+            - prisonNumber
+
+    CourseParticipation:
+      allOf:
+        - $ref: "#/components/schemas/CreateCourseParticipation"
+        - type: object
+          properties:
+            id:
+              description: A unique identifier for this record of participation in a course.
+              type: string
+              format: uuid
+          required:
+            - id
 
     CourseParticipationSettingType:
       description: Either Custody or Community.

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -792,6 +792,9 @@ components:
           $ref: '#/components/schemas/CourseParticipationOutcome'
         source:
           type: string
+      required:
+        - setting
+        - outcome
 
     CreateCourseParticipation:
       allOf:
@@ -832,6 +835,8 @@ components:
           type: string
         type:
           $ref: '#/components/schemas/CourseParticipationSettingType'
+      required:
+        - type
 
     CourseParticipationOutcome:
       description: The outcome of participating in a course.

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -772,24 +772,6 @@ components:
       required:
         - status
 
-    StartReferral:
-      type: object
-      properties:
-        offeringId:
-          description: The id (UUID) of an active offering
-          type: string
-          format: uuid
-        prisonNumber:
-          description: The prison number of the person who is being referred
-          example: "A1234AA"
-          type: string
-        referrerId:
-          type: string
-      required:
-        - offeringId
-        - prisonNumber
-        - referrerId
-
     CourseParticipationUpdate:
       type: object
       properties:
@@ -867,25 +849,11 @@ components:
         yearCompleted:
           type: integer
 
-    ReferralStarted:
+    StartReferral:
       type: object
       properties:
-        referralId:
-          description: The unique id (UUID) of the new referral.
-          type: string
-          format: uuid
-      required:
-        - referralId
-
-    Referral:
-      type: object
-      properties:
-        id:
-          description: The unique id (UUID) of this referral.
-          type: string
-          format: uuid
         offeringId:
-          description: The id (UUID) of an active offering.
+          description: The id (UUID) of an active offering
           type: string
           format: uuid
         prisonNumber:
@@ -895,20 +863,10 @@ components:
         referrerId:
           description: A permanent identifier for the person creating the referral. StaffId for prison staff.
           type: string
-        reason:
-          type: string
-        oasysConfirmed:
-          type: boolean
-          default: false
-        status:
-          $ref: "#/components/schemas/ReferralStatus"
       required:
-        - id
         - offeringId
         - prisonNumber
         - referrerId
-        - oasysConfirmed
-        - status
 
     ReferralUpdate:
       type: object
@@ -920,6 +878,36 @@ components:
           default: false
       required:
         - oasysConfirmed
+
+    Referral:
+      allOf:
+        - $ref: "#/components/schemas/StartReferral"
+        - $ref: "#/components/schemas/ReferralUpdate"
+        - type: object
+          properties:
+            id:
+              description: The unique id (UUID) of this referral.
+              type: string
+              format: uuid
+            status:
+              $ref: "#/components/schemas/ReferralStatus"
+          required:
+            - id
+            - offeringId
+            - prisonNumber
+            - referrerId
+            - oasysConfirmed
+            - status
+
+    ReferralStarted:
+      type: object
+      properties:
+        referralId:
+          description: The unique id (UUID) of the new referral.
+          type: string
+          format: uuid
+      required:
+        - referralId
 
     StatusUpdate:
       type: object

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -12,7 +12,7 @@ paths:
       summary: List all courses
       responses:
         200:
-          description: Return a JSON representation of all courses that are not withdrawn
+          description: Return a JSON representation of all courses that are not withdrawn.
           content:
             'application/json':
               schema:
@@ -44,7 +44,7 @@ paths:
       summary: List all courses
       responses:
         200:
-          description: Return a CSV format representation of all courses that are not withdrawn. The data is compatible with the PUT /courses endpoint and may be round-tripped
+          description: Return a CSV format representation of all courses that are not withdrawn. The data is compatible with the PUT /courses endpoint and may be round-tripped.
           content:
             'text/csv;charset=UTF-8':
               schema:
@@ -59,7 +59,7 @@ paths:
       summary: Download a CSV format representation of the current set of prerequisites.
       responses:
         200:
-          description: The CSV formatted data is compatible the PUT operation and may be round-tripped
+          description: The CSV formatted data is compatible with the PUT operation and may be round-tripped.
           content:
             'text/csv;charset=UTF-8':
               schema:
@@ -210,11 +210,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/CourseOffering'
         401:
-          description: Unauthorized. The request was unauthorized
+          description: Unauthorised. The request was unauthorised.
         403:
-          description: Forbidden.  The client is not authorised to access this offering
+          description: Forbidden.  The client is not authorised to access this offering.
         404:
-          description: invalid course offering id
+          description: Invalid course offering id
           content:
             'application/json':
               schema:
@@ -245,7 +245,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         401:
-          description: Unauthorized. The request was unauthorized
+          description: Unauthorised. The request was unauthorised.
 
     get:
       summary: Retrieve some referrals
@@ -254,27 +254,27 @@ paths:
       parameters:
         - name: status
           in: query
-          description: If present only return referrals in the given state
+          description: If present, only return referrals in the given state
           required: false
           schema:
             $ref: "#/components/schemas/ReferralStatus"
         - name: offeringId
           in: query
-          description: The id (UUID) of an active offering. If present only return referrals for that offering
+          description: The id (UUID) of an active offering. If present, only return referrals for that offering.
           required: false
           schema:
             type: string
             format: uuid
         - name: prisonNumber
           in: query
-          description: The prison number of the person who is being referred. If present only return referrals for the person.
+          description: The prison number of the person who is being referred. If present, only return referrals for the person.
           example: "A1234AA"
           required: false
           schema:
             type: string
         - name: referrerId
           in: query
-          description: A permanent identifier for the person creating the referral. StaffId for prison staff. If present only return referrals for that referrer
+          description: A permanent identifier for the person creating the referral. StaffId for prison staff. If present, only return referrals for that referrer.
           required: false
           schema:
             type: string
@@ -289,9 +289,9 @@ paths:
                   items:
                     $ref: '#/components/schemas/Referral'
         401:
-          description: The request was unauthorized
+          description: The request was unauthorised
         403:
-          description: Forbidden.  The client is not authorised to access referrals
+          description: Forbidden.  The client is not authorised to access referrals.
 
   /referrals/{id}:
     get:
@@ -314,9 +314,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/Referral'
         401:
-          description: The request was unauthorized
+          description: The request was unauthorised
         403:
-          description: Forbidden.  The client is not authorised to access this referral
+          description: Forbidden.  The client is not authorised to access this referral.
         404:
          description: The referral does not exist
 
@@ -342,9 +342,9 @@ paths:
         204:
           description: The referral was updated
         401:
-          description: The request was unauthorized
+          description: The request was unauthorised
         403:
-          description: Forbidden.  The client is not authorised to access this referral
+          description: Forbidden.  The client is not authorised to access this referral.
         404:
           description: The referral does not exist
 
@@ -369,48 +369,48 @@ paths:
               $ref: '#/components/schemas/StatusUpdate'
       responses:
         204:
-          description: The referral now has the requested status
+          description: The referral now has the requested status.
         401:
-          description: The request was unauthorized
+          description: The request was unauthorised.
         403:
-          description: Forbidden.  The client is not authorised to access this referral
+          description: Forbidden.  The client is not authorised to access this referral.
         404:
-          description: The referral does not exist
+          description: The referral does not exist.
         409:
-          description: The referral may not change its status to the supplied value
+          description: The referral may not change its status to the supplied value.
 
   /offerings/{id}/course:
     get:
       tags:
         - Courses
-      summary: Retrieve the course that owns an offering
+      summary: Retrieve the course that owns an offering.
       parameters:
         - name: id
           in: path
-          description: The id (UUID) of an offering
+          description: The id (UUID) of an offering.
           required: true
           schema:
             type: string
             format: uuid
       responses:
         200:
-          description: Information about the Course that owns the offering
+          description: Information about the Course that owns the offering.
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Course'
         401:
-          description: The request was unauthorized
+          description: The request was unauthorised
         403:
-          description: Forbidden.  The client is not authorised to access this offering
+          description: Forbidden.  The client is not authorised to access this offering.
         404:
-          description: No offering has the supplied id (Not Found)
+          description: No offering has the supplied id (Not Found).
 
   /course-participations:
     post:
       tags:
         - Course participations
-      summary: Record information about a person's prior participation in a course
+      summary: Record information about a person's prior participation in a course.
       requestBody:
         required: true
         content:
@@ -419,7 +419,7 @@ paths:
               $ref: '#/components/schemas/CreateCourseParticipation'
       responses:
         201:
-          description: The course participation information has been added
+          description: The course participation information has been added.
           content:
             'application/json':
               schema:
@@ -431,7 +431,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         401:
-          description: The client is not authorized to perform this operation
+          description: The client is not authorized to perform this operation.
           content:
             'application/json':
               schema:
@@ -441,11 +441,11 @@ paths:
     get:
       tags:
         - Course participations
-      summary: Return information about a person's participation in a course. Selected by a unique identifier
+      summary: Return information about a person's participation in a course. Selected by a unique identifier.
       parameters:
         - name: courseParticipationId
           in: path
-          description: The unique identifier assigned to this record when it was created
+          description: The unique identifier assigned to this record when it was created.
           schema:
             type: string
             format: uuid
@@ -458,7 +458,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/CourseParticipation"
         401:
-          description: The client is not authorized to perform this operation
+          description: The client is not authorised to perform this operation.
           content:
             'application/json':
               schema:
@@ -471,7 +471,7 @@ paths:
       parameters:
         - name: courseParticipationId
           in: path
-          description: The unique identifier assigned to this record when it was created
+          description: The unique identifier assigned to this record when it was created.
           schema:
             type: string
             format: uuid
@@ -484,19 +484,19 @@ paths:
         required: true
       responses:
         200:
-          description: The information about a person's participation in a course has been updated
+          description: The information about a person's participation in a course has been updated.
           content:
             'application/json':
               schema:
                 $ref: "#/components/schemas/CourseParticipation"
         401:
-          description: The client is not authorized to perform this operation
+          description: The client is not authorized to perform this operation.
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         404:
-          description: There is no information for the id so it cannot be updated.
+          description: There is no information for the id, so it cannot be updated.
           content:
             'application/json':
               schema:
@@ -509,16 +509,16 @@ paths:
       parameters:
         - name: courseParticipationId
           in: path
-          description: The unique identifier assigned to this record when it was created
+          description: The unique identifier assigned to this record when it was created.
           schema:
             type: string
             format: uuid
           required: true
       responses:
         204:
-          description: The information about a person's participation in a course has been deleted
+          description: The information about a person's participation in a course has been deleted.
         401:
-          description: The client is not authorized to perform this operation
+          description: The client is not authorized to perform this operation.
           content:
             'application/json':
               schema:
@@ -528,18 +528,18 @@ paths:
     get:
       tags:
         - Course participations
-      summary: Retrieve course participation information for a person identified by their prison number
+      summary: Retrieve course participation information for a person identified by their prison number.
       parameters:
         - name: prisonNumber
           in: path
-          description: The prison number of the person for whom the information should be retrieved
+          description: The prison number of the person for whom the information should be retrieved.
           example: "A1234AA"
           required: true
           schema:
             type: string
       responses:
         200:
-          description: All historic course participation information for the person.  Empty if none found
+          description: All historic course participation information for the person.  Empty if none found.
           content:
             'application/json':
               schema:
@@ -547,7 +547,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/CourseParticipation"
         401:
-          description: The client is not authorized to perform this operation
+          description: The client is not authorised to perform this operation.
           content:
             'application/json':
               schema:
@@ -639,11 +639,11 @@ components:
         name:
           type: string
           example: "age"
-          description: "The name of this Course Prerequisite"
+          description: "The name of this Course Prerequisite."
         description:
           type: string
           example: "18+"
-          description: "The value of this Course Prerequisite"
+          description: "The value of this Course Prerequisite."
         course:
           type: string
           example: "Kaizen"
@@ -667,7 +667,7 @@ components:
         organisationId:
           type: string
           example: "MDI"
-          description: "The unique identifier associated with the location hosting the offering. For prisons this is the PrisonId which is usually three capital letters."
+          description: "The unique identifier associated with the location hosting the offering. For prisons, this is the PrisonId, which is usually three capital letters."
         contactEmail:
           type: string
           format: email
@@ -677,7 +677,7 @@ components:
           type: string
           format: email
           example: "ap-admin-2@digital.justice.gov.uk"
-          description: "An optional secondary email address of a contact for this offering"
+          description: "An optional secondary email address of a contact for this offering."
 
       required:
         - id
@@ -691,10 +691,10 @@ components:
         course:
           type: string
           example: "Kaizen"
-          description: "The name of the Course to which this Offering applies. This value is only present to help with comprehension. It is not used to match offerings with courses"
+          description: "The name of the Course to which this Offering applies. This value is only present to help with comprehension. It is not used to match offerings with courses."
         identifier:
           type: string
-          description: "The unique identifier of the Course variant to which this Offering applies. The offering is added to the course having this identifier"
+          description: "The unique identifier of the Course variant to which this Offering applies. The offering is added to the course having this identifier."
           example: "BNM-IPVO"
         organisation:
           type: string
@@ -702,16 +702,16 @@ components:
           type: string
           format: email
           example: "ap-admin@digital.justice.gov.uk"
-          description: "The email address of the contact for this offering"
+          description: "The email address of the contact for this offering."
         "secondary contact email":
           type: string
           format: email
           example: "ap-admin2@digital.justice.gov.uk"
-          description: "An optional secondary email address of a contact for this offering"
+          description: "An optional secondary email address of a contact for this offering."
         prisonId:
           type: string
           example: "MDI"
-          description: "The prison id for the prison associated with this Offering. This is usually three capital letters"
+          description: "The prison id for the prison associated with this Offering. This is usually three capital letters."
       required:
         - course
         - prisonId
@@ -798,21 +798,17 @@ components:
           type: string
         courseId:
           description: "The identifier of a course currently or previously managed by this service.  
-                        Must be the unique id of a course. If the participant's course is not known to this service
+                        Must be the unique identifier of a course. If the participant's course is not known to this service
                         or cannot be identified then this field will be null while the otherCourseName
                         property will be populated."
           type: string
           format: uuid
         otherCourseName:
-          description: "The name of the course taken by the participant.  Only  used if this course is not managed
-                        by this service or cannot be identified. See courseId"
+          description: "The name of the course taken by the participant.  Only used if this course is not managed
+                        by this service or cannot be identified. See courseId."
           type: string
-        yearStarted:
-          description: The year in which the participant commenced the course
-          example: 2021
-          type: integer
         setting:
-          $ref: '#/components/schemas/CourseSetting'
+          $ref: '#/components/schemas/CourseParticipationSetting'
         outcome:
           $ref: '#/components/schemas/CourseParticipationOutcome'
         source:
@@ -830,21 +826,17 @@ components:
           type: string
         courseId:
           description: "The identifier of a course currently or previously managed by this service.  
-                        Must be the unique id of a course. If the participant's course is not known to this service
-                        or cannot be identified then this field should not be supplied. Instead, the otherCourseName
-                        property should be populated."
+                        Must be the unique identifier of a course. If the participant's course is not known to this service
+                        or cannot be identified then this field should not be supplied. Instead, add an arbitrary name 
+                        for the course in otherCourseName."
           type: string
           format: uuid
         otherCourseName:
-          description: "The name of the course taken by the participant.  Should only be used if this course is not managed
-                        by this service or cannot be identified. See courseId"
+          description: "The name of the course taken by the participant.  It should only be used when this course is not managed
+                        by this service or cannot be identified. See courseId."
           type: string
-        yearStarted:
-          description: The year in which the participant commenced the course
-          example: 2021
-          type: integer
         setting:
-          $ref: '#/components/schemas/CourseSetting'
+          $ref: '#/components/schemas/CourseParticipationSetting'
         outcome:
           $ref: '#/components/schemas/CourseParticipationOutcome'
         source:
@@ -857,45 +849,53 @@ components:
       properties:
         courseId:
           description: "The identifier of a course currently or previously managed by this service.  
-                        Must be the unique id of a course. If the participant's course is not known to this service
-                        or cannot be identified then this field should not be supplied. Instead, the otherCourseName
-                        property should be populated."
+                        Must be the unique identifier of a course. If the participant's course is not known to this service
+                        or cannot be identified, then this field should not be supplied. Instead, add an arbitrary name 
+                        for the course in otherCourseName."
           type: string
           format: uuid
         otherCourseName:
-          description: "The name of the course taken by the participant.  Should only be used if this course is not managed
-                        by this service or cannot be identified. See courseId"
+          description: "The name of the course taken by the participant.  It should only be used when this course is not managed
+                        by this service or cannot be identified. See courseId."
           type: string
-        yearStarted:
-          description: The year in which the participant commenced the course
-          example: 2021
-          type: integer
         setting:
-          $ref: '#/components/schemas/CourseSetting'
+          $ref: '#/components/schemas/CourseParticipationSetting'
         outcome:
           $ref: '#/components/schemas/CourseParticipationOutcome'
         source:
           type: string
 
-    CourseSetting:
-      description: Either Custody or Community
+    CourseParticipationSettingType:
+      description: Either Custody or Community.
       type: string
       enum:
         - custody
         - community
 
+    CourseParticipationSetting:
+      description: Information about where the course was held.
+      type: object
+      properties:
+        location:
+          type: string
+        type:
+          $ref: '#/components/schemas/CourseParticipationSettingType'
+
     CourseParticipationOutcome:
-      description: The outcome of participating in a course
+      description: The outcome of participating in a course.
       type: object
       properties:
         status:
           type: string
           enum:
-            - deselected
             - incomplete
             - complete
         detail:
           type: string
+        yearStarted:
+          type: integer
+        yearCompleted:
+          type: integer
 
     ReferralStarted:
       type: object
@@ -915,15 +915,15 @@ components:
           type: string
           format: uuid
         offeringId:
-          description: The id (UUID) of an active offering
+          description: The id (UUID) of an active offering.
           type: string
           format: uuid
         prisonNumber:
-          description: The prison number of the person who is being referred
+          description: The prison number of the person who is being referred.
           example: "A1234AA"
           type: string
         referrerId:
-          description: A permanent identifier for the person creating the referral. StaffId for prison staff
+          description: A permanent identifier for the person creating the referral. StaffId for prison staff.
           type: string
         reason:
           type: string

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/RepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/RepositoryTest.kt
@@ -31,7 +31,7 @@ abstract class RepositoryTest(
   fun truncateTables() {
     JdbcTestUtils.deleteFromTables(
       jdbcTemplate,
-      "course_participation_history",
+      "course_participation",
       "referral",
       "prerequisite",
       "offering",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/CourseParticipationHistoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/CourseParticipationHistoryTest.kt
@@ -3,7 +3,10 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationh
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationSetting
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.shareddomain.BusinessException
 import java.util.UUID
 
@@ -34,10 +37,9 @@ class CourseParticipationHistoryTest {
         courseId = courseId,
         otherCourseName = otherCourseName,
         source = null,
-        outcome = null,
-        setting = null,
+        outcome = CourseOutcome(detail = null, yearCompleted = null, yearStarted = null, status = null),
+        setting = CourseParticipationSetting(type = CourseSetting.CUSTODY, location = null),
         prisonNumber = "A1234BC",
-        yearStarted = null,
       )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/jparepo/JpaCourseParticipationHistoryRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/jparepo/JpaCourseParticipationHistoryRepositoryTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.C
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.jparepo.CourseEntityRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseStatus
 import java.time.Year
@@ -31,14 +32,18 @@ constructor(
       CourseParticipationHistory(
         courseId = courseId,
         prisonNumber = "A1234AA",
-        otherCourseName = "Other course name",
-        yearStarted = Year.parse("2021"),
+        otherCourseName = null,
         source = "source",
         outcome = CourseOutcome(
           status = CourseStatus.COMPLETE,
           detail = "Course outcome detail",
+          yearStarted = Year.parse("2021"),
+          yearCompleted = Year.parse("2022"),
         ),
-        setting = CourseSetting.CUSTODY,
+        setting = CourseParticipationSetting(
+          type = CourseSetting.CUSTODY,
+          location = "location",
+        ),
       ),
     ).id!!
 
@@ -52,14 +57,48 @@ constructor(
       id = participationId,
       courseId = courseId,
       prisonNumber = "A1234AA",
-      otherCourseName = "Other course name",
-      yearStarted = Year.parse("2021"),
+      otherCourseName = null,
       source = "source",
       outcome = CourseOutcome(
         status = CourseStatus.COMPLETE,
         detail = "Course outcome detail",
+        yearStarted = Year.parse("2021"),
+        yearCompleted = Year.parse("2022"),
       ),
-      setting = CourseSetting.CUSTODY,
+      setting = CourseParticipationSetting(
+        type = CourseSetting.CUSTODY,
+        location = "location",
+      ),
+    )
+  }
+
+  @Test
+  fun `save and retrieve a course participation history with minimal fields`() {
+    val participationId = courseParticipationHistoryRepository.save(
+      CourseParticipationHistory(
+        courseId = null,
+        prisonNumber = "A1234AA",
+        otherCourseName = "Other course name",
+        source = null,
+        setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
+        outcome = CourseOutcome(status = null, detail = null, yearStarted = null, yearCompleted = null),
+      ),
+    ).id!!
+
+    commitAndStartNewTx()
+
+    val persistentHistory = courseParticipationHistoryRepository.findById(participationId).getOrNull()
+
+    persistentHistory.shouldNotBeNull()
+
+    persistentHistory shouldBeEqualToComparingFields CourseParticipationHistory(
+      id = participationId,
+      courseId = null,
+      prisonNumber = "A1234AA",
+      otherCourseName = "Other course name",
+      source = null,
+      setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
+      outcome = CourseOutcome(status = null, detail = null, yearStarted = null, yearCompleted = null),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryControllerTest.kt
@@ -69,18 +69,21 @@ class CourseParticipationHistoryControllerTest(
         accept = MediaType.APPLICATION_JSON
         contentType = MediaType.APPLICATION_JSON
         header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
-        content = """{
-          "courseId": "$courseId",
-          "prisonNumber": "A1234AA",
-          "yearStarted": 2020,
-          "source": "source",
-          "outcome": {
-            "status": "complete",
-            "detail": "Detail"
-          },
-          "setting": "custody"
-        }
-        """
+        content = """
+          { 
+            "otherCourseName": null,
+            "courseId": "$courseId",
+            "prisonNumber": "A1234AA",
+            "source": "source",
+            "setting": {
+              "type": "custody"
+            },
+            "outcome": {
+              "status": "complete",
+              "detail": "Detail",
+              "yearStarted": 2020
+            }
+          }"""
       }.andExpect {
         status { isCreated() }
         content {
@@ -171,7 +174,7 @@ class CourseParticipationHistoryControllerTest(
         source = "source",
         setting = CourseSetting.COMMUNITY,
         outcome = CourseOutcome(
-          status = CourseStatus.DESELECTED,
+          status = CourseStatus.INCOMPLETE,
           detail = "Detail",
         ),
       )
@@ -183,19 +186,22 @@ class CourseParticipationHistoryControllerTest(
         status { isOk() }
         content {
           json(
-            """{ 
-            "id": "$participationHistoryId",
-            "otherCourseName": null,
-            "courseId": "$courseId",
-            "yearStarted": 2020,
-            "prisonNumber": "A1234BC",
-            "source": "source",
-            "setting": "community",
-            "outcome": {
-                    "status": "deselected",
-                    "detail": "Detail"
-                    }
-              }""",
+            """
+            { 
+              "id": "$participationHistoryId",
+              "otherCourseName": null,
+              "courseId": "$courseId",
+              "prisonNumber": "A1234BC",
+              "source": "source",
+              "setting": {
+                type: "community"
+              },
+              "outcome": {
+                "status": "incomplete",
+                "detail": "Detail",
+                "yearStarted": 2020
+              }
+            }""",
           )
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryControllerTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fix
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistoryService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseStatus
 import java.time.Year
@@ -59,9 +60,16 @@ class CourseParticipationHistoryControllerTest(
           courseId = courseId,
           source = "source",
           prisonNumber = "A1234AA",
-          outcome = CourseOutcome(status = CourseStatus.COMPLETE, detail = "Detail"),
-          setting = CourseSetting.CUSTODY,
-          yearStarted = Year.of(2020),
+          outcome = CourseOutcome(
+            status = CourseStatus.COMPLETE,
+            detail = "Detail",
+            yearStarted = Year.of(2020),
+            yearCompleted = Year.of(2021),
+          ),
+          setting = CourseParticipationSetting(
+            type = CourseSetting.CUSTODY,
+            location = "location",
+          ),
           otherCourseName = null,
         )
 
@@ -76,12 +84,14 @@ class CourseParticipationHistoryControllerTest(
             "prisonNumber": "A1234AA",
             "source": "source",
             "setting": {
-              "type": "custody"
+              "type": "custody",
+              "location": "location"
             },
             "outcome": {
               "status": "complete",
               "detail": "Detail",
-              "yearStarted": 2020
+              "yearStarted": 2020,
+              "yearCompleted": 2021
             }
           }"""
       }.andExpect {
@@ -97,13 +107,17 @@ class CourseParticipationHistoryControllerTest(
         courseId = courseId,
         otherCourseName = null,
         prisonNumber = "A1234AA",
-        yearStarted = Year.of(2020),
         source = "source",
         outcome = CourseOutcome(
           status = CourseStatus.COMPLETE,
           detail = "Detail",
+          yearStarted = Year.of(2020),
+          yearCompleted = Year.of(2021),
         ),
-        setting = CourseSetting.CUSTODY,
+        setting = CourseParticipationSetting(
+          type = CourseSetting.CUSTODY,
+          location = "location",
+        ),
       )
     }
 
@@ -169,13 +183,17 @@ class CourseParticipationHistoryControllerTest(
         id = participationHistoryId,
         otherCourseName = null,
         courseId = courseId,
-        yearStarted = Year.of(2020),
         prisonNumber = "A1234BC",
         source = "source",
-        setting = CourseSetting.COMMUNITY,
+        setting = CourseParticipationSetting(
+          type = CourseSetting.COMMUNITY,
+          location = "location",
+        ),
         outcome = CourseOutcome(
           status = CourseStatus.INCOMPLETE,
           detail = "Detail",
+          yearStarted = Year.of(2020),
+          yearCompleted = Year.of(2020),
         ),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryIntegrationTest.kt
@@ -49,6 +49,16 @@ constructor(
         CreateCourseParticipation(
           courseId = courseId,
           prisonNumber = "A1234AA",
+          setting = CourseParticipationSetting(
+            type = CourseParticipationSettingType.custody,
+            location = "location",
+          ),
+          outcome = CourseParticipationOutcome(
+            status = CourseParticipationOutcome.Status.complete,
+            yearStarted = 2021,
+            yearCompleted = 2022,
+            detail = "Some detail",
+          ),
         ),
       ).exchange()
       .expectStatus().isCreated
@@ -72,6 +82,16 @@ constructor(
       id = cpa.id,
       courseId = courseId,
       prisonNumber = "A1234AA",
+      setting = CourseParticipationSetting(
+        type = CourseParticipationSettingType.custody,
+        location = "location",
+      ),
+      outcome = CourseParticipationOutcome(
+        status = CourseParticipationOutcome.Status.complete,
+        yearStarted = 2021,
+        yearCompleted = 2022,
+        detail = "Some detail",
+      ),
     )
   }
 
@@ -90,6 +110,8 @@ constructor(
           courseId = courseId,
           otherCourseName = "A Course",
           prisonNumber = "A1234AA",
+          setting = CourseParticipationSetting(type = CourseParticipationSettingType.custody),
+          outcome = CourseParticipationOutcome(),
         ),
       ).exchange()
       .expectStatus().isBadRequest
@@ -109,7 +131,7 @@ constructor(
 
     val courseParticipationId = addCourseParticipationHistory(courseId, "A1234AA")
 
-    val cp = webTestClient
+    val updatedCourseParticipation = webTestClient
       .put()
       .uri("/course-participations/{id}", courseParticipationId)
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
@@ -131,7 +153,7 @@ constructor(
       .expectBody<CourseParticipation>()
       .returnResult().responseBody
 
-    val expectedCp = CourseParticipation(
+    val expectedCourseParticipation = CourseParticipation(
       id = courseParticipationId,
       courseId = courseId,
       setting = CourseParticipationSetting(
@@ -145,8 +167,8 @@ constructor(
       ),
     )
 
-    cp shouldBe expectedCp
-    getCourseParticipation(courseParticipationId) shouldBe expectedCp
+    updatedCourseParticipation shouldBe expectedCourseParticipation
+    getCourseParticipation(courseParticipationId) shouldBe expectedCourseParticipation
   }
 
   @Test
@@ -233,6 +255,8 @@ constructor(
         CreateCourseParticipation(
           courseId = courseId,
           prisonNumber = prisonNumber,
+          setting = CourseParticipationSetting(type = CourseParticipationSettingType.community),
+          outcome = CourseParticipationOutcome(),
         ),
       ).exchange()
       .expectStatus().isCreated

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationHistoryIntegrationTest.kt
@@ -18,8 +18,9 @@ import org.springframework.test.web.reactive.server.returnResult
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Course
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationOutcome
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSetting
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSettingType
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationUpdate
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CreateCourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fixture.JwtAuthHelper
@@ -116,11 +117,13 @@ constructor(
       .bodyValue(
         CourseParticipationUpdate(
           courseId = courseId,
-          yearStarted = 2020,
-          setting = CourseSetting.custody,
+          setting = CourseParticipationSetting(
+            type = CourseParticipationSettingType.custody,
+          ),
           outcome = CourseParticipationOutcome(
-            status = CourseParticipationOutcome.Status.deselected,
+            status = CourseParticipationOutcome.Status.incomplete,
             detail = "Some detail",
+            yearStarted = 2020,
           ),
         ),
       ).exchange()
@@ -131,12 +134,14 @@ constructor(
     val expectedCp = CourseParticipation(
       id = courseParticipationId,
       courseId = courseId,
-      yearStarted = 2020,
-      setting = CourseSetting.custody,
+      setting = CourseParticipationSetting(
+        type = CourseParticipationSettingType.custody,
+      ),
       prisonNumber = "A1234AA",
       outcome = CourseParticipationOutcome(
-        status = CourseParticipationOutcome.Status.deselected,
+        status = CourseParticipationOutcome.Status.incomplete,
         detail = "Some detail",
+        yearStarted = 2020,
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
@@ -59,7 +59,7 @@ class PeopleControllerTest(
           source = "source",
           setting = CourseSetting.COMMUNITY,
           outcome = CourseOutcome(
-            status = CourseStatus.DESELECTED,
+            status = CourseStatus.INCOMPLETE,
             detail = "Detail",
           ),
         ),
@@ -77,14 +77,16 @@ class PeopleControllerTest(
               "id": "$participationHistoryId",
               "otherCourseName": null,
               "courseId": "$courseId",
-              "yearStarted": 2020,
               "prisonNumber": "A1234BC",
               "source": "source",
-              "setting": "community",
+              "setting": {
+                "type": "community"
+              },
               "outcome": {
-                      "status": "deselected",
-                      "detail": "Detail"
-                      }
+                "status": "incomplete",
+                "detail": "Detail",
+                "yearStarted": 2020
+              }
             }]""",
           )
         }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.fix
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationHistoryService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseStatus
 import java.time.Year
@@ -54,13 +55,17 @@ class PeopleControllerTest(
           id = participationHistoryId,
           otherCourseName = null,
           courseId = courseId,
-          yearStarted = Year.of(2020),
           prisonNumber = "A1234BC",
           source = "source",
-          setting = CourseSetting.COMMUNITY,
+          setting = CourseParticipationSetting(
+            type = CourseSetting.COMMUNITY,
+            location = null,
+          ),
           outcome = CourseOutcome(
             status = CourseStatus.INCOMPLETE,
             detail = "Detail",
+            yearStarted = Year.of(2018),
+            yearCompleted = Year.of(2023),
           ),
         ),
       )
@@ -85,7 +90,8 @@ class PeopleControllerTest(
               "outcome": {
                 "status": "incomplete",
                 "detail": "Detail",
-                "yearStarted": 2020
+                "yearStarted": 2018,
+                "yearCompleted": 2023
               }
             }]""",
           )


### PR DESCRIPTION
## Context

Trello: [Add additional programme history fields to API](https://trello.com/c/kWwW6vM1/862-add-additional-programme-history-fields-to-api)

## Changes in this PR
Expanded the `setting` and `outcome` properties of `CourseParticipationHistory`
* `yearStarted` has been moved to `outcome`, see below
* `setting` now has `var location: String?` and `var type: CourseSetting`
* `outcome` now has additional properties `var yearStarted: Year?` and `var yearCompleted`: Year?`

`outcome` has an additional unused private field
 ```
@Formula("0")
val ignoreMe: Int = 0
```
If all properties of an `@Embedded` object are `null` Hibernate will not create the object. Instead the property (`outcome`) is set `null` - even if it is not a nullable type! The additional field `ignoreMe`, which _not_ nullable forces Hibernate to always populate the `outcome` property with an instance of `CourseOutcome`

The `course_participation_history` table has been renamed to `course_participation`

 OpenAPI specifications provide an `allOf` keyword which provides an inheritance mechanism for component schemas.  `allOf` has been used to remove some of the redundancy in `api.yml`.

OpenApi `Operation` objects have an `operationId` field that name each operation. If an `operationId` on an `operation` then the kotlin-spring code generator uses the value of this field as the name of the generated method that handles this operation.  `operationId`s have been added to all the `course-participation` related operations in `api.yml`. Hopefully this makes the generated method names more readable. It also means that those method names do not change when the operation paths are changed.  A future refactoring could add `operationId`s to all operations in the `api.yml` specification.

## Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
