### PR TITLE
Housekeeping: Bump dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.4.1"
   kotlin("plugin.spring") version "1.9.10"
   kotlin("plugin.jpa") version "1.9.10"
-  id("org.openapi.generator") version "7.0.0"
+  id("org.openapi.generator") version "7.0.1"
 }
 
 configurations {
@@ -39,7 +39,7 @@ dependencies {
   testImplementation("io.jsonwebtoken:jjwt-api:0.11.5")
   testImplementation("io.jsonwebtoken:jjwt-impl:0.11.5")
   testImplementation("io.jsonwebtoken:jjwt-orgjson:0.11.5")
-  testImplementation("au.com.dius.pact.provider:junit5spring:4.6.2")
+  testImplementation("au.com.dius.pact.provider:junit5spring:4.6.3")
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
 }
 


### PR DESCRIPTION
## Context

The Gradle OWAP dependencyAnalyze task suggests updating a couple of dependencies.

## Changes in this PR
Updated a couple of dependencies in `build.gradle.kts`

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
