### PR TITLE
(862) Add additional programme history fields to API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipation.kt
@@ -51,19 +51,5 @@ class CourseOutcome(
   var detail: String?,
 )
 
-enum class CourseSetting {
-  CUSTODY,
-  COMMUNITY,
-  ;
-
-  override fun toString(): String = name.lowercase()
-}
-
-enum class CourseStatus {
-  DESELECTED,
-  INCOMPLETE,
-  COMPLETE,
-  ;
-
-  override fun toString(): String = name.lowercase()
-}
+enum class CourseSetting { CUSTODY, COMMUNITY }
+enum class CourseStatus { INCOMPLETE, COMPLETE }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationService.kt
@@ -18,32 +18,32 @@ class CourseParticipationService(
       repository.save(it)
     }
 
-  fun getCourseParticipation(courseParticipationId: UUID): CourseParticipation? =
-    repository.findById(courseParticipationId).getOrNull()
+  fun getCourseParticipation(historicCourseParticipationId: UUID): CourseParticipation? =
+    repository.findById(historicCourseParticipationId).getOrNull()
 
-  fun updateCourseParticipation(courseParticipationId: UUID, update: CourseParticipationUpdate): CourseParticipation =
+  fun updateCourseParticipation(historicCourseParticipationId: UUID, update: CourseParticipationUpdate): CourseParticipation =
     repository
-      .getReferenceById(courseParticipationId)
+      .getReferenceById(historicCourseParticipationId)
       .applyUpdate(update)
 
   fun findByPrisonNumber(prisonNumber: String): List<CourseParticipation> = repository.findByPrisonNumber(prisonNumber)
-  fun deleteCourseParticipation(courseParticipationId: UUID) {
-    repository.deleteById(courseParticipationId)
-  }
-
-  companion object {
-    private fun CourseParticipation.applyUpdate(update: CourseParticipationUpdate): CourseParticipation =
-      this.apply {
-        yearStarted = update.yearStarted
-        courseId = update.courseId
-        otherCourseName = update.otherCourseName
-        setting = update.setting
-        if (outcome == null) {
-          outcome = update.outcome?.let { CourseOutcome(status = it.status, detail = it.detail) }
-        } else {
-          outcome!!.status = update.outcome?.status
-          outcome!!.detail = update.outcome?.detail
-        }
-      }
+  fun deleteCourseParticipation(historicCourseParticipationId: UUID) {
+    repository.deleteById(historicCourseParticipationId)
   }
 }
+
+private fun CourseParticipation.applyUpdate(update: CourseParticipationUpdate): CourseParticipation =
+  apply {
+    courseId = update.courseId
+    otherCourseName = update.otherCourseName
+    setting.run {
+      type = update.setting.type
+      location = update.setting.location
+    }
+    outcome.run {
+      status = update.outcome.status
+      detail = update.outcome.detail
+      yearStarted = update.outcome.yearStarted
+      yearCompleted = update.outcome.yearCompleted
+    }
+  }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationUpdate.kt
@@ -1,12 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain
 
-import java.time.Year
 import java.util.UUID
 
 data class CourseParticipationUpdate(
   val courseId: UUID? = null,
   val otherCourseName: String?,
-  val yearStarted: Year?,
-  val setting: CourseSetting?,
-  val outcome: CourseOutcome?,
+  val setting: CourseParticipationSetting,
+  val outcome: CourseOutcome,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationController.kt
@@ -16,22 +16,21 @@ import java.util.UUID
 class CourseParticipationController(
   @Autowired val service: CourseParticipationService,
 ) : CourseParticipationsApiDelegate {
-  override fun courseParticipationsPost(createCourseParticipation: CreateCourseParticipation): ResponseEntity<CourseParticipation> =
+  override fun createCourseParticipation(createCourseParticipation: CreateCourseParticipation): ResponseEntity<CourseParticipation> =
     service.addCourseParticipation(createCourseParticipation.toDomain())
       ?.let {
         ResponseEntity.status(HttpStatus.CREATED).body(it.toApi())
       } ?: throw Exception("Unable to add to course participation")
-
-  override fun courseParticipationsCourseParticipationIdGet(courseParticipationId: UUID): ResponseEntity<CourseParticipation> =
+  override fun getCourseParticipation(courseParticipationId: UUID): ResponseEntity<CourseParticipation> =
     service.getCourseParticipation(courseParticipationId)
       ?.let {
         ResponseEntity.ok(it.toApi())
       } ?: throw NotFoundException("No course participation found for id $courseParticipationId")
 
-  override fun courseParticipationsCourseParticipationIdPut(courseParticipationId: UUID, courseParticipationUpdate: CourseParticipationUpdate): ResponseEntity<CourseParticipation> =
+  override fun updateCourseParticipation(courseParticipationId: UUID, courseParticipationUpdate: CourseParticipationUpdate): ResponseEntity<CourseParticipation> =
     ResponseEntity.ok(service.updateCourseParticipation(courseParticipationId, courseParticipationUpdate.toDomain()).toApi())
 
-  override fun courseParticipationsCourseParticipationIdDelete(courseParticipationId: UUID): ResponseEntity<Unit> {
+  override fun deleteCourseParticipation(courseParticipationId: UUID): ResponseEntity<Unit> {
     service.deleteCourseParticipation(courseParticipationId)
     return ResponseEntity.noContent().build()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleController.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Cours
 class PeopleController(
   @Autowired val service: CourseParticipationService,
 ) : PeopleApiDelegate {
-  override fun peoplePrisonNumberCourseParticipationsGet(prisonNumber: String): ResponseEntity<List<CourseParticipationApi>> =
+  override fun getCourseParticipationsForPrisonNumber(prisonNumber: String): ResponseEntity<List<CourseParticipationApi>> =
     ResponseEntity.ok(
       service
         .findByPrisonNumber(prisonNumber)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
@@ -1,16 +1,17 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.restapi
 
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationOutcome
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSettingType
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CreateCourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipation
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseStatus
 import java.time.Year
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipation as ApiCourseParticipation
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSetting as ApiCourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationUpdate as ApiCourseParticipationUpdate
 
 fun CreateCourseParticipation.toDomain() =
@@ -19,17 +20,15 @@ fun CreateCourseParticipation.toDomain() =
     courseId = courseId,
     otherCourseName = otherCourseName,
     source = source,
-    setting = setting?.toDomain(),
-    outcome = outcome?.toDomain(),
-    yearStarted = outcome?.yearStarted?.let(Year::of),
+    setting = setting.toDomain(),
+    outcome = outcome.toDomain(),
   )
 
 fun ApiCourseParticipationUpdate.toDomain() = CourseParticipationUpdate(
   courseId = courseId,
-  yearStarted = outcome?.yearStarted?.let(Year::of),
-  setting = setting?.toDomain(),
   otherCourseName = otherCourseName,
-  outcome = outcome?.toDomain(),
+  setting = setting.toDomain(),
+  outcome = outcome.toDomain(),
 )
 
 fun CourseParticipationSettingType.toDomain() = when (this) {
@@ -37,16 +36,28 @@ fun CourseParticipationSettingType.toDomain() = when (this) {
   CourseParticipationSettingType.custody -> CourseSetting.CUSTODY
 }
 
-fun CourseParticipationSetting.toDomain() = this.type?.toDomain()
-
-fun CourseSetting.toApi() = CourseParticipationSetting(
-  type = when (this) {
-    CourseSetting.CUSTODY -> CourseParticipationSettingType.custody
-    CourseSetting.COMMUNITY -> CourseParticipationSettingType.community
-  },
+fun ApiCourseParticipationSetting.toDomain() = CourseParticipationSetting(
+  type = type.toDomain(),
+  location = location,
 )
 
-fun CourseParticipationOutcome.toDomain() = CourseOutcome(status = status?.toDomain(), detail = detail)
+fun CourseParticipationSetting.toApi() = ApiCourseParticipationSetting(
+  type = type.toApi(),
+  location = location,
+)
+
+fun CourseSetting.toApi() = when (this) {
+  CourseSetting.CUSTODY -> CourseParticipationSettingType.custody
+  CourseSetting.COMMUNITY -> CourseParticipationSettingType.community
+}
+
+fun CourseParticipationOutcome.toDomain() =
+  CourseOutcome(
+    status = status?.toDomain(),
+    detail = detail,
+    yearStarted = yearStarted?.let(Year::of),
+    yearCompleted = yearCompleted?.let(Year::of),
+  )
 
 fun CourseParticipationOutcome.Status.toDomain() = when (this) {
   CourseParticipationOutcome.Status.complete -> CourseStatus.COMPLETE
@@ -61,15 +72,16 @@ fun CourseStatus.toApi() = when (this) {
 fun CourseParticipation.toApi() = ApiCourseParticipation(
   id = id!!,
   prisonNumber = prisonNumber,
-  setting = setting?.toApi(),
+  setting = setting.toApi(),
   courseId = courseId,
   otherCourseName = otherCourseName,
   source = source,
-  outcome = outcome?.let {
+  outcome = with(outcome) {
     CourseParticipationOutcome(
-      status = it.status?.toApi(),
-      detail = it.detail,
+      status = status?.toApi(),
+      detail = detail,
       yearStarted = yearStarted?.value,
+      yearCompleted = yearCompleted?.value,
     )
   },
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.restapi
 
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationOutcome
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSetting
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSettingType
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CreateCourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipation
@@ -10,47 +12,49 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhi
 import java.time.Year
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipation as ApiCourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationUpdate as ApiCourseParticipationUpdate
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseSetting as ApiCourseSetting
 
-fun CreateCourseParticipation.toDomain() = CourseParticipation(
-  prisonNumber = prisonNumber,
-  courseId = courseId,
-  otherCourseName = otherCourseName,
-  source = source,
-  setting = setting?.toDomain(),
-  outcome = outcome?.toDomain(),
-  yearStarted = yearStarted?.let(Year::of),
-)
+fun CreateCourseParticipation.toDomain() =
+  CourseParticipation(
+    prisonNumber = prisonNumber,
+    courseId = courseId,
+    otherCourseName = otherCourseName,
+    source = source,
+    setting = setting?.toDomain(),
+    outcome = outcome?.toDomain(),
+    yearStarted = outcome?.yearStarted?.let(Year::of),
+  )
 
 fun ApiCourseParticipationUpdate.toDomain() = CourseParticipationUpdate(
   courseId = courseId,
-  yearStarted = yearStarted?.let(Year::of),
+  yearStarted = outcome?.yearStarted?.let(Year::of),
   setting = setting?.toDomain(),
   otherCourseName = otherCourseName,
   outcome = outcome?.toDomain(),
 )
 
-fun ApiCourseSetting.toDomain() = when (this) {
-  ApiCourseSetting.community -> CourseSetting.COMMUNITY
-  ApiCourseSetting.custody -> CourseSetting.CUSTODY
+fun CourseParticipationSettingType.toDomain() = when (this) {
+  CourseParticipationSettingType.community -> CourseSetting.COMMUNITY
+  CourseParticipationSettingType.custody -> CourseSetting.CUSTODY
 }
 
-fun CourseSetting.toApi() = when (this) {
-  CourseSetting.CUSTODY -> ApiCourseSetting.custody
-  CourseSetting.COMMUNITY -> ApiCourseSetting.community
-}
+fun CourseParticipationSetting.toDomain() = this.type?.toDomain()
+
+fun CourseSetting.toApi() = CourseParticipationSetting(
+  type = when (this) {
+    CourseSetting.CUSTODY -> CourseParticipationSettingType.custody
+    CourseSetting.COMMUNITY -> CourseParticipationSettingType.community
+  },
+)
 
 fun CourseParticipationOutcome.toDomain() = CourseOutcome(status = status?.toDomain(), detail = detail)
 
 fun CourseParticipationOutcome.Status.toDomain() = when (this) {
   CourseParticipationOutcome.Status.complete -> CourseStatus.COMPLETE
-  CourseParticipationOutcome.Status.deselected -> CourseStatus.DESELECTED
   CourseParticipationOutcome.Status.incomplete -> CourseStatus.INCOMPLETE
 }
 
 fun CourseStatus.toApi() = when (this) {
   CourseStatus.INCOMPLETE -> CourseParticipationOutcome.Status.incomplete
-  CourseStatus.DESELECTED -> CourseParticipationOutcome.Status.deselected
   CourseStatus.COMPLETE -> CourseParticipationOutcome.Status.complete
 }
 
@@ -60,12 +64,12 @@ fun CourseParticipation.toApi() = ApiCourseParticipation(
   setting = setting?.toApi(),
   courseId = courseId,
   otherCourseName = otherCourseName,
-  yearStarted = yearStarted?.value,
   source = source,
   outcome = outcome?.let {
     CourseParticipationOutcome(
       status = it.status?.toApi(),
       detail = it.detail,
+      yearStarted = yearStarted?.value,
     )
   },
 )

--- a/src/main/resources/db/migration/V18__extend_course_participation_table.sql
+++ b/src/main/resources/db/migration/V18__extend_course_participation_table.sql
@@ -1,0 +1,26 @@
+ALTER TABLE course_participation
+    ADD COLUMN year_completed integer;
+
+ALTER TABLE course_participation
+    RENAME COLUMN setting TO type;
+
+ALTER TABLE course_participation
+    ADD COLUMN location text;
+
+ALTER TABLE course_participation
+    ADD COLUMN created_by_username text NOT NULL default current_user;
+
+ALTER TABLE course_participation
+    ALTER COLUMN created_by_username SET NOT NULL;
+
+ALTER TABLE course_participation
+    ADD COLUMN created_date_time TIMESTAMP NOT NULL default NOW();
+
+ALTER TABLE course_participation
+    ALTER COLUMN created_date_time SET NOT NULL;
+
+ALTER TABLE course_participation
+    ADD COLUMN last_modified_by_username text;
+
+ALTER TABLE course_participation
+    ADD COLUMN last_modified_date_time TIMESTAMP;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -411,6 +411,7 @@ paths:
       tags:
         - Course participations
       summary: Record information about a person's prior participation in a course.
+      operationId: createCourseParticipation
       requestBody:
         required: true
         content:
@@ -442,6 +443,7 @@ paths:
       tags:
         - Course participations
       summary: Return information about a person's participation in a course. Selected by a unique identifier.
+      operationId: getCourseParticipation
       parameters:
         - name: courseParticipationId
           in: path
@@ -468,6 +470,7 @@ paths:
       tags:
         - Course participations
       summary: Update the information about a person's participation in a course.
+      operationId: updateCourseParticipation
       parameters:
         - name: courseParticipationId
           in: path
@@ -506,6 +509,7 @@ paths:
       tags:
         - Course participations
       summary: Delete information about a person's participation in a course.
+      operationId: deleteCourseParticipation
       parameters:
         - name: courseParticipationId
           in: path
@@ -529,6 +533,7 @@ paths:
       tags:
         - Course participations
       summary: Retrieve course participation information for a person identified by their prison number.
+      operationId: getCourseParticipationsForPrisonNumber
       parameters:
         - name: prisonNumber
           in: path
@@ -785,65 +790,6 @@ components:
         - prisonNumber
         - referrerId
 
-    CourseParticipation:
-      type: object
-      properties:
-        id:
-          description: A unique identifier for this record of participation in a course
-          type: string
-          format: uuid
-        prisonNumber:
-          description: The prison number of the course participant
-          example: "A1234AA"
-          type: string
-        courseId:
-          description: "The identifier of a course currently or previously managed by this service.  
-                        Must be the unique identifier of a course. If the participant's course is not known to this service
-                        or cannot be identified then this field will be null while the otherCourseName
-                        property will be populated."
-          type: string
-          format: uuid
-        otherCourseName:
-          description: "The name of the course taken by the participant.  Only used if this course is not managed
-                        by this service or cannot be identified. See courseId."
-          type: string
-        setting:
-          $ref: '#/components/schemas/CourseParticipationSetting'
-        outcome:
-          $ref: '#/components/schemas/CourseParticipationOutcome'
-        source:
-          type: string
-      required:
-        - id
-        - prisonNumber
-
-    CreateCourseParticipation:
-      type: object
-      properties:
-        prisonNumber:
-          description: The prison number of the course participant
-          example: "A1234AA"
-          type: string
-        courseId:
-          description: "The identifier of a course currently or previously managed by this service.  
-                        Must be the unique identifier of a course. If the participant's course is not known to this service
-                        or cannot be identified then this field should not be supplied. Instead, add an arbitrary name 
-                        for the course in otherCourseName."
-          type: string
-          format: uuid
-        otherCourseName:
-          description: "The name of the course taken by the participant.  It should only be used when this course is not managed
-                        by this service or cannot be identified. See courseId."
-          type: string
-        setting:
-          $ref: '#/components/schemas/CourseParticipationSetting'
-        outcome:
-          $ref: '#/components/schemas/CourseParticipationOutcome'
-        source:
-          type: string
-      required:
-        - prisonNumber
-
     CourseParticipationUpdate:
       type: object
       properties:
@@ -864,6 +810,30 @@ components:
           $ref: '#/components/schemas/CourseParticipationOutcome'
         source:
           type: string
+
+    CreateCourseParticipation:
+      allOf:
+        - $ref: "#/components/schemas/CourseParticipationUpdate"
+        - type: object
+          properties:
+            prisonNumber:
+              description: The prison number of the course participant.
+              example: "A1234AA"
+              type: string
+          required:
+            - prisonNumber
+
+    CourseParticipation:
+      allOf:
+        - $ref: "#/components/schemas/CreateCourseParticipation"
+        - type: object
+          properties:
+            id:
+              description: A unique identifier for this record of participation in a course.
+              type: string
+              format: uuid
+          required:
+            - id
 
     CourseParticipationSettingType:
       description: Either Custody or Community.

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -792,6 +792,9 @@ components:
           $ref: '#/components/schemas/CourseParticipationOutcome'
         source:
           type: string
+      required:
+        - setting
+        - outcome
 
     CreateCourseParticipation:
       allOf:
@@ -832,6 +835,8 @@ components:
           type: string
         type:
           $ref: '#/components/schemas/CourseParticipationSettingType'
+      required:
+        - type
 
     CourseParticipationOutcome:
       description: The outcome of participating in a course.

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -12,7 +12,7 @@ paths:
       summary: List all courses
       responses:
         200:
-          description: Return a JSON representation of all courses that are not withdrawn
+          description: Return a JSON representation of all courses that are not withdrawn.
           content:
             'application/json':
               schema:
@@ -44,7 +44,7 @@ paths:
       summary: List all courses
       responses:
         200:
-          description: Return a CSV format representation of all courses that are not withdrawn. The data is compatible with the PUT /courses endpoint and may be round-tripped
+          description: Return a CSV format representation of all courses that are not withdrawn. The data is compatible with the PUT /courses endpoint and may be round-tripped.
           content:
             'text/csv;charset=UTF-8':
               schema:
@@ -59,7 +59,7 @@ paths:
       summary: Download a CSV format representation of the current set of prerequisites.
       responses:
         200:
-          description: The CSV formatted data is compatible the PUT operation and may be round-tripped
+          description: The CSV formatted data is compatible with the PUT operation and may be round-tripped.
           content:
             'text/csv;charset=UTF-8':
               schema:
@@ -117,7 +117,7 @@ paths:
           content:
             'application/json':
               schema:
-                  $ref: '#/components/schemas/Course'
+                $ref: '#/components/schemas/Course'
 
   /courses/{courseId}/offerings:
     get:
@@ -210,11 +210,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/CourseOffering'
         401:
-          description: Unauthorized. The request was unauthorized
+          description: Unauthorised. The request was unauthorised.
         403:
-          description: Forbidden.  The client is not authorised to access this offering
+          description: Forbidden.  The client is not authorised to access this offering.
         404:
-          description: invalid course offering id
+          description: Invalid course offering id
           content:
             'application/json':
               schema:
@@ -245,7 +245,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         401:
-          description: Unauthorized. The request was unauthorized
+          description: Unauthorised. The request was unauthorised.
 
     get:
       summary: Retrieve some referrals
@@ -254,27 +254,27 @@ paths:
       parameters:
         - name: status
           in: query
-          description: If present only return referrals in the given state
+          description: If present, only return referrals in the given state
           required: false
           schema:
             $ref: "#/components/schemas/ReferralStatus"
         - name: offeringId
           in: query
-          description: The id (UUID) of an active offering. If present only return referrals for that offering
+          description: The id (UUID) of an active offering. If present, only return referrals for that offering.
           required: false
           schema:
             type: string
             format: uuid
         - name: prisonNumber
           in: query
-          description: The prison number of the person who is being referred. If present only return referrals for the person.
+          description: The prison number of the person who is being referred. If present, only return referrals for the person.
           example: "A1234AA"
           required: false
           schema:
             type: string
         - name: referrerId
           in: query
-          description: A permanent identifier for the person creating the referral. StaffId for prison staff. If present only return referrals for that referrer
+          description: A permanent identifier for the person creating the referral. StaffId for prison staff. If present, only return referrals for that referrer.
           required: false
           schema:
             type: string
@@ -284,14 +284,14 @@ paths:
           description: Returns information about matching referrals
           content:
             'application/json':
-                schema:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/Referral'
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Referral'
         401:
-          description: The request was unauthorized
+          description: The request was unauthorised
         403:
-          description: Forbidden.  The client is not authorised to access referrals
+          description: Forbidden.  The client is not authorised to access referrals.
 
   /referrals/{id}:
     get:
@@ -314,11 +314,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/Referral'
         401:
-          description: The request was unauthorized
+          description: The request was unauthorised
         403:
-          description: Forbidden.  The client is not authorised to access this referral
+          description: Forbidden.  The client is not authorised to access this referral.
         404:
-         description: The referral does not exist
+          description: The referral does not exist
 
     put:
       tags:
@@ -342,9 +342,9 @@ paths:
         204:
           description: The referral was updated
         401:
-          description: The request was unauthorized
+          description: The request was unauthorised
         403:
-          description: Forbidden.  The client is not authorised to access this referral
+          description: Forbidden.  The client is not authorised to access this referral.
         404:
           description: The referral does not exist
 
@@ -369,48 +369,48 @@ paths:
               $ref: '#/components/schemas/StatusUpdate'
       responses:
         204:
-          description: The referral now has the requested status
+          description: The referral now has the requested status.
         401:
-          description: The request was unauthorized
+          description: The request was unauthorised.
         403:
-          description: Forbidden.  The client is not authorised to access this referral
+          description: Forbidden.  The client is not authorised to access this referral.
         404:
-          description: The referral does not exist
+          description: The referral does not exist.
         409:
-          description: The referral may not change its status to the supplied value
+          description: The referral may not change its status to the supplied value.
 
   /offerings/{id}/course:
     get:
       tags:
         - Courses
-      summary: Retrieve the course that owns an offering
+      summary: Retrieve the course that owns an offering.
       parameters:
         - name: id
           in: path
-          description: The id (UUID) of an offering
+          description: The id (UUID) of an offering.
           required: true
           schema:
             type: string
             format: uuid
       responses:
         200:
-          description: Information about the Course that owns the offering
+          description: Information about the Course that owns the offering.
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/Course'
         401:
-          description: The request was unauthorized
+          description: The request was unauthorised
         403:
-          description: Forbidden.  The client is not authorised to access this offering
+          description: Forbidden.  The client is not authorised to access this offering.
         404:
-          description: No offering has the supplied id (Not Found)
+          description: No offering has the supplied id (Not Found).
 
   /course-participations:
     post:
       tags:
         - Course participations
-      summary: Record information about a person's prior participation in a course
+      summary: Record information about a person's prior participation in a course.
       requestBody:
         required: true
         content:
@@ -419,7 +419,7 @@ paths:
               $ref: '#/components/schemas/CreateCourseParticipation'
       responses:
         201:
-          description: The course participation information has been added
+          description: The course participation information has been added.
           content:
             'application/json':
               schema:
@@ -431,7 +431,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         401:
-          description: The client is not authorized to perform this operation
+          description: The client is not authorized to perform this operation.
           content:
             'application/json':
               schema:
@@ -441,11 +441,11 @@ paths:
     get:
       tags:
         - Course participations
-      summary: Return information about a person's participation in a course. Selected by a unique identifier
+      summary: Return information about a person's participation in a course. Selected by a unique identifier.
       parameters:
         - name: courseParticipationId
           in: path
-          description: The unique identifier assigned to this record when it was created
+          description: The unique identifier assigned to this record when it was created.
           schema:
             type: string
             format: uuid
@@ -458,7 +458,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/CourseParticipation"
         401:
-          description: The client is not authorized to perform this operation
+          description: The client is not authorised to perform this operation.
           content:
             'application/json':
               schema:
@@ -471,7 +471,7 @@ paths:
       parameters:
         - name: courseParticipationId
           in: path
-          description: The unique identifier assigned to this record when it was created
+          description: The unique identifier assigned to this record when it was created.
           schema:
             type: string
             format: uuid
@@ -484,19 +484,19 @@ paths:
         required: true
       responses:
         200:
-          description: The information about a person's participation in a course has been updated
+          description: The information about a person's participation in a course has been updated.
           content:
             'application/json':
               schema:
                 $ref: "#/components/schemas/CourseParticipation"
         401:
-          description: The client is not authorized to perform this operation
+          description: The client is not authorized to perform this operation.
           content:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
         404:
-          description: There is no information for the id so it cannot be updated.
+          description: There is no information for the id, so it cannot be updated.
           content:
             'application/json':
               schema:
@@ -509,16 +509,16 @@ paths:
       parameters:
         - name: courseParticipationId
           in: path
-          description: The unique identifier assigned to this record when it was created
+          description: The unique identifier assigned to this record when it was created.
           schema:
             type: string
             format: uuid
           required: true
       responses:
         204:
-          description: The information about a person's participation in a course has been deleted
+          description: The information about a person's participation in a course has been deleted.
         401:
-          description: The client is not authorized to perform this operation
+          description: The client is not authorized to perform this operation.
           content:
             'application/json':
               schema:
@@ -528,18 +528,18 @@ paths:
     get:
       tags:
         - Course participations
-      summary: Retrieve course participation information for a person identified by their prison number
+      summary: Retrieve course participation information for a person identified by their prison number.
       parameters:
         - name: prisonNumber
           in: path
-          description: The prison number of the person for whom the information should be retrieved
+          description: The prison number of the person for whom the information should be retrieved.
           example: "A1234AA"
           required: true
           schema:
             type: string
       responses:
         200:
-          description: All historic course participation information for the person.  Empty if none found
+          description: All historic course participation information for the person.  Empty if none found.
           content:
             'application/json':
               schema:
@@ -547,7 +547,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/CourseParticipation"
         401:
-          description: The client is not authorized to perform this operation
+          description: The client is not authorised to perform this operation.
           content:
             'application/json':
               schema:
@@ -639,11 +639,11 @@ components:
         name:
           type: string
           example: "age"
-          description: "The name of this Course Prerequisite"
+          description: "The name of this Course Prerequisite."
         description:
           type: string
           example: "18+"
-          description: "The value of this Course Prerequisite"
+          description: "The value of this Course Prerequisite."
         course:
           type: string
           example: "Kaizen"
@@ -667,7 +667,7 @@ components:
         organisationId:
           type: string
           example: "MDI"
-          description: "The unique identifier associated with the location hosting the offering. For prisons this is the PrisonId which is usually three capital letters."
+          description: "The unique identifier associated with the location hosting the offering. For prisons, this is the PrisonId, which is usually three capital letters."
         contactEmail:
           type: string
           format: email
@@ -677,7 +677,7 @@ components:
           type: string
           format: email
           example: "ap-admin-2@digital.justice.gov.uk"
-          description: "An optional secondary email address of a contact for this offering"
+          description: "An optional secondary email address of a contact for this offering."
 
       required:
         - id
@@ -691,10 +691,10 @@ components:
         course:
           type: string
           example: "Kaizen"
-          description: "The name of the Course to which this Offering applies. This value is only present to help with comprehension. It is not used to match offerings with courses"
+          description: "The name of the Course to which this Offering applies. This value is only present to help with comprehension. It is not used to match offerings with courses."
         identifier:
           type: string
-          description: "The unique identifier of the Course variant to which this Offering applies. The offering is added to the course having this identifier"
+          description: "The unique identifier of the Course variant to which this Offering applies. The offering is added to the course having this identifier."
           example: "BNM-IPVO"
         organisation:
           type: string
@@ -702,16 +702,16 @@ components:
           type: string
           format: email
           example: "ap-admin@digital.justice.gov.uk"
-          description: "The email address of the contact for this offering"
+          description: "The email address of the contact for this offering."
         "secondary contact email":
           type: string
           format: email
           example: "ap-admin2@digital.justice.gov.uk"
-          description: "An optional secondary email address of a contact for this offering"
+          description: "An optional secondary email address of a contact for this offering."
         prisonId:
           type: string
           example: "MDI"
-          description: "The prison id for the prison associated with this Offering. This is usually three capital letters"
+          description: "The prison id for the prison associated with this Offering. This is usually three capital letters."
       required:
         - course
         - prisonId
@@ -798,21 +798,17 @@ components:
           type: string
         courseId:
           description: "The identifier of a course currently or previously managed by this service.  
-                        Must be the unique id of a course. If the participant's course is not known to this service
+                        Must be the unique identifier of a course. If the participant's course is not known to this service
                         or cannot be identified then this field will be null while the otherCourseName
                         property will be populated."
           type: string
           format: uuid
         otherCourseName:
-          description: "The name of the course taken by the participant.  Only  used if this course is not managed
-                        by this service or cannot be identified. See courseId"
+          description: "The name of the course taken by the participant.  Only used if this course is not managed
+                        by this service or cannot be identified. See courseId."
           type: string
-        yearStarted:
-          description: The year in which the participant commenced the course
-          example: 2021
-          type: integer
         setting:
-          $ref: '#/components/schemas/CourseSetting'
+          $ref: '#/components/schemas/CourseParticipationSetting'
         outcome:
           $ref: '#/components/schemas/CourseParticipationOutcome'
         source:
@@ -830,21 +826,17 @@ components:
           type: string
         courseId:
           description: "The identifier of a course currently or previously managed by this service.  
-                        Must be the unique id of a course. If the participant's course is not known to this service
-                        or cannot be identified then this field should not be supplied. Instead, the otherCourseName
-                        property should be populated."
+                        Must be the unique identifier of a course. If the participant's course is not known to this service
+                        or cannot be identified then this field should not be supplied. Instead, add an arbitrary name 
+                        for the course in otherCourseName."
           type: string
           format: uuid
         otherCourseName:
-          description: "The name of the course taken by the participant.  Should only be used if this course is not managed
-                        by this service or cannot be identified. See courseId"
+          description: "The name of the course taken by the participant.  It should only be used when this course is not managed
+                        by this service or cannot be identified. See courseId."
           type: string
-        yearStarted:
-          description: The year in which the participant commenced the course
-          example: 2021
-          type: integer
         setting:
-          $ref: '#/components/schemas/CourseSetting'
+          $ref: '#/components/schemas/CourseParticipationSetting'
         outcome:
           $ref: '#/components/schemas/CourseParticipationOutcome'
         source:
@@ -857,45 +849,53 @@ components:
       properties:
         courseId:
           description: "The identifier of a course currently or previously managed by this service.  
-                        Must be the unique id of a course. If the participant's course is not known to this service
-                        or cannot be identified then this field should not be supplied. Instead, the otherCourseName
-                        property should be populated."
+                        Must be the unique identifier of a course. If the participant's course is not known to this service
+                        or cannot be identified, then this field should not be supplied. Instead, add an arbitrary name 
+                        for the course in otherCourseName."
           type: string
           format: uuid
         otherCourseName:
-          description: "The name of the course taken by the participant.  Should only be used if this course is not managed
-                        by this service or cannot be identified. See courseId"
+          description: "The name of the course taken by the participant.  It should only be used when this course is not managed
+                        by this service or cannot be identified. See courseId."
           type: string
-        yearStarted:
-          description: The year in which the participant commenced the course
-          example: 2021
-          type: integer
         setting:
-          $ref: '#/components/schemas/CourseSetting'
+          $ref: '#/components/schemas/CourseParticipationSetting'
         outcome:
           $ref: '#/components/schemas/CourseParticipationOutcome'
         source:
           type: string
 
-    CourseSetting:
-      description: Either Custody or Community
+    CourseParticipationSettingType:
+      description: Either Custody or Community.
       type: string
       enum:
         - custody
         - community
 
+    CourseParticipationSetting:
+      description: Information about where the course was held.
+      type: object
+      properties:
+        location:
+          type: string
+        type:
+          $ref: '#/components/schemas/CourseParticipationSettingType'
+
     CourseParticipationOutcome:
-      description: The outcome of participating in a course
+      description: The outcome of participating in a course.
       type: object
       properties:
         status:
           type: string
           enum:
-            - deselected
             - incomplete
             - complete
         detail:
           type: string
+        yearStarted:
+          type: integer
+        yearCompleted:
+          type: integer
 
     ReferralStarted:
       type: object
@@ -915,15 +915,15 @@ components:
           type: string
           format: uuid
         offeringId:
-          description: The id (UUID) of an active offering
+          description: The id (UUID) of an active offering.
           type: string
           format: uuid
         prisonNumber:
-          description: The prison number of the person who is being referred
+          description: The prison number of the person who is being referred.
           example: "A1234AA"
           type: string
         referrerId:
-          description: A permanent identifier for the person creating the referral. StaffId for prison staff
+          description: A permanent identifier for the person creating the referral. StaffId for prison staff.
           type: string
         reason:
           type: string

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -772,24 +772,6 @@ components:
       required:
         - status
 
-    StartReferral:
-      type: object
-      properties:
-        offeringId:
-          description: The id (UUID) of an active offering
-          type: string
-          format: uuid
-        prisonNumber:
-          description: The prison number of the person who is being referred
-          example: "A1234AA"
-          type: string
-        referrerId:
-          type: string
-      required:
-        - offeringId
-        - prisonNumber
-        - referrerId
-
     CourseParticipationUpdate:
       type: object
       properties:
@@ -867,25 +849,11 @@ components:
         yearCompleted:
           type: integer
 
-    ReferralStarted:
+    StartReferral:
       type: object
       properties:
-        referralId:
-          description: The unique id (UUID) of the new referral.
-          type: string
-          format: uuid
-      required:
-        - referralId
-
-    Referral:
-      type: object
-      properties:
-        id:
-          description: The unique id (UUID) of this referral.
-          type: string
-          format: uuid
         offeringId:
-          description: The id (UUID) of an active offering.
+          description: The id (UUID) of an active offering
           type: string
           format: uuid
         prisonNumber:
@@ -895,20 +863,10 @@ components:
         referrerId:
           description: A permanent identifier for the person creating the referral. StaffId for prison staff.
           type: string
-        reason:
-          type: string
-        oasysConfirmed:
-          type: boolean
-          default: false
-        status:
-          $ref: "#/components/schemas/ReferralStatus"
       required:
-        - id
         - offeringId
         - prisonNumber
         - referrerId
-        - oasysConfirmed
-        - status
 
     ReferralUpdate:
       type: object
@@ -920,6 +878,36 @@ components:
           default: false
       required:
         - oasysConfirmed
+
+    Referral:
+      allOf:
+        - $ref: "#/components/schemas/StartReferral"
+        - $ref: "#/components/schemas/ReferralUpdate"
+        - type: object
+          properties:
+            id:
+              description: The unique id (UUID) of this referral.
+              type: string
+              format: uuid
+            status:
+              $ref: "#/components/schemas/ReferralStatus"
+          required:
+            - id
+            - offeringId
+            - prisonNumber
+            - referrerId
+            - oasysConfirmed
+            - status
+
+    ReferralStarted:
+      type: object
+      properties:
+        referralId:
+          description: The unique id (UUID) of the new referral.
+          type: string
+          format: uuid
+      required:
+        - referralId
 
     StatusUpdate:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/testsupport/RandomDataGenerators.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/testsupport/RandomDataGenerators.kt
@@ -1,36 +1,37 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport
 
-import java.util.Locale
 import kotlin.random.Random
 
-private val charPoolUpperCase = ('A'..'Z').toList()
-private val charPoolLowerCase = ('a'..'z').toList()
-private val charPoolNumbers = ('0'..'9').toList()
+private val upperCase = ('A'..'Z').toList()
+private val lowerCase = ('a'..'z').toList()
+private val digits = ('0'..'9').toList()
 
-private fun randomWithCharPool(charPool: List<Char>, length: Int) = (1..length)
-  .map { Random.nextInt(0, charPool.size) }
-  .map(charPool::get)
-  .joinToString("")
+fun randomAlphanumericString(length: Int) = (upperCase + lowerCase + digits)(length).asString()
 
-fun randomStringMultiCaseWithNumbers(length: Int) = randomWithCharPool(charPoolUpperCase + charPoolLowerCase + charPoolNumbers, length)
+fun randomUppercaseString(length: Int) = upperCase(length).asString()
 
-fun randomStringUpperCase(length: Int) = randomWithCharPool(charPoolUpperCase, length)
+fun randomLowercaseString(length: Int) = lowerCase(length).asString()
 
-fun randomStringLowerCase(length: Int) = randomWithCharPool(charPoolLowerCase, length)
+fun randomUppercaseAlphanumericString(length: Int) = (upperCase + digits)(length).asString()
 
-fun randomStringUpperCaseWithNumbers(length: Int) = randomWithCharPool(charPoolUpperCase + charPoolNumbers, length)
-
-fun randomSentence(wordCountRange: IntRange = 1..20, wordLengthRange: IntRange = 3..10): String =
-  (1..randomInt(wordCountRange.first, wordCountRange.last))
-    .joinToString(" ") {
-      randomWithCharPool(charPoolLowerCase, randomInt(wordLengthRange.first, wordLengthRange.last))
-    }.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
-
-fun randomEmailAddress() = randomWithCharPool(charPoolLowerCase, 5) + "." + randomWithCharPool(charPoolLowerCase, 8) + "@" + randomWithCharPool(charPoolLowerCase, 6) + ".com"
+fun randomSentence(wordRange: IntRange = 1..20, wordLength: IntRange = 3..10): String =
+  (sequenceOf(capitalisedWord(wordLength)) + generateSequence { word(wordLength) })
+    .take(wordRange.random())
+    .reduce { left, right -> left + space() + right }
+    .asString()
 
 fun randomInt(min: Int, max: Int) = Random.nextInt(min, max)
 
-fun Collection<Char>.takeNAtRandom(n: Int): Sequence<Char> = generateSequence { this.random() }.take(n)
-fun prisonNumber(): String = (charPoolUpperCase.takeNAtRandom(1) + charPoolNumbers.takeNAtRandom(4) + charPoolUpperCase.takeNAtRandom(2)).asString()
+private fun space() = sequenceOf(' ')
 
-private fun Sequence<Char>.asString() = fold(StringBuffer()) { buffer, char -> buffer.append(char) }.toString()
+fun word(length: IntRange) = lowerCase(length.random())
+
+fun capitalisedWord(length: IntRange) = upperCase(1) + lowerCase((length).random() - 1)
+
+fun randomEmailAddress() = (lowerCase(5) + ".".asSequence() + lowerCase(8) + "@".asSequence() + lowerCase(6) + ".com".asSequence()).asString()
+
+fun randomPrisonNumber(): String = (upperCase(1) + digits(4) + upperCase(2)).asString()
+
+fun Sequence<Char>.asString() = fold(StringBuilder(), StringBuilder::append).toString()
+
+private operator fun Collection<Char>.invoke(n: Int) = generateSequence { random() }.take(n)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/testsupport/RandomDataGeneratorsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/testsupport/RandomDataGeneratorsTest.kt
@@ -3,9 +3,26 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsup
 import io.kotest.matchers.string.shouldMatch
 import org.junit.jupiter.api.RepeatedTest
 
+private const val TEST_REPEATS = 20
+
 class RandomDataGeneratorsTest {
-  @RepeatedTest(10)
+  @RepeatedTest(TEST_REPEATS)
   fun `should create random prison numbers`() {
-    prisonNumber() shouldMatch "^[A-Z][0-9]{4}[A-Z]{2}$"
+    randomPrisonNumber() shouldMatch "^[A-Z][0-9]{4}[A-Z]{2}$"
+  }
+
+  @RepeatedTest(TEST_REPEATS)
+  fun `should create capitalised word`() {
+    capitalisedWord(1..3).asString() shouldMatch "^[A-Z][a-z]{0,2}$"
+  }
+
+  @RepeatedTest(TEST_REPEATS)
+  fun `should create random sentences`() {
+    randomSentence(1..3, 1..3) shouldMatch "^([A-Z][a-z]{0,2})( [a-z]{1,3}){0,2}$"
+  }
+
+  @RepeatedTest(TEST_REPEATS)
+  fun `should create random email addresses`() {
+    randomEmailAddress() shouldMatch "^[a-z]{5}\\.[a-z]{8}@[a-z]{6}\\.com$"
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseEntityFactory.kt
@@ -2,14 +2,14 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomStringLowerCase
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomStringUpperCase
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomLowercaseString
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomUppercaseString
 import java.util.UUID
 
 class CourseEntityFactory : Factory<CourseEntity> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var name: Yielded<String> = { randomStringLowerCase(6) }
-  private var identifier: Yielded<String> = { randomStringUpperCase(10) }
+  private var name: Yielded<String> = { randomLowercaseString(6) }
+  private var identifier: Yielded<String> = { randomUppercaseString(10) }
   private var description: Yielded<String?> = { null }
   private var alternateName: Yielded<String?> = { null }
   private var referable: Yielded<Boolean> = { true }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/OfferingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/OfferingEntityFactory.kt
@@ -2,13 +2,13 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomAlphanumericString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomEmailAddress
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomStringMultiCaseWithNumbers
 import java.util.UUID
 
 class OfferingEntityFactory : Factory<Offering> {
   private var id: Yielded<UUID> = { UUID.randomUUID() }
-  private var organisationId: Yielded<String> = { randomStringMultiCaseWithNumbers(6) }
+  private var organisationId: Yielded<String> = { randomAlphanumericString(6) }
   private var contactEmail: Yielded<String> = { randomEmailAddress() }
   private var secondaryContactEmail: Yielded<String> = { randomEmailAddress() }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/ReferralEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/ReferralEntityFactory.kt
@@ -2,7 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomStringUpperCaseWithNumbers
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomPrisonNumber
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomUppercaseAlphanumericString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral
 import java.util.UUID
 
@@ -10,8 +11,8 @@ class ReferralEntityFactory : Factory<Referral> {
 
   private var id: Yielded<UUID?> = { UUID.randomUUID() }
   private var offeringId: Yielded<UUID> = { UUID.randomUUID() }
-  private var prisonNumber: Yielded<String> = { randomStringUpperCaseWithNumbers(6) }
-  private var referrerId: Yielded<String> = { randomStringUpperCaseWithNumbers(6) }
+  private var prisonNumber: Yielded<String> = { randomPrisonNumber() }
+  private var referrerId: Yielded<String> = { randomUppercaseAlphanumericString(6) }
   private var reason: Yielded<String?> = { null }
   private var oasysConfirmed: Yielded<Boolean> = { false }
   private var status: Yielded<Referral.Status> = { Referral.Status.REFERRAL_STARTED }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationEntityFactory.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationh
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomPrisonNumber
-import java.time.Year
 import java.util.UUID
 
 class CourseParticipationEntityFactory : Factory<CourseParticipation> {
@@ -12,33 +11,35 @@ class CourseParticipationEntityFactory : Factory<CourseParticipation> {
   private var prisonNumber: Yielded<String> = { randomPrisonNumber() }
   private var courseId: Yielded<UUID?> = { UUID.randomUUID() }
   private var otherCourseName: Yielded<String?> = { null }
-  private var yearStarted: Yielded<Year?> = { null }
   private var source: Yielded<String?> = { null }
-  private var setting: Yielded<CourseSetting?> = { null }
-  private var outcome: Yielded<CourseOutcome?> = { null }
+  private var setting: Yielded<CourseParticipationSetting> = { CourseParticipationSetting(type = CourseSetting.CUSTODY) }
+  private var outcome: Yielded<CourseOutcome> = { CourseOutcome() }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
   }
+
   fun withPrisonNumber(prisonNumber: String) = apply {
     this.prisonNumber = { prisonNumber }
   }
+
   fun withCourseId(courseId: UUID?) = apply {
     this.courseId = { courseId }
   }
+
   fun withOtherCourseName(otherCourseName: String?) = apply {
     this.otherCourseName = { otherCourseName }
   }
-  fun withYearStarted(yearStarted: Year?) = apply {
-    this.yearStarted = { yearStarted }
-  }
+
   fun withSource(source: String?) = apply {
     this.source = { source }
   }
-  fun withSetting(setting: CourseSetting?) = apply {
+
+  fun withSetting(setting: CourseParticipationSetting) = apply {
     this.setting = { setting }
   }
-  fun withOutcome(outcome: CourseOutcome?) = apply {
+
+  fun withOutcome(outcome: CourseOutcome) = apply {
     this.outcome = { outcome }
   }
 
@@ -48,7 +49,6 @@ class CourseParticipationEntityFactory : Factory<CourseParticipation> {
       prisonNumber = this.prisonNumber(),
       courseId = this.courseId(),
       otherCourseName = this.otherCourseName(),
-      yearStarted = this.yearStarted(),
       source = this.source(),
       setting = this.setting(),
       outcome = this.outcome(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationEntityFactory.kt
@@ -2,14 +2,14 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationh
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomStringUpperCaseWithNumbers
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomPrisonNumber
 import java.time.Year
 import java.util.UUID
 
 class CourseParticipationEntityFactory : Factory<CourseParticipation> {
 
   private var id: Yielded<UUID?> = { UUID.randomUUID() }
-  private var prisonNumber: Yielded<String> = { randomStringUpperCaseWithNumbers(6) }
+  private var prisonNumber: Yielded<String> = { randomPrisonNumber() }
   private var courseId: Yielded<UUID?> = { UUID.randomUUID() }
   private var otherCourseName: Yielded<String?> = { null }
   private var yearStarted: Yielded<Year?> = { null }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/repositories/JpaCourseParticipationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/repositories/JpaCourseParticipationRepositoryTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.C
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.repositories.CourseEntityRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipation
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseStatus
 import java.time.Year
@@ -19,47 +20,85 @@ import kotlin.jvm.optionals.getOrNull
 class JpaCourseParticipationRepositoryTest
 @Autowired
 constructor(
-  val courseParticipationRepository: JpaCourseParticipationRepository,
+  val courseParticipationHistoryRepository: JpaCourseParticipationRepository,
   val courseEntityRepository: CourseEntityRepository,
   jdbcTemplate: JdbcTemplate,
 ) : RepositoryTest(jdbcTemplate) {
   @Test
-  fun `It should successfully save and retrieve records`() {
+  fun `It should successfully save and retrieve a CourseParticipation entity`() {
     val courseId = courseEntityRepository.save(CourseEntity(name = "A Course", identifier = "ID")).id!!
 
-    val participationId = courseParticipationRepository.save(
+    val participationId = courseParticipationHistoryRepository.save(
       CourseParticipation(
         courseId = courseId,
         prisonNumber = "A1234AA",
-        otherCourseName = "Other course name",
-        yearStarted = Year.parse("2021"),
+        otherCourseName = null,
         source = "source",
         outcome = CourseOutcome(
           status = CourseStatus.COMPLETE,
           detail = "Course outcome detail",
+          yearStarted = Year.parse("2021"),
+          yearCompleted = Year.parse("2022"),
         ),
-        setting = CourseSetting.CUSTODY,
+        setting = CourseParticipationSetting(
+          type = CourseSetting.CUSTODY,
+          location = "location",
+        ),
       ),
     ).id!!
 
     commitAndStartNewTx()
 
-    val persistentCourseParticipationi = courseParticipationRepository.findById(participationId).getOrNull()
+    val persistentHistory = courseParticipationHistoryRepository.findById(participationId).getOrNull()
 
-    persistentCourseParticipationi.shouldNotBeNull()
+    persistentHistory.shouldNotBeNull()
 
-    persistentCourseParticipationi shouldBeEqualToComparingFields CourseParticipation(
+    persistentHistory shouldBeEqualToComparingFields CourseParticipation(
       id = participationId,
       courseId = courseId,
       prisonNumber = "A1234AA",
-      otherCourseName = "Other course name",
-      yearStarted = Year.parse("2021"),
+      otherCourseName = null,
       source = "source",
       outcome = CourseOutcome(
         status = CourseStatus.COMPLETE,
         detail = "Course outcome detail",
+        yearStarted = Year.parse("2021"),
+        yearCompleted = Year.parse("2022"),
       ),
-      setting = CourseSetting.CUSTODY,
+      setting = CourseParticipationSetting(
+        type = CourseSetting.CUSTODY,
+        location = "location",
+      ),
+    )
+  }
+
+  @Test
+  fun `It should successfully save and retrieve a CourseParticipation entity having all nullable fields set to null`() {
+    val participationId = courseParticipationHistoryRepository.save(
+      CourseParticipation(
+        courseId = null,
+        prisonNumber = "A1234AA",
+        otherCourseName = "Other course name",
+        source = null,
+        setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
+        outcome = CourseOutcome(status = null, detail = null, yearStarted = null, yearCompleted = null),
+      ),
+    ).id!!
+
+    commitAndStartNewTx()
+
+    val persistentHistory = courseParticipationHistoryRepository.findById(participationId).getOrNull()
+
+    persistentHistory.shouldNotBeNull()
+
+    persistentHistory shouldBeEqualToComparingFields CourseParticipation(
+      id = participationId,
+      courseId = null,
+      prisonNumber = "A1234AA",
+      otherCourseName = "Other course name",
+      source = null,
+      setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
+      outcome = CourseOutcome(status = null, detail = null, yearStarted = null, yearCompleted = null),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationControllerTest.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.restapi.
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseStatus
 import java.time.Year
@@ -57,9 +58,8 @@ class CourseParticipationControllerTest(
           courseId = courseId,
           source = "source",
           prisonNumber = "A1234AA",
-          outcome = CourseOutcome(status = CourseStatus.COMPLETE, detail = "Detail"),
-          setting = CourseSetting.CUSTODY,
-          yearStarted = Year.of(2020),
+          outcome = CourseOutcome(status = CourseStatus.COMPLETE, detail = "Detail", yearStarted = Year.of(2020)),
+          setting = CourseParticipationSetting(type = CourseSetting.CUSTODY),
           otherCourseName = null,
         )
       mockMvc.post("/course-participations") {
@@ -92,13 +92,13 @@ class CourseParticipationControllerTest(
         courseId = courseId,
         otherCourseName = null,
         prisonNumber = "A1234AA",
-        yearStarted = Year.of(2020),
         source = "source",
         outcome = CourseOutcome(
           status = CourseStatus.COMPLETE,
           detail = "Detail",
+          yearStarted = Year.of(2020),
         ),
-        setting = CourseSetting.CUSTODY,
+        setting = CourseParticipationSetting(type = CourseSetting.CUSTODY),
       )
     }
 
@@ -160,13 +160,13 @@ class CourseParticipationControllerTest(
         id = courseParticipationId,
         otherCourseName = null,
         courseId = courseId,
-        yearStarted = Year.of(2020),
         prisonNumber = "A1234BC",
         source = "source",
-        setting = CourseSetting.COMMUNITY,
+        setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY),
         outcome = CourseOutcome(
           status = CourseStatus.INCOMPLETE,
           detail = "Detail",
+          yearStarted = Year.of(2020),
         ),
       )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationIntegrationTest.kt
@@ -49,6 +49,16 @@ constructor(
         CreateCourseParticipation(
           courseId = courseId,
           prisonNumber = "A1234AA",
+          setting = CourseParticipationSetting(
+            type = CourseParticipationSettingType.custody,
+            location = "location",
+          ),
+          outcome = CourseParticipationOutcome(
+            status = CourseParticipationOutcome.Status.complete,
+            yearStarted = 2021,
+            yearCompleted = 2022,
+            detail = "Some detail",
+          ),
         ),
       ).exchange()
       .expectStatus().isCreated
@@ -72,6 +82,16 @@ constructor(
       id = cpa.id,
       courseId = courseId,
       prisonNumber = "A1234AA",
+      setting = CourseParticipationSetting(
+        type = CourseParticipationSettingType.custody,
+        location = "location",
+      ),
+      outcome = CourseParticipationOutcome(
+        status = CourseParticipationOutcome.Status.complete,
+        yearStarted = 2021,
+        yearCompleted = 2022,
+        detail = "Some detail",
+      ),
     )
   }
 
@@ -90,6 +110,8 @@ constructor(
           courseId = courseId,
           otherCourseName = "A Course",
           prisonNumber = "A1234AA",
+          setting = CourseParticipationSetting(type = CourseParticipationSettingType.custody),
+          outcome = CourseParticipationOutcome(),
         ),
       ).exchange()
       .expectStatus().isBadRequest
@@ -233,6 +255,8 @@ constructor(
         CreateCourseParticipation(
           courseId = courseId,
           prisonNumber = prisonNumber,
+          setting = CourseParticipationSetting(type = CourseParticipationSettingType.community),
+          outcome = CourseParticipationOutcome(),
         ),
       ).exchange()
       .expectStatus().isCreated

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationIntegrationTest.kt
@@ -19,7 +19,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Cours
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CreateCourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.restapi.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.restapi.JwtAuthHelper
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.prisonNumber
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomPrisonNumber
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.IntegrationTestBase
 import java.util.UUID
 
@@ -30,7 +30,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Creating a course participation should return 201 with correct body`() {
     val courseId = getFirstCourseId()
-    val prisonNumber = prisonNumber()
+    val prisonNumber = randomPrisonNumber()
 
     val createdCourseParticipationId = createCourseParticipation(
       courseId = courseId,
@@ -57,7 +57,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     val createCourseParticipationErrorResponse = createCourseParticipation(
       courseId = getFirstCourseId(),
       otherCourseName = "A Course",
-      prisonNumber = prisonNumber(),
+      prisonNumber = randomPrisonNumber(),
     ).expectStatus().isBadRequest
       .expectBody<ErrorResponse>()
       .returnResult().responseBody!!
@@ -72,7 +72,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Updating a course participation with a valid payload should return 200 with correct body`() {
     val courseId = getFirstCourseId()
-    val prisonNumber = prisonNumber()
+    val prisonNumber = randomPrisonNumber()
 
     val courseParticipationId = createCourseParticipation(
       courseId = courseId,
@@ -119,8 +119,8 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `Searching for a course participation with a valid prison number should return 200 with correct body`() {
-    val prisonNumber = prisonNumber()
-    val otherPrisonNumber = prisonNumber()
+    val prisonNumber = randomPrisonNumber()
+    val otherPrisonNumber = randomPrisonNumber()
 
     val createdCourseParticipationIds = getCourseIds().map {
       createCourseParticipation(
@@ -163,13 +163,13 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     getCourseIds().forEach {
       createCourseParticipation(
         courseId = it,
-        prisonNumber = prisonNumber(),
+        prisonNumber = randomPrisonNumber(),
       ).expectStatus().isCreated
         .expectBody<CourseParticipation>()
         .returnResult().responseBody!!
     }
 
-    val randomPrisonNumber = prisonNumber()
+    val randomPrisonNumber = randomPrisonNumber()
 
     val courseParticipationsForPrisonNumber = webTestClient
       .get()
@@ -186,7 +186,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `Deleting a course participation returns 204 with no body`() {
-    val randomPrisonNumber = prisonNumber()
+    val randomPrisonNumber = randomPrisonNumber()
 
     val createdCourseParticipationId = createCourseParticipation(
       courseId = getFirstCourseId(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationIntegrationTest.kt
@@ -2,67 +2,101 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationh
 
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
 import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
+import org.springframework.test.web.reactive.server.returnResult
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Course
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationOutcome
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSetting
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSettingType
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationUpdate
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CreateCourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.restapi.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.restapi.JwtAuthHelper
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomPrisonNumber
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.IntegrationTestBase
 import java.util.UUID
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @Import(JwtAuthHelper::class)
-class CourseParticipationIntegrationTest : IntegrationTestBase() {
+class CourseParticipationIntegrationTest
+@Autowired
+constructor(
+  val webTestClient: WebTestClient,
+  val jwtAuthHelper: JwtAuthHelper,
+) {
   @Test
-  fun `Creating a course participation should return 201 with correct body`() {
+  fun `Add and retrieve a course participation history - happy flow`() {
     val courseId = getFirstCourseId()
-    val prisonNumber = randomPrisonNumber()
 
-    val createdCourseParticipationId = createCourseParticipation(
-      courseId = courseId,
-      prisonNumber = prisonNumber,
-    ).expectStatus().isCreated
+    val cpa = webTestClient
+      .post()
+      .uri("/course-participations")
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .contentType(MediaType.APPLICATION_JSON)
+      .accept(MediaType.APPLICATION_JSON)
+      .bodyValue(
+        CreateCourseParticipation(
+          courseId = courseId,
+          prisonNumber = "A1234AA",
+        ),
+      ).exchange()
+      .expectStatus().isCreated
       .expectBody<CourseParticipation>()
-      .returnResult().responseBody!!.id
+      .returnResult().responseBody!!
 
-    createdCourseParticipationId shouldNotBe null
+    cpa.shouldNotBeNull()
+    cpa.id.shouldNotBeNull()
 
-    val retrievedCourseParticipation = getCourseParticipation(createdCourseParticipationId)
+    val courseParticipation = webTestClient
+      .get()
+      .uri("/course-participations/{id}", cpa.id)
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<CourseParticipation>()
+      .returnResult().responseBody!!
 
-    val expectedCourseParticipation = CourseParticipation(
-      id = createdCourseParticipationId,
+    courseParticipation shouldBe CourseParticipation(
+      id = cpa.id,
       courseId = courseId,
-      prisonNumber = prisonNumber,
+      prisonNumber = "A1234AA",
     )
-
-    retrievedCourseParticipation shouldBe expectedCourseParticipation
   }
 
   @Test
-  fun `Creating a course participation with a valid course id but a different course name should return 400 with error body`() {
-    val createCourseParticipationErrorResponse = createCourseParticipation(
-      courseId = getFirstCourseId(),
-      otherCourseName = "A Course",
-      prisonNumber = randomPrisonNumber(),
-    ).expectStatus().isBadRequest
-      .expectBody<ErrorResponse>()
+  fun `Add a course participation history with courseId and otherCourseName is rejected`() {
+    val courseId = getFirstCourseId()
+
+    val errorResponse = webTestClient
+      .post()
+      .uri("/course-participations")
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .contentType(MediaType.APPLICATION_JSON)
+      .accept(MediaType.APPLICATION_JSON)
+      .bodyValue(
+        CreateCourseParticipation(
+          courseId = courseId,
+          otherCourseName = "A Course",
+          prisonNumber = "A1234AA",
+        ),
+      ).exchange()
+      .expectStatus().isBadRequest
+      .expectBody(ErrorResponse::class.java)
       .returnResult().responseBody!!
 
-    createCourseParticipationErrorResponse shouldBe ErrorResponse(
+    errorResponse shouldBe ErrorResponse(
       HttpStatus.BAD_REQUEST,
       developerMessage = "Expected just one of courseId or otherCourseName but both values are present",
       userMessage = "Business rule violation: Expected just one of courseId or otherCourseName but both values are present",
@@ -70,174 +104,125 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `Updating a course participation with a valid payload should return 200 with correct body`() {
+  fun `Update a course participation history`() {
     val courseId = getFirstCourseId()
-    val prisonNumber = randomPrisonNumber()
 
-    val courseParticipationId = createCourseParticipation(
-      courseId = courseId,
-      prisonNumber = prisonNumber,
-    ).expectStatus().isCreated
-      .expectBody<CourseParticipation>()
-      .returnResult().responseBody!!.id
+    val courseParticipationId = addCourseParticipationHistory(courseId, "A1234AA")
 
-    val updatedCourseParticipation = webTestClient
+    val cp = webTestClient
       .put()
-      .uri("/course-participations/$courseParticipationId")
+      .uri("/course-participations/{id}", courseParticipationId)
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(
         CourseParticipationUpdate(
           courseId = courseId,
-          yearStarted = 2020,
-          setting = CourseSetting.custody,
+          setting = CourseParticipationSetting(
+            type = CourseParticipationSettingType.custody,
+          ),
           outcome = CourseParticipationOutcome(
-            status = CourseParticipationOutcome.Status.deselected,
+            status = CourseParticipationOutcome.Status.incomplete,
             detail = "Some detail",
+            yearStarted = 2020,
           ),
         ),
-      )
-      .exchange().expectStatus().isOk
+      ).exchange()
+      .expectStatus().isOk
       .expectBody<CourseParticipation>()
-      .returnResult().responseBody!!
+      .returnResult().responseBody
 
-    val expectedCourseParticipation = CourseParticipation(
+    val expectedCp = CourseParticipation(
       id = courseParticipationId,
       courseId = courseId,
-      yearStarted = 2020,
-      setting = CourseSetting.custody,
-      prisonNumber = prisonNumber,
+      setting = CourseParticipationSetting(
+        type = CourseParticipationSettingType.custody,
+      ),
+      prisonNumber = "A1234AA",
       outcome = CourseParticipationOutcome(
-        status = CourseParticipationOutcome.Status.deselected,
+        status = CourseParticipationOutcome.Status.incomplete,
         detail = "Some detail",
+        yearStarted = 2020,
       ),
     )
 
-    updatedCourseParticipation shouldBe expectedCourseParticipation
-    getCourseParticipation(courseParticipationId) shouldBe expectedCourseParticipation
+    cp shouldBe expectedCp
+    getCourseParticipation(courseParticipationId) shouldBe expectedCp
   }
 
   @Test
-  fun `Searching for a course participation with a valid prison number should return 200 with correct body`() {
-    val prisonNumber = randomPrisonNumber()
-    val otherPrisonNumber = randomPrisonNumber()
+  fun `find course participation history by prison number returns matches`() {
+    val ids = getCourseIds().map { addCourseParticipationHistory(it, "A1234AA") }.toSet()
+    ids.shouldNotBeEmpty()
 
-    val createdCourseParticipationIds = getCourseIds().map {
-      createCourseParticipation(
-        courseId = it,
-        prisonNumber = prisonNumber,
-      ).expectStatus().isCreated
-        .expectBody<CourseParticipation>()
-        .returnResult().responseBody!!.id
-    }.toSet()
+    val otherIds = getCourseIds().map { addCourseParticipationHistory(it, "Z9999ZZ") }.toSet()
 
-    createdCourseParticipationIds.shouldNotBeEmpty()
-
-    val unrelatedCourseParticipationIds = getCourseIds().map {
-      createCourseParticipation(
-        courseId = it,
-        prisonNumber = otherPrisonNumber,
-      ).expectStatus().isCreated
-        .expectBody<CourseParticipation>()
-        .returnResult().responseBody!!.id
-    }.toSet()
-
-    unrelatedCourseParticipationIds.intersect(createdCourseParticipationIds).shouldBeEmpty()
+    otherIds.intersect(ids).shouldBeEmpty()
 
     val courseIdsForPrisonNumber = webTestClient
       .get()
-      .uri("/people/$prisonNumber/course-participations")
+      .uri("/people/{prisonNumber}/course-participations", "A1234AA")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
       .expectBody<List<CourseParticipation>>()
-      .returnResult().responseBody!!
-      .map { it.id }.toSet()
+      .returnResult().responseBody!!.map { it.id }.toSet()
 
-    courseIdsForPrisonNumber shouldBe createdCourseParticipationIds
+    courseIdsForPrisonNumber shouldBe ids
   }
 
   @Test
-  fun `Searching for a course participation with a random prison number should return 200 with empty body`() {
-    getCourseIds().forEach {
-      createCourseParticipation(
-        courseId = it,
-        prisonNumber = randomPrisonNumber(),
-      ).expectStatus().isCreated
-        .expectBody<CourseParticipation>()
-        .returnResult().responseBody!!
-    }
+  fun `find course participation history by prison number returns no matches`() {
+    getCourseIds().map { addCourseParticipationHistory(it, "A1234AA") }
 
-    val randomPrisonNumber = randomPrisonNumber()
-
-    val courseParticipationsForPrisonNumber = webTestClient
+    webTestClient
       .get()
-      .uri("/people/$randomPrisonNumber/course-participations")
+      .uri("/people/{prisonNumber}/course-participations", "Z0000ZZ")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
       .expectBody<List<CourseParticipation>>()
-      .returnResult().responseBody!!
-
-    courseParticipationsForPrisonNumber shouldBe emptyList()
+      .returnResult().responseBody!!.shouldBeEmpty()
   }
 
   @Test
-  fun `Deleting a course participation returns 204 with no body`() {
-    val randomPrisonNumber = randomPrisonNumber()
-
-    val createdCourseParticipationId = createCourseParticipation(
-      courseId = getFirstCourseId(),
-      prisonNumber = randomPrisonNumber,
-    ).expectStatus().isCreated
-      .expectBody<CourseParticipation>()
-      .returnResult().responseBody!!.id
-
-    val retrievedCourseParticipationId = getCourseParticipation(createdCourseParticipationId).id
+  fun `delete course participation history`() {
+    val id = addCourseParticipationHistory(getFirstCourseId(), "X9999XX")
+    getCourseParticipationStatusCode(id) shouldBe HttpStatus.OK
 
     webTestClient
       .delete()
-      .uri("/course-participations/$retrievedCourseParticipationId")
+      .uri("/course-participations/{id}", id)
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isNoContent
 
-    webTestClient
-      .get()
-      .uri("/course-participations/$createdCourseParticipationId")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
-      .accept(MediaType.APPLICATION_JSON)
-      .exchange()
-      .expectStatus().isNotFound
+    getCourseParticipationStatusCode(id) shouldBe HttpStatus.NOT_FOUND
 
     webTestClient
       .delete()
-      .uri("/course-participations/$retrievedCourseParticipationId")
+      .uri("/course-participations/{id}", id)
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isNoContent
   }
 
-  fun getCourseParticipation(id: UUID): CourseParticipation =
+  private fun getFirstCourseId(): UUID = getCourseIds().first()
+
+  private fun getCourseIds(): List<UUID> =
     webTestClient
       .get()
-      .uri("/course-participations/$id")
+      .uri("/courses")
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
-      .expectStatus().isOk
-      .expectBody<CourseParticipation>()
-      .returnResult().responseBody!!
+      .expectBody<List<Course>>()
+      .returnResult().responseBody!!.map { it.id }
 
-  fun createCourseParticipation(
-    courseId: UUID,
-    otherCourseName: String? = null,
-    prisonNumber: String,
-  ): WebTestClient.ResponseSpec =
+  private fun addCourseParticipationHistory(courseId: UUID, prisonNumber: String): UUID =
     webTestClient
       .post()
       .uri("/course-participations")
@@ -247,9 +232,30 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
       .bodyValue(
         CreateCourseParticipation(
           courseId = courseId,
-          otherCourseName = otherCourseName,
           prisonNumber = prisonNumber,
         ),
-      )
+      ).exchange()
+      .expectStatus().isCreated
+      .expectBody<CourseParticipation>()
+      .returnResult().responseBody!!.id
+
+  private fun getCourseParticipation(id: UUID): CourseParticipation =
+    webTestClient
+      .get()
+      .uri("/course-participations/{id}", id)
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .accept(MediaType.APPLICATION_JSON)
       .exchange()
+      .expectStatus().isOk
+      .expectBody<CourseParticipation>()
+      .returnResult().responseBody!!
+
+  private fun getCourseParticipationStatusCode(id: UUID): HttpStatusCode =
+    webTestClient
+      .get()
+      .uri("/course-participations/{id}", id)
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .returnResult<Any>().status
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
@@ -12,19 +12,25 @@ import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockHttpServletRequestDsl
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.restapi.JwtAuthHelper
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomUppercaseAlphanumericString
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomPrisonNumber
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationSetting
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseStatus
+import java.time.Year
+import java.util.UUID
 
 @WebMvcTest
 @ContextConfiguration(classes = [PeopleControllerTest::class])
 @ComponentScan(
   basePackages = [
     "uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.restapi",
-    "uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.config",
     "uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api",
   ],
 )
@@ -36,50 +42,87 @@ class PeopleControllerTest(
   val jwtAuthHelper: JwtAuthHelper,
 ) {
   @MockkBean
-  private lateinit var courseParticipationService: CourseParticipationService
+  private lateinit var service: CourseParticipationService
 
   @Nested
   inner class FindByPrisonNumber {
     @Test
     fun `GET course-participations with JWT and valid prison number returns 200 with correct body`() {
-      val sharedPrisonNumber = randomUppercaseAlphanumericString(6)
-
-      val courseParticipationHistoryList = listOf(
-        CourseParticipationEntityFactory().withPrisonNumber(sharedPrisonNumber).produce(),
-        CourseParticipationEntityFactory().withPrisonNumber(sharedPrisonNumber).produce(),
+      val prisonNumber = randomPrisonNumber()
+      val courseParticipations = listOf(
+        CourseParticipation(
+          id = UUID.randomUUID(),
+          otherCourseName = null,
+          courseId = UUID.randomUUID(),
+          prisonNumber = prisonNumber,
+          source = "S1",
+          setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = "A location"),
+          outcome = CourseOutcome(status = CourseStatus.INCOMPLETE, detail = "Detail", yearStarted = Year.of(2018), yearCompleted = Year.of(2023)),
+        ),
+        CourseParticipation(
+          id = UUID.randomUUID(),
+          otherCourseName = "A Course Name",
+          courseId = null,
+          prisonNumber = prisonNumber,
+          source = "S2",
+          setting = CourseParticipationSetting(type = CourseSetting.CUSTODY),
+          outcome = CourseOutcome(),
+        ),
       )
 
-      every { courseParticipationService.findByPrisonNumber(any()) } returns courseParticipationHistoryList
+      every { service.findByPrisonNumber(any()) } returns courseParticipations
 
-      mockMvc.get("/people/$sharedPrisonNumber/course-participations") {
+      mockMvc.get("/people/{prisonNumber}/course-participations", "A1234AA") {
         accept = MediaType.APPLICATION_JSON
-        header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+        authorizationHeader()
       }.andExpect {
         status { isOk() }
         content {
-          courseParticipationHistoryList.forEachIndexed { index, entity ->
-            jsonPath("$[$index].id") { value(entity.id.toString()) }
-            jsonPath("$[$index].prisonNumber") { value(sharedPrisonNumber) }
-          }
+          json(
+            strict = true,
+            jsonContent =
+            """[
+              {
+                "id": "${courseParticipations[0].id}",
+                "otherCourseName": null,
+                "courseId": "${courseParticipations[0].courseId}",
+                "prisonNumber": "$prisonNumber",
+                "source": "S1",
+                "setting": { "type": "community", "location": "A location" },
+                "outcome": { "status": "incomplete", "detail": "Detail", "yearStarted": 2018, "yearCompleted": 2023 }
+              },
+              {
+                "id": "${courseParticipations[1].id}",
+                "otherCourseName": "A Course Name",
+                "courseId": null,
+                "prisonNumber": "$prisonNumber",
+                "source": "S2",
+                "setting": { "type": "custody", "location": null },
+                "outcome": { "detail":  null, "status":  null, "yearStarted":  null, "yearCompleted":  null }
+              }
+            ]""",
+          )
         }
       }
 
-      verify { courseParticipationService.findByPrisonNumber(sharedPrisonNumber) }
+      verify { service.findByPrisonNumber("A1234AA") }
     }
 
     @Test
     fun `GET course-participations with JWT and unknown prison number returns 200 with an empty body`() {
-      every { courseParticipationService.findByPrisonNumber(any()) } returns emptyList()
+      every { service.findByPrisonNumber(any()) } returns emptyList()
 
-      mockMvc.get("/people/${randomUppercaseAlphanumericString(6)}/course-participations") {
+      mockMvc.get("/people/{prisonNumber}/course-participations", "A1234AA") {
         accept = MediaType.APPLICATION_JSON
-        header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+        authorizationHeader()
       }.andExpect {
         status { isOk() }
         content {
-          jsonPath("$") { isEmpty() }
+          json("[]")
         }
       }
     }
   }
+
+  private fun MockHttpServletRequestDsl.authorizationHeader() = header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
@@ -15,7 +15,7 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.restapi.JwtAuthHelper
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomStringUpperCaseWithNumbers
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomUppercaseAlphanumericString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationService
 
@@ -42,7 +42,7 @@ class PeopleControllerTest(
   inner class FindByPrisonNumber {
     @Test
     fun `GET course-participations with JWT and valid prison number returns 200 with correct body`() {
-      val sharedPrisonNumber = randomStringUpperCaseWithNumbers(6)
+      val sharedPrisonNumber = randomUppercaseAlphanumericString(6)
 
       val courseParticipationHistoryList = listOf(
         CourseParticipationEntityFactory().withPrisonNumber(sharedPrisonNumber).produce(),
@@ -71,7 +71,7 @@ class PeopleControllerTest(
     fun `GET course-participations with JWT and unknown prison number returns 200 with an empty body`() {
       every { courseParticipationService.findByPrisonNumber(any()) } returns emptyList()
 
-      mockMvc.get("/people/${randomStringUpperCaseWithNumbers(6)}/course-participations") {
+      mockMvc.get("/people/${randomUppercaseAlphanumericString(6)}/course-participations") {
         accept = MediaType.APPLICATION_JSON
         header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       }.andExpect {


### PR DESCRIPTION
## Context

Trello: [Add additional programme history fields to API](https://trello.com/c/kWwW6vM1/862-add-additional-programme-history-fields-to-api)

## Changes in this PR
Expanded the `setting` and `outcome` properties of `CourseParticipation`
* `yearStarted` has been moved to `outcome`, see below
* `setting` now has `var location: String?` and `var type: CourseSetting`
* `outcome` now has additional properties `var yearStarted: Year?` and `var yearCompleted`: Year?`

`outcome` has an additional unused private field
 ```
@Formula("0")
val ignoreMe: Int = 0
```
If all properties of an `@Embedded` object are `null` Hibernate will not create the object. Instead the property (`outcome`) is set `null` - even if it is not a nullable type! The additional non-nullable field `ignoreMe`,  forces Hibernate to populate the `outcome` property with an instance of `CourseOutcome` even when all fields of CourseOutcome are null.

 OpenAPI specifications provide an `allOf` keyword which provides an inheritance mechanism for component schemas.  `allOf` has been used to remove some of the redundancy in `api.yml`.

OpenApi `Operation` objects have an `operationId` field that name each operation. If an `operationId` on an `operation` then the kotlin-spring code generator uses the value of this field as the name of the generated method that handles this operation.  `operationId`s have been added to all the `course-participation` related operations in `api.yml`. Hopefully this makes the generated method names more readable. It also means that those method names do not change when the operation paths are changed.  A future refactoring could add `operationId`s to all operations in the `api.yml` specification.

## Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
