### PR TITLE
862 Course participation audit fields - second step - manual rebase

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/jpa/ExtraJpaConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/jpa/ExtraJpaConfiguration.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.jpa
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.domain.AuditorAware
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.UserDetails
+import java.util.Optional
+
+@Configuration
+@EnableJpaAuditing(modifyOnCreate = false)
+class ExtraJpaConfiguration {
+  @Bean
+  fun auditorAware() = AuditorAware {
+    Optional.ofNullable(
+      when (val principal = SecurityContextHolder.getContext().authentication?.principal) {
+        is String -> principal
+        is UserDetails -> principal.username
+        is Map<*, *> -> principal["username"] as String
+        else -> null
+      },
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipation.kt
@@ -4,17 +4,25 @@ import jakarta.persistence.Column
 import jakarta.persistence.Embeddable
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import org.hibernate.Hibernate
 import org.hibernate.annotations.Formula
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedBy
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.domain.BusinessException
+import java.time.LocalDateTime
 import java.time.Year
 import java.util.UUID
 
 @Entity
+@EntityListeners(AuditingEntityListener::class)
 class CourseParticipation(
   @Id
   @GeneratedValue
@@ -31,6 +39,18 @@ class CourseParticipation(
 
   @Embedded
   val outcome: CourseOutcome,
+
+  @CreatedBy
+  var createdByUsername: String = "anonymous",
+
+  @CreatedDate
+  var createdDateTime: LocalDateTime = LocalDateTime.MIN,
+
+  @LastModifiedBy
+  var lastModifiedByUsername: String? = null,
+
+  @LastModifiedDate
+  var lastModifiedDateTime: LocalDateTime? = null,
 ) {
   fun assertOnlyCourseIdOrCourseNamePresent() {
     if (courseId == null && otherCourseName == null) {
@@ -52,7 +72,7 @@ class CourseParticipation(
 }
 
 @Embeddable
-class CourseParticipationSetting(
+data class CourseParticipationSetting(
   var location: String? = null,
 
   @Enumerated(EnumType.STRING)
@@ -60,7 +80,7 @@ class CourseParticipationSetting(
 )
 
 @Embeddable
-class CourseOutcome(
+data class CourseOutcome(
   @Enumerated(EnumType.STRING)
   @Column(name = "outcome_status")
   var status: CourseStatus? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseStatus
 import java.time.Year
+import java.time.format.DateTimeFormatter
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipation as ApiCourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSetting as ApiCourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationUpdate as ApiCourseParticipationUpdate
@@ -84,4 +85,6 @@ fun CourseParticipation.toApi() = ApiCourseParticipation(
       yearCompleted = yearCompleted?.value,
     )
   },
+  addedBy = createdByUsername,
+  createdAt = createdDateTime.format(DateTimeFormatter.ISO_DATE_TIME),
 )

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -817,8 +817,16 @@ components:
               description: A unique identifier for this record of participation in a course.
               type: string
               format: uuid
+            addedBy:
+              description: The identity of the person who added this CourseParticipation
+              type: string
+            createdAt:
+              description: The date and time at which this CourseParticipation was created. ISO 8601 date-time format.
+              type: string
           required:
             - id
+            - addedBy
+            - createdAt
 
     CourseParticipationSettingType:
       description: Either Custody or Community.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/jpa/RepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/jpa/RepositoryTest.kt
@@ -6,10 +6,14 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.security.authentication.TestingAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.userdetails.User
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.transaction.TestTransaction
 import org.springframework.test.jdbc.JdbcTestUtils
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.TEST_USER_NAME
 
 private const val BASE_PACKAGE = "uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi"
 
@@ -35,6 +39,11 @@ abstract class RepositoryTest(
       "course",
     )
     commitAndStartNewTx()
+  }
+
+  @BeforeEach
+  fun setSecurityContextAuthentication() {
+    SecurityContextHolder.getContext().authentication = TestingAuthenticationToken(User(TEST_USER_NAME, "", emptyList()), null)
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/restapi/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/restapi/JwtAuthHelper.kt
@@ -7,6 +7,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.TEST_USER_NAME
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.interfaces.RSAPublicKey
@@ -30,7 +31,7 @@ class JwtAuthHelper {
   fun authorizationHeaderConfigurer() = { headers: HttpHeaders -> headers.set(HttpHeaders.AUTHORIZATION, bearerToken()) }
 
   fun bearerToken(): String = createJwt(
-    subject = "hmpps-accredited-programmes-ui",
+    subject = TEST_USER_NAME,
     expiryTime = Duration.ofHours(1L),
   ).let { "Bearer $it" }
 
@@ -46,7 +47,7 @@ class JwtAuthHelper {
     subject?.let { claims["user_name"] = it }
     roles?.let { claims["authorities"] = it }
     scope?.let { claims["scope"] = it }
-    claims["client_id"] = "court-reg-client"
+    claims["client_id"] = "hmpps-accredited-programmes-ui"
 
     return Jwts.builder()
       .setId(jwtId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/testsupport/TestConstants.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/testsupport/TestConstants.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport
+
+const val TEST_USER_NAME = "TestUsername"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/repositories/JpaCourseParticipationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/repositories/JpaCourseParticipationRepositoryTest.kt
@@ -1,12 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.repositories
 
-import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.date.shouldBeWithin
+import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.nulls.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.jpa.RepositoryTest
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.jpa.commitAndStartNewTx
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.TEST_USER_NAME
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomPrisonNumber
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.repositories.CourseEntityRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
@@ -14,24 +17,28 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseStatus
+import java.time.Duration
+import java.time.LocalDateTime
 import java.time.Year
 import kotlin.jvm.optionals.getOrNull
 
 class JpaCourseParticipationRepositoryTest
 @Autowired
 constructor(
-  val courseParticipationHistoryRepository: JpaCourseParticipationRepository,
+  val courseParticipationRepository: JpaCourseParticipationRepository,
   val courseEntityRepository: CourseEntityRepository,
   jdbcTemplate: JdbcTemplate,
 ) : RepositoryTest(jdbcTemplate) {
   @Test
   fun `It should successfully save and retrieve a CourseParticipation entity`() {
     val courseId = courseEntityRepository.save(CourseEntity(name = "A Course", identifier = "ID")).id!!
+    val startTime = LocalDateTime.now()
+    val prisonNumber = randomPrisonNumber()
 
-    val participationId = courseParticipationHistoryRepository.save(
+    val participationId = courseParticipationRepository.save(
       CourseParticipation(
         courseId = courseId,
-        prisonNumber = "A1234AA",
+        prisonNumber = prisonNumber,
         otherCourseName = null,
         source = "source",
         outcome = CourseOutcome(
@@ -40,44 +47,45 @@ constructor(
           yearStarted = Year.parse("2021"),
           yearCompleted = Year.parse("2022"),
         ),
-        setting = CourseParticipationSetting(
-          type = CourseSetting.CUSTODY,
-          location = "location",
-        ),
+        setting = CourseParticipationSetting(type = CourseSetting.CUSTODY, location = "location"),
       ),
     ).id!!
 
     commitAndStartNewTx()
 
-    val persistentHistory = courseParticipationHistoryRepository.findById(participationId).getOrNull()
+    val persistentHistory = courseParticipationRepository.findById(participationId).getOrNull()
 
     persistentHistory.shouldNotBeNull()
 
-    persistentHistory shouldBeEqualToComparingFields CourseParticipation(
-      id = participationId,
-      courseId = courseId,
-      prisonNumber = "A1234AA",
-      otherCourseName = null,
-      source = "source",
-      outcome = CourseOutcome(
-        status = CourseStatus.COMPLETE,
-        detail = "Course outcome detail",
-        yearStarted = Year.parse("2021"),
-        yearCompleted = Year.parse("2022"),
+    persistentHistory.shouldBeEqualToIgnoringFields(
+      CourseParticipation(
+        id = participationId,
+        courseId = courseId,
+        prisonNumber = prisonNumber,
+        otherCourseName = null,
+        source = "source",
+        outcome = CourseOutcome(
+          status = CourseStatus.COMPLETE,
+          detail = "Course outcome detail",
+          yearStarted = Year.parse("2021"),
+          yearCompleted = Year.parse("2022"),
+        ),
+        setting = CourseParticipationSetting(type = CourseSetting.CUSTODY, location = "location"),
+        createdByUsername = TEST_USER_NAME,
       ),
-      setting = CourseParticipationSetting(
-        type = CourseSetting.CUSTODY,
-        location = "location",
-      ),
+      CourseParticipation::createdDateTime,
     )
+    persistentHistory.createdDateTime.shouldBeWithin(Duration.ofSeconds(1), startTime)
   }
 
   @Test
   fun `It should successfully save and retrieve a CourseParticipation entity having all nullable fields set to null`() {
-    val participationId = courseParticipationHistoryRepository.save(
+    val prisonNumber = randomPrisonNumber()
+
+    val participationId = courseParticipationRepository.save(
       CourseParticipation(
         courseId = null,
-        prisonNumber = "A1234AA",
+        prisonNumber = prisonNumber,
         otherCourseName = "Other course name",
         source = null,
         setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
@@ -87,18 +95,64 @@ constructor(
 
     commitAndStartNewTx()
 
-    val persistentHistory = courseParticipationHistoryRepository.findById(participationId).getOrNull()
+    val persistentHistory = courseParticipationRepository.findById(participationId).getOrNull()
 
     persistentHistory.shouldNotBeNull()
 
-    persistentHistory shouldBeEqualToComparingFields CourseParticipation(
-      id = participationId,
-      courseId = null,
-      prisonNumber = "A1234AA",
-      otherCourseName = "Other course name",
-      source = null,
-      setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
-      outcome = CourseOutcome(status = null, detail = null, yearStarted = null, yearCompleted = null),
+    persistentHistory.shouldBeEqualToIgnoringFields(
+      CourseParticipation(
+        id = participationId,
+        courseId = null,
+        prisonNumber = prisonNumber,
+        otherCourseName = "Other course name",
+        source = null,
+        setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
+        outcome = CourseOutcome(status = null, detail = null, yearStarted = null, yearCompleted = null),
+        createdByUsername = TEST_USER_NAME,
+      ),
+      CourseParticipation::createdDateTime,
     )
+  }
+
+  @Test
+  fun `save and update a course participation history - audit fields`() {
+    val startTime = LocalDateTime.now()
+    val prisonNumber = randomPrisonNumber()
+
+    val participationId = courseParticipationRepository.save(
+      CourseParticipation(
+        courseId = null,
+        prisonNumber = prisonNumber,
+        otherCourseName = "Other course name",
+        source = null,
+        setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
+        outcome = CourseOutcome(status = null, detail = null, yearStarted = null, yearCompleted = null),
+      ),
+    ).id!!
+
+    val persistentHistory = courseParticipationRepository.findById(participationId).get()
+    persistentHistory.setting.type = CourseSetting.CUSTODY
+
+    commitAndStartNewTx()
+
+    persistentHistory.shouldBeEqualToIgnoringFields(
+      CourseParticipation(
+        id = participationId,
+        courseId = null,
+        prisonNumber = prisonNumber,
+        otherCourseName = "Other course name",
+        source = null,
+        setting = CourseParticipationSetting(type = CourseSetting.CUSTODY, location = null),
+        outcome = CourseOutcome(status = null, detail = null, yearStarted = null, yearCompleted = null),
+        createdByUsername = TEST_USER_NAME,
+        lastModifiedByUsername = TEST_USER_NAME,
+      ),
+      CourseParticipation::createdDateTime,
+      CourseParticipation::lastModifiedDateTime,
+    )
+
+    persistentHistory.createdDateTime.shouldBeWithin(Duration.ofSeconds(1), startTime)
+    persistentHistory.lastModifiedDateTime.shouldNotBeNull()
+    persistentHistory.lastModifiedDateTime!!.shouldBeWithin(Duration.ofSeconds(1), startTime)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationIntegrationTest.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationh
 
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
+import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
@@ -24,6 +26,9 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Cours
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CreateCourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.restapi.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.restapi.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.TEST_USER_NAME
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -37,6 +42,7 @@ constructor(
 ) {
   @Test
   fun `Add and retrieve a course participation history - happy flow`() {
+    val startTime = LocalDateTime.now()
     val courseId = getFirstCourseId()
 
     val cpa = webTestClient
@@ -78,21 +84,28 @@ constructor(
       .expectBody<CourseParticipation>()
       .returnResult().responseBody!!
 
-    courseParticipation shouldBe CourseParticipation(
-      id = cpa.id,
-      courseId = courseId,
-      prisonNumber = "A1234AA",
-      setting = CourseParticipationSetting(
-        type = CourseParticipationSettingType.custody,
-        location = "location",
+    courseParticipation.shouldBeEqualToIgnoringFields(
+      CourseParticipation(
+        id = cpa.id,
+        courseId = courseId,
+        prisonNumber = "A1234AA",
+        setting = CourseParticipationSetting(
+          type = CourseParticipationSettingType.custody,
+          location = "location",
+        ),
+        outcome = CourseParticipationOutcome(
+          status = CourseParticipationOutcome.Status.complete,
+          yearStarted = 2021,
+          yearCompleted = 2022,
+          detail = "Some detail",
+        ),
+        addedBy = TEST_USER_NAME,
+        createdAt = LocalDateTime.MAX.format(DateTimeFormatter.ISO_DATE_TIME),
       ),
-      outcome = CourseParticipationOutcome(
-        status = CourseParticipationOutcome.Status.complete,
-        yearStarted = 2021,
-        yearCompleted = 2022,
-        detail = "Some detail",
-      ),
+      CourseParticipation::createdAt,
     )
+
+    LocalDateTime.parse(courseParticipation.createdAt) shouldBeGreaterThanOrEqualTo startTime
   }
 
   @Test
@@ -127,11 +140,12 @@ constructor(
 
   @Test
   fun `Update a course participation history`() {
+    val startTime = LocalDateTime.now()
     val courseId = getFirstCourseId()
 
     val courseParticipationId = addCourseParticipationHistory(courseId, "A1234AA")
 
-    val cp = webTestClient
+    val courseParticipationFromUpdate = webTestClient
       .put()
       .uri("/course-participations/{id}", courseParticipationId)
       .headers(jwtAuthHelper.authorizationHeaderConfigurer())
@@ -153,7 +167,7 @@ constructor(
       .expectBody<CourseParticipation>()
       .returnResult().responseBody
 
-    val expectedCp = CourseParticipation(
+    val expectedCourseParticipation = CourseParticipation(
       id = courseParticipationId,
       courseId = courseId,
       setting = CourseParticipationSetting(
@@ -165,10 +179,13 @@ constructor(
         detail = "Some detail",
         yearStarted = 2020,
       ),
+      addedBy = TEST_USER_NAME,
+      createdAt = LocalDateTime.MAX.format(DateTimeFormatter.ISO_DATE_TIME),
     )
 
-    cp shouldBe expectedCp
-    getCourseParticipation(courseParticipationId) shouldBe expectedCp
+    courseParticipationFromUpdate.shouldBeEqualToIgnoringFields(expectedCourseParticipation, CourseParticipation::createdAt)
+    LocalDateTime.parse(courseParticipationFromUpdate!!.createdAt) shouldBeGreaterThanOrEqualTo startTime
+    getCourseParticipation(courseParticipationId).shouldBeEqualToIgnoringFields(expectedCourseParticipation, CourseParticipation::createdAt)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.MockHttpServletRequestDsl
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.restapi.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomLowercaseString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomPrisonNumber
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipation
@@ -23,7 +24,9 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationhistory.domain.CourseStatus
+import java.time.LocalDateTime
 import java.time.Year
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 @WebMvcTest
@@ -49,6 +52,9 @@ class PeopleControllerTest(
     @Test
     fun `GET course-participations with JWT and valid prison number returns 200 with correct body`() {
       val prisonNumber = randomPrisonNumber()
+      val createdAt = LocalDateTime.now()
+      val username = randomLowercaseString(10)
+
       val courseParticipations = listOf(
         CourseParticipation(
           id = UUID.randomUUID(),
@@ -58,6 +64,8 @@ class PeopleControllerTest(
           source = "S1",
           setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = "A location"),
           outcome = CourseOutcome(status = CourseStatus.INCOMPLETE, detail = "Detail", yearStarted = Year.of(2018), yearCompleted = Year.of(2023)),
+          createdByUsername = username,
+          createdDateTime = createdAt,
         ),
         CourseParticipation(
           id = UUID.randomUUID(),
@@ -67,6 +75,8 @@ class PeopleControllerTest(
           source = "S2",
           setting = CourseParticipationSetting(type = CourseSetting.CUSTODY),
           outcome = CourseOutcome(),
+          createdByUsername = username,
+          createdDateTime = createdAt,
         ),
       )
 
@@ -89,7 +99,9 @@ class PeopleControllerTest(
                 "prisonNumber": "$prisonNumber",
                 "source": "S1",
                 "setting": { "type": "community", "location": "A location" },
-                "outcome": { "status": "incomplete", "detail": "Detail", "yearStarted": 2018, "yearCompleted": 2023 }
+                "outcome": { "status": "incomplete", "detail": "Detail", "yearStarted": 2018, "yearCompleted": 2023 },
+                "addedBy": "$username",
+                "createdAt": "${createdAt.format(DateTimeFormatter.ISO_DATE_TIME)}"
               },
               {
                 "id": "${courseParticipations[1].id}",
@@ -98,7 +110,9 @@ class PeopleControllerTest(
                 "prisonNumber": "$prisonNumber",
                 "source": "S2",
                 "setting": { "type": "custody", "location": null },
-                "outcome": { "detail":  null, "status":  null, "yearStarted":  null, "yearCompleted":  null }
+                "outcome": { "detail":  null, "status":  null, "yearStarted":  null, "yearCompleted":  null },
+                "addedBy": "$username",
+                "createdAt": "${createdAt.format(DateTimeFormatter.ISO_DATE_TIME)}"
               }
             ]""",
           )


### PR DESCRIPTION
## Context

Trello: [Add additional programme history fields to API](https://trello.com/c/kWwW6vM1/862-add-additional-programme-history-fields-to-api)

## Changes in this PR
The card asks for an `addedBy` (required) text field (name/username?)  and a `createdAt` field to be added to programme history records returned from the API.

This is achieved by 
* Enabling JPA Auditing
* Adding an implementation of the `AuditorAware` interface. The implementation obtains a username from the Spring Security SecurityContext.  The Spring Security implementation extracts this username from the JWT token provided with the request.
* Adding `@EntityListeners(AuditingEntityListener::class` to the `CourseParticipation` to make it auditing aware
* Adding audit properties annotated with `@CreatedBy`,` @CreatedDate`, `@LastModifiedBy` and `@LastModifiedDate`. These are managed by the Spring Data auditing feature.

Repository and integration tests show that the username embedded in the request's JWT is persisted and later returned as the value of the `addedBy` property of responses containing JSON representations of `CourseParticipation` objects.

## Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
