### PR TITLE
862 Add property hasReviewedProgrammeHistory to Referral

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/Referral.kt
@@ -26,6 +26,7 @@ class Referral(
   val referrerId: String,
   var reason: String? = null,
   var oasysConfirmed: Boolean = false,
+  var hasReviewedProgrammeHistory: Boolean = false,
   @Enumerated(STRING)
   var status: Status = REFERRAL_STARTED,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/ReferralService.kt
@@ -21,10 +21,11 @@ class ReferralService(
 
   fun getReferral(referralId: UUID) = referralRepository.findById(referralId).getOrNull()
 
-  fun updateReferral(referralId: UUID, reason: String?, oasysConfirmed: Boolean) {
+  fun updateReferral(referralId: UUID, reason: String?, oasysConfirmed: Boolean, hasReviewedProgrammeHistory: Boolean) {
     val referral = referralRepository.getReferenceById(referralId)
     referral.reason = reason
     referral.oasysConfirmed = oasysConfirmed
+    referral.hasReviewedProgrammeHistory = hasReviewedProgrammeHistory
   }
 
   fun updateReferralStatus(referralId: UUID, nextStatus: Status) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralTransformers.kt
@@ -11,6 +11,7 @@ fun DomainReferral.toApi(): ApiReferral = ApiReferral(
   prisonNumber = prisonNumber,
   referrerId = referrerId,
   oasysConfirmed = oasysConfirmed,
+  hasReviewedProgrammeHistory = hasReviewedProgrammeHistory,
   reason = reason,
   status = status.toApi(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsController.kt
@@ -19,13 +19,15 @@ class ReferralsController(
 ) : ReferralsApiDelegate {
 
   override fun startReferral(startReferral: StartReferral): ResponseEntity<ReferralStarted> =
-    referralService.startReferral(
-      prisonNumber = startReferral.prisonNumber,
-      referrerId = startReferral.referrerId,
-      offeringId = startReferral.offeringId,
-    )?.let {
-      ResponseEntity.status(HttpStatus.CREATED).body(ReferralStarted(it))
-    } ?: throw Exception("Unable to start referral")
+    with(startReferral) {
+      referralService.startReferral(
+        prisonNumber = prisonNumber,
+        referrerId = referrerId,
+        offeringId = offeringId,
+      )?.let {
+        ResponseEntity.status(HttpStatus.CREATED).body(ReferralStarted(it))
+      } ?: throw Exception("Unable to start referral")
+    }
 
   override fun getReferral(id: UUID): ResponseEntity<Referral> =
     referralService
@@ -34,12 +36,13 @@ class ReferralsController(
       ?: throw NotFoundException("No Referral found at /referrals/$id")
 
   override fun updateReferral(id: UUID, referralUpdate: ReferralUpdate): ResponseEntity<Unit> = with(referralUpdate) {
-    referralService.updateReferral(id, reason, oasysConfirmed)
+    referralService.updateReferral(id, reason, oasysConfirmed, hasReviewedProgrammeHistory)
     ResponseEntity.noContent().build()
   }
 
-  override fun updateReferralStatus(id: UUID, statusUpdate: StatusUpdate): ResponseEntity<Unit> {
-    referralService.updateReferralStatus(id, statusUpdate.status.toDomain())
-    return ResponseEntity.noContent().build()
-  }
+  override fun updateReferralStatus(id: UUID, statusUpdate: StatusUpdate): ResponseEntity<Unit> =
+    with(statusUpdate) {
+      referralService.updateReferralStatus(id, status.toDomain())
+      ResponseEntity.noContent().build()
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsController.kt
@@ -18,7 +18,7 @@ class ReferralsController(
   val referralService: ReferralService,
 ) : ReferralsApiDelegate {
 
-  override fun referralsPost(startReferral: StartReferral): ResponseEntity<ReferralStarted> =
+  override fun startReferral(startReferral: StartReferral): ResponseEntity<ReferralStarted> =
     referralService.startReferral(
       prisonNumber = startReferral.prisonNumber,
       referrerId = startReferral.referrerId,
@@ -27,18 +27,18 @@ class ReferralsController(
       ResponseEntity.status(HttpStatus.CREATED).body(ReferralStarted(it))
     } ?: throw Exception("Unable to start referral")
 
-  override fun referralsIdGet(id: UUID): ResponseEntity<Referral> =
+  override fun getReferral(id: UUID): ResponseEntity<Referral> =
     referralService
       .getReferral(id)
       ?.let { ResponseEntity.ok(it.toApi()) }
       ?: throw NotFoundException("No Referral found at /referrals/$id")
 
-  override fun referralsIdPut(id: UUID, referralUpdate: ReferralUpdate): ResponseEntity<Unit> = with(referralUpdate) {
+  override fun updateReferral(id: UUID, referralUpdate: ReferralUpdate): ResponseEntity<Unit> = with(referralUpdate) {
     referralService.updateReferral(id, reason, oasysConfirmed)
     ResponseEntity.noContent().build()
   }
 
-  override fun referralsIdStatusPut(id: UUID, statusUpdate: StatusUpdate): ResponseEntity<Unit> {
+  override fun updateReferralStatus(id: UUID, statusUpdate: StatusUpdate): ResponseEntity<Unit> {
     referralService.updateReferralStatus(id, statusUpdate.status.toDomain())
     return ResponseEntity.noContent().build()
   }

--- a/src/main/resources/db/migration/V19__add_has_reviewed_programme_history_to_referral.sql
+++ b/src/main/resources/db/migration/V19__add_has_reviewed_programme_history_to_referral.sql
@@ -1,0 +1,2 @@
+ALTER TABLE referral
+ADD COLUMN has_reviewed_programme_history BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -225,6 +225,7 @@ paths:
       tags:
         - Referrals
       summary: Start a referral
+      operationId: startReferral
       requestBody:
         required: true
         content:
@@ -249,6 +250,7 @@ paths:
 
     get:
       summary: Retrieve some referrals
+      operationId: getReferrals
       tags:
         - Referrals
       parameters:
@@ -298,6 +300,7 @@ paths:
       tags:
         - Referrals
       summary: Retrieve a referral
+      operationId: getReferral
       parameters:
         - name: id
           in: path
@@ -324,6 +327,7 @@ paths:
       tags:
         - Referrals
       summary: Update a referral
+      operationId: updateReferral
       parameters:
         - name: id
           in: path
@@ -353,6 +357,7 @@ paths:
       summary: Change a referral's status
       tags:
         - Referrals
+      operationId: updateReferralStatus
       parameters:
         - name: id
           in: path

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -889,8 +889,12 @@ components:
         oasysConfirmed:
           type: boolean
           default: false
+        hasReviewedProgrammeHistory:
+          type: boolean
+          default: false
       required:
         - oasysConfirmed
+        - hasReviewedProgrammeHistory
 
     Referral:
       allOf:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/ReferralEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/ReferralEntityFactory.kt
@@ -15,39 +15,49 @@ class ReferralEntityFactory : Factory<Referral> {
   private var referrerId: Yielded<String> = { randomUppercaseAlphanumericString(6) }
   private var reason: Yielded<String?> = { null }
   private var oasysConfirmed: Yielded<Boolean> = { false }
+  private var hasReviewedProgrammeHistory: Yielded<Boolean> = { false }
   private var status: Yielded<Referral.Status> = { Referral.Status.REFERRAL_STARTED }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
   }
+
   fun withOfferingId(offeringId: UUID) = apply {
     this.offeringId = { offeringId }
   }
+
   fun withPrisonNumber(prisonNumber: String) = apply {
     this.prisonNumber = { prisonNumber }
   }
+
   fun withReferrerId(referrerId: String) = apply {
     this.referrerId = { referrerId }
   }
+
   fun withReason(reason: String?) = apply {
     this.reason = { reason }
   }
+
   fun withOasysConfirmed(oasysConfirmed: Boolean) = apply {
     this.oasysConfirmed = { oasysConfirmed }
   }
+
+  fun withHasReviewedProgrammeHistory(hasReviewedProgrammeHistory: Boolean) = apply {
+    this.hasReviewedProgrammeHistory = { hasReviewedProgrammeHistory }
+  }
+
   fun withStatus(status: Referral.Status) = apply {
     this.status = { status }
   }
 
-  override fun produce(): Referral {
-    return Referral(
-      id = this.id(),
-      offeringId = this.offeringId(),
-      prisonNumber = this.prisonNumber(),
-      referrerId = this.referrerId(),
-      reason = this.reason(),
-      oasysConfirmed = this.oasysConfirmed(),
-      status = this.status(),
-    )
-  }
+  override fun produce(): Referral = Referral(
+    id = id(),
+    offeringId = offeringId(),
+    prisonNumber = prisonNumber(),
+    referrerId = referrerId(),
+    reason = reason(),
+    oasysConfirmed = oasysConfirmed(),
+    hasReviewedProgrammeHistory = hasReviewedProgrammeHistory(),
+    status = status(),
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/repositories/JpaReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/repositories/JpaReferralRepositoryTest.kt
@@ -7,6 +7,12 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.jpa.RepositoryTest
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.jpa.commitAndStartNewTx
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomEmailAddress
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomLowercaseString
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomPrisonNumber
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomSentence
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomUppercaseAlphanumericString
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.testsupport.randomUppercaseString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.CourseRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.course.domain.Offering
@@ -22,26 +28,57 @@ constructor(
 ) : RepositoryTest(jdbcTemplate) {
   @Test
   fun `referralRepository should successfully save and retrieve records`() {
-    val persistentOfferingId = persistOffering()
-    val referralId = repository.save(Referral(referrerId = "refId", prisonNumber = "A1234AA", offeringId = persistentOfferingId)).id!!
+    val persistentOfferingId = persistAnOffering()
+    val prisonNumber = randomPrisonNumber()
+    val referrerId = randomUppercaseAlphanumericString(10)
+    val referralId = repository.save(Referral(referrerId = referrerId, prisonNumber = prisonNumber, offeringId = persistentOfferingId)).id!!
 
     commitAndStartNewTx()
 
     repository.findById(referralId) shouldBePresent {
-      referrerId shouldBe "refId"
-      prisonNumber shouldBe "A1234AA"
+      referrerId shouldBe referrerId
+      prisonNumber shouldBe prisonNumber
       offeringId shouldBe persistentOfferingId
+      oasysConfirmed shouldBe false
+      hasReviewedProgrammeHistory shouldBe false
     }
   }
 
-  private fun persistOffering(): UUID {
+  @Test
+  fun `referralRepository should successfully update and retrieve records`() {
+    val persistentOfferingId = persistAnOffering()
+    val prisonNumber = randomPrisonNumber()
+    val referrerId = randomUppercaseAlphanumericString(10)
+    val referralId = repository.save(Referral(referrerId = referrerId, prisonNumber = prisonNumber, offeringId = persistentOfferingId)).id!!
+
+    commitAndStartNewTx()
+
+    val persistentReferral = repository.findById(referralId).get()
+    with(persistentReferral) {
+      oasysConfirmed = true
+      hasReviewedProgrammeHistory = true
+    }
+
+    commitAndStartNewTx()
+
+    repository.findById(referralId) shouldBePresent {
+      referrerId shouldBe referrerId
+      prisonNumber shouldBe prisonNumber
+      offeringId shouldBe persistentOfferingId
+      oasysConfirmed shouldBe true
+      hasReviewedProgrammeHistory shouldBe true
+    }
+  }
+
+  private fun persistAnOffering(): UUID {
+    val courseIdentifier = randomLowercaseString(6)
     courseRepository.saveCourse(
       CourseEntity(
-        identifier = "C",
-        name = "Course",
-        alternateName = "Alt C",
+        identifier = courseIdentifier,
+        name = randomSentence(1..3, 1..8),
+        alternateName = null,
       ).apply {
-        addOffering(Offering(organisationId = "MDI", contactEmail = "a@b.c"))
+        addOffering(Offering(organisationId = randomUppercaseString(3), contactEmail = randomEmailAddress()))
       },
     )
     commitAndStartNewTx()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsControllerTest.kt
@@ -83,6 +83,8 @@ constructor(
     val referral = ReferralEntityFactory()
       .withId(UUID.randomUUID())
       .withOfferingId(UUID.randomUUID())
+      .withOasysConfirmed(true)
+      .withHasReviewedProgrammeHistory(true)
       .produce()
 
     every { referralService.getReferral(any()) } returns referral
@@ -98,7 +100,8 @@ constructor(
         jsonPath("$.prisonNumber") { value(referral.prisonNumber) }
         jsonPath("$.referrerId") { value(referral.referrerId) }
         jsonPath("$.status") { REFERRAL_STARTED }
-        jsonPath("$.oasysConfirmed") { value(false) }
+        jsonPath("$.oasysConfirmed") { value(true) }
+        jsonPath("$.hasReviewedProgrammeHistory") { value(true) }
         jsonPath("$.reason") { doesNotExist() }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/restapi/ReferralsIntegrationTest.kt
@@ -43,6 +43,7 @@ class ReferralsIntegrationTest : IntegrationTestBase() {
       status = ReferralStatus.referralStarted,
       reason = null,
       oasysConfirmed = false,
+      hasReviewedProgrammeHistory = false,
     )
   }
 
@@ -61,6 +62,7 @@ class ReferralsIntegrationTest : IntegrationTestBase() {
         ReferralUpdate(
           reason = "A Reason",
           oasysConfirmed = true,
+          hasReviewedProgrammeHistory = true,
         ),
       )
       .exchange()
@@ -74,6 +76,7 @@ class ReferralsIntegrationTest : IntegrationTestBase() {
       status = ReferralStatus.referralStarted,
       reason = "A Reason",
       oasysConfirmed = true,
+      hasReviewedProgrammeHistory = true,
     )
   }
 


### PR DESCRIPTION
## Context

Trello: [Add additional programme history fields to API](https://trello.com/c/kWwW6vM1/862-add-additional-programme-history-fields-to-api)

## Changes in this PR
Added a new, mandatory, boolean field hasReviewedProgrammeHistory to the data exchanged over api endpoints for referrals.  Field is propagated to database and returned in queries.

## Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
