### PR TITLE
Add an integration test that confirms that a course participation having minimal fields set can be persisted and retrieved.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipation.kt
@@ -76,7 +76,10 @@ data class CourseParticipationSetting(
   var location: String? = null,
 
   @Enumerated(EnumType.STRING)
-  var type: CourseSetting,
+  var type: CourseSetting?,
+
+  @Formula("0")
+  private val ignoreMe: Int = 0, // This unused, non-nullable field forces Hibernate to create an @Embedded instance when all fields are null.
 )
 
 @Embeddable

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
@@ -38,12 +38,12 @@ fun CourseParticipationSettingType.toDomain() = when (this) {
 }
 
 fun ApiCourseParticipationSetting.toDomain() = CourseParticipationSetting(
-  type = type.toDomain(),
+  type = type?.toDomain(),
   location = location,
 )
 
 fun CourseParticipationSetting.toApi() = ApiCourseParticipationSetting(
-  type = type.toApi(),
+  type = type?.toApi(),
   location = location,
 )
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -848,8 +848,6 @@ components:
           type: string
         type:
           $ref: '#/components/schemas/CourseParticipationSettingType'
-      required:
-        - type
 
     CourseParticipationOutcome:
       description: The outcome of participating in a course.


### PR DESCRIPTION
## Context

There's a requirement for creating Course Participation entries with very little information.
This PR makes a small change and adds a test to shows how this can be done.
## Changes in this PR
* Make the 'type' field of CreateCourseParticipation.setting nullable (optional).
* Propagate this through the application.
* Added an integration test to `CourseParticipationIntegrationTest` to show that the scenario works correctly.

## Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
