### PR TITLE
944 Make CourseParticipation`setting` and `outcome` fields optional

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipation.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import org.hibernate.Hibernate
-import org.hibernate.annotations.Formula
 import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
@@ -36,10 +35,10 @@ class CourseParticipation(
   var detail: String?,
 
   @Embedded
-  var setting: CourseParticipationSetting,
+  var setting: CourseParticipationSetting? = null,
 
   @Embedded
-  val outcome: CourseOutcome,
+  var outcome: CourseOutcome? = null,
 
   @CreatedBy
   var createdByUsername: String = "anonymous",
@@ -77,23 +76,17 @@ data class CourseParticipationSetting(
   var location: String? = null,
 
   @Enumerated(EnumType.STRING)
-  var type: CourseSetting?,
-
-  @Formula("0")
-  private val ignoreMe: Int = 0, // This unused, non-nullable field forces Hibernate to create an @Embedded instance when all fields are null.
+  var type: CourseSetting,
 )
 
 @Embeddable
 data class CourseOutcome(
   @Enumerated(EnumType.STRING)
   @Column(name = "outcome_status")
-  var status: CourseStatus? = null,
+  var status: CourseStatus,
 
   var yearStarted: Year? = null,
   var yearCompleted: Year? = null,
-
-  @Formula("0")
-  private val ignoreMe: Int = 0, // This unused, non-nullable field forces Hibernate to create an @Embedded instance when all fields are null.
 )
 
 enum class CourseSetting { CUSTODY, COMMUNITY }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationService.kt
@@ -38,13 +38,23 @@ private fun CourseParticipation.applyUpdate(update: CourseParticipationUpdate): 
     otherCourseName = update.otherCourseName
     source = update.source
     detail = update.detail
-    setting.run {
-      type = update.setting.type
-      location = update.setting.location
+
+    update.setting?.let {
+      if (setting == null) {
+        setting = it
+      } else {
+        setting?.location = it.location
+        setting?.type = it.type
+      }
     }
-    outcome.run {
-      status = update.outcome.status
-      yearStarted = update.outcome.yearStarted
-      yearCompleted = update.outcome.yearCompleted
+
+    update.outcome?.let {
+      if (outcome == null) {
+        outcome = it
+      } else {
+        outcome?.status = it.status
+        outcome?.yearStarted = it.yearStarted
+        outcome?.yearCompleted = it.yearCompleted
+      }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationUpdate.kt
@@ -7,6 +7,6 @@ data class CourseParticipationUpdate(
   val otherCourseName: String?,
   val source: String?,
   val detail: String?,
-  val setting: CourseParticipationSetting,
-  val outcome: CourseOutcome,
+  val setting: CourseParticipationSetting? = null,
+  val outcome: CourseOutcome? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
@@ -22,8 +22,8 @@ fun CreateCourseParticipation.toDomain() =
     otherCourseName = otherCourseName,
     source = source,
     detail = detail,
-    setting = setting.toDomain(),
-    outcome = outcome.toDomain(),
+    setting = setting?.toDomain(),
+    outcome = outcome?.toDomain(),
   )
 
 fun ApiCourseParticipationUpdate.toDomain() = CourseParticipationUpdate(
@@ -31,8 +31,8 @@ fun ApiCourseParticipationUpdate.toDomain() = CourseParticipationUpdate(
   otherCourseName = otherCourseName,
   source = source,
   detail = detail,
-  setting = setting.toDomain(),
-  outcome = outcome.toDomain(),
+  setting = setting?.toDomain(),
+  outcome = outcome?.toDomain(),
 )
 
 fun CourseParticipationSettingType.toDomain() = when (this) {
@@ -41,12 +41,12 @@ fun CourseParticipationSettingType.toDomain() = when (this) {
 }
 
 fun ApiCourseParticipationSetting.toDomain() = CourseParticipationSetting(
-  type = type?.toDomain(),
+  type = type.toDomain(),
   location = location,
 )
 
 fun CourseParticipationSetting.toApi() = ApiCourseParticipationSetting(
-  type = type?.toApi(),
+  type = type.toApi(),
   location = location,
 )
 
@@ -57,7 +57,7 @@ fun CourseSetting.toApi() = when (this) {
 
 fun CourseParticipationOutcome.toDomain() =
   CourseOutcome(
-    status = status?.toDomain(),
+    status = status.toDomain(),
     yearStarted = yearStarted?.let(Year::of),
     yearCompleted = yearCompleted?.let(Year::of),
   )
@@ -75,16 +75,16 @@ fun CourseStatus.toApi() = when (this) {
 fun CourseParticipation.toApi() = ApiCourseParticipation(
   id = id!!,
   prisonNumber = prisonNumber,
-  setting = setting.toApi(),
+  setting = setting?.toApi(),
   courseId = courseId,
   otherCourseName = otherCourseName,
   source = source,
   detail = detail,
-  outcome = with(outcome) {
+  outcome = outcome?.let {
     CourseParticipationOutcome(
-      status = status?.toApi(),
-      yearStarted = yearStarted?.value,
-      yearCompleted = yearCompleted?.value,
+      status = it.status.toApi(),
+      yearStarted = it.yearStarted?.value,
+      yearCompleted = it.yearCompleted?.value,
     )
   },
   addedBy = createdByUsername,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -799,9 +799,6 @@ components:
           type: string
         source:
           type: string
-      required:
-        - setting
-        - outcome
 
     CreateCourseParticipation:
       allOf:
@@ -850,6 +847,8 @@ components:
           type: string
         type:
           $ref: '#/components/schemas/CourseParticipationSettingType'
+      required:
+        - type
 
     CourseParticipationOutcome:
       description: The outcome of participating in a course.
@@ -864,6 +863,8 @@ components:
           type: integer
         yearCompleted:
           type: integer
+      required:
+        - status
 
     StartReferral:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationEntityFactory.kt
@@ -14,7 +14,7 @@ class CourseParticipationEntityFactory : Factory<CourseParticipation> {
   private var source: Yielded<String?> = { null }
   private var detail: Yielded<String?> = { null }
   private var setting: Yielded<CourseParticipationSetting> = { CourseParticipationSetting(type = CourseSetting.CUSTODY) }
-  private var outcome: Yielded<CourseOutcome> = { CourseOutcome() }
+  private var outcome: Yielded<CourseOutcome> = { CourseOutcome(status = CourseStatus.INCOMPLETE) }
 
   fun withId(id: UUID) = apply {
     this.id = { id }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/repositories/JpaCourseParticipationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/repositories/JpaCourseParticipationRepositoryTest.kt
@@ -30,7 +30,7 @@ constructor(
   jdbcTemplate: JdbcTemplate,
 ) : RepositoryTest(jdbcTemplate) {
   @Test
-  fun `It should successfully save and retrieve a CourseParticipation entity`() {
+  fun `Should save and retrieve a CourseParticipation entity`() {
     val courseId = courseEntityRepository.save(CourseEntity(name = "A Course", identifier = "ID")).id!!
     val startTime = LocalDateTime.now()
     val prisonNumber = randomPrisonNumber()
@@ -79,7 +79,7 @@ constructor(
   }
 
   @Test
-  fun `It should successfully save and retrieve a CourseParticipation entity having all nullable fields set to null`() {
+  fun `Should save and retrieve a CourseParticipation entity having all nullable fields set to null`() {
     val prisonNumber = randomPrisonNumber()
 
     val participationId = courseParticipationRepository.save(
@@ -89,8 +89,8 @@ constructor(
         otherCourseName = "Other course name",
         source = null,
         detail = null,
-        setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
-        outcome = CourseOutcome(status = null, yearStarted = null, yearCompleted = null),
+        setting = null,
+        outcome = null,
       ),
     ).id!!
 
@@ -108,8 +108,8 @@ constructor(
         otherCourseName = "Other course name",
         source = null,
         detail = null,
-        setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
-        outcome = CourseOutcome(status = null, yearStarted = null, yearCompleted = null),
+        setting = null,
+        outcome = null,
         createdByUsername = TEST_USER_NAME,
       ),
       CourseParticipation::createdDateTime,
@@ -117,7 +117,7 @@ constructor(
   }
 
   @Test
-  fun `save and update a course participation history - audit fields`() {
+  fun `Should save and update a CouseParticipation entity with all auditable fields`() {
     val startTime = LocalDateTime.now()
     val prisonNumber = randomPrisonNumber()
 
@@ -129,12 +129,12 @@ constructor(
         source = null,
         detail = null,
         setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
-        outcome = CourseOutcome(status = null, yearStarted = null, yearCompleted = null),
+        outcome = CourseOutcome(status = CourseStatus.COMPLETE, yearStarted = null, yearCompleted = null),
       ),
     ).id!!
 
     val persistentHistory = courseParticipationRepository.findById(participationId).get()
-    persistentHistory.setting.type = CourseSetting.CUSTODY
+    persistentHistory.setting?.type = CourseSetting.CUSTODY
 
     commitAndStartNewTx()
 
@@ -147,7 +147,7 @@ constructor(
         source = null,
         detail = null,
         setting = CourseParticipationSetting(type = CourseSetting.CUSTODY, location = null),
-        outcome = CourseOutcome(status = null, yearStarted = null, yearCompleted = null),
+        outcome = CourseOutcome(status = CourseStatus.COMPLETE, yearStarted = null, yearCompleted = null),
         createdByUsername = TEST_USER_NAME,
         lastModifiedByUsername = TEST_USER_NAME,
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
@@ -50,7 +50,7 @@ class PeopleControllerTest(
   @Nested
   inner class FindByPrisonNumber {
     @Test
-    fun `GET course-participations with JWT and valid prison number returns 200 with correct body`() {
+    fun `getCourseParticipationsForPrisonNumber with JWT and valid prison number returns 200 with correct body`() {
       val prisonNumber = randomPrisonNumber()
       val createdAt = LocalDateTime.now()
       val username = randomLowercaseString(10)
@@ -76,7 +76,7 @@ class PeopleControllerTest(
           source = "Source of information 2",
           detail = "Course detail 2",
           setting = CourseParticipationSetting(type = CourseSetting.CUSTODY),
-          outcome = CourseOutcome(),
+          outcome = CourseOutcome(status = CourseStatus.INCOMPLETE),
           createdByUsername = username,
           createdDateTime = createdAt,
         ),
@@ -114,7 +114,7 @@ class PeopleControllerTest(
                 "source": "Source of information 2",
                 "detail": "Course detail 2",
                 "setting": { "type": "custody", "location": null },
-                "outcome": { "status":  null, "yearStarted":  null, "yearCompleted":  null },
+                "outcome": { "status": "incomplete", "yearStarted": null, "yearCompleted":  null },
                 "addedBy": "$username",
                 "createdAt": "${createdAt.format(DateTimeFormatter.ISO_DATE_TIME)}"
               }
@@ -127,7 +127,7 @@ class PeopleControllerTest(
     }
 
     @Test
-    fun `GET course-participations with JWT and unknown prison number returns 200 with an empty body`() {
+    fun `getCourseParticipationsForPrisonNumber with JWT and unknown prison number returns 200 with empty body`() {
       every { service.findByPrisonNumber(any()) } returns emptyList()
 
       mockMvc.get("/people/{prisonNumber}/course-participations", "A1234AA") {


### PR DESCRIPTION
## Context

> [see #944 on the Accredited Programmes Trello board.](https://trello.com/c/Vtpg6D7G/944-make-setting-and-outcome-not-required-on-a-courseparticipation-make-type-status-required-api-s)

## Changes in this PR

We [recently](https://github.com/ministryofjustice/hmpps-accredited-programmes-api/pull/133) updated the API to accept an empty object when creating a `CourseParticipation`. Manually submitting its empty embedded objects on creation -`CourseParticipationSetting` and `CourseOutcome` - now seems redundant.

This ticket focuses on removing these as required fields in the OpenApi specification, when `POST`ing to `/course-participations`:

- Removing the `required` flag from `setting` on `CourseParticipation`, and giving the `type` enum property on `CourseParticipationSetting` the `required` flag instead.
- Removing the `required` flag from `outcome` on `CourseParticipation`, and giving the `status` enum property on `CourseOutcome` the `required` flag instead.

This allows us to `POST` a null `setting` or `outcome` object when necessary.

Relevant tests have also been updated (and renamed, where they don't fit the current structure).

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
