### PR TITLE
953 Remove deprecated `detail` attribute from CourseParticipation 2/2

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationService.kt
@@ -44,7 +44,6 @@ private fun CourseParticipation.applyUpdate(update: CourseParticipationUpdate): 
     }
     outcome.run {
       status = update.outcome.status
-      detail = update.outcome.detail
       yearStarted = update.outcome.yearStarted
       yearCompleted = update.outcome.yearCompleted
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationUpdate.kt
@@ -6,7 +6,7 @@ data class CourseParticipationUpdate(
   val courseId: UUID? = null,
   val otherCourseName: String?,
   val source: String?,
-  var detail: String?,
+  val detail: String?,
   val setting: CourseParticipationSetting,
   val outcome: CourseOutcome,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
@@ -58,7 +58,6 @@ fun CourseSetting.toApi() = when (this) {
 fun CourseParticipationOutcome.toDomain() =
   CourseOutcome(
     status = status?.toDomain(),
-    detail = detail,
     yearStarted = yearStarted?.let(Year::of),
     yearCompleted = yearCompleted?.let(Year::of),
   )
@@ -84,7 +83,6 @@ fun CourseParticipation.toApi() = ApiCourseParticipation(
   outcome = with(outcome) {
     CourseParticipationOutcome(
       status = status?.toApi(),
-      detail = detail,
       yearStarted = yearStarted?.value,
       yearCompleted = yearCompleted?.value,
     )

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -860,9 +860,6 @@ components:
           enum:
             - incomplete
             - complete
-        detail:
-          type: string
-          deprecated: true
         yearStarted:
           type: integer
         yearCompleted:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/repositories/JpaCourseParticipationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/repositories/JpaCourseParticipationRepositoryTest.kt
@@ -44,7 +44,6 @@ constructor(
         detail = "Course detail",
         outcome = CourseOutcome(
           status = CourseStatus.COMPLETE,
-          detail = "Course outcome detail",
           yearStarted = Year.parse("2021"),
           yearCompleted = Year.parse("2022"),
         ),
@@ -68,7 +67,6 @@ constructor(
         detail = "Course detail",
         outcome = CourseOutcome(
           status = CourseStatus.COMPLETE,
-          detail = "Course outcome detail",
           yearStarted = Year.parse("2021"),
           yearCompleted = Year.parse("2022"),
         ),
@@ -92,7 +90,7 @@ constructor(
         source = null,
         detail = null,
         setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
-        outcome = CourseOutcome(status = null, detail = null, yearStarted = null, yearCompleted = null),
+        outcome = CourseOutcome(status = null, yearStarted = null, yearCompleted = null),
       ),
     ).id!!
 
@@ -111,7 +109,7 @@ constructor(
         source = null,
         detail = null,
         setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
-        outcome = CourseOutcome(status = null, detail = null, yearStarted = null, yearCompleted = null),
+        outcome = CourseOutcome(status = null, yearStarted = null, yearCompleted = null),
         createdByUsername = TEST_USER_NAME,
       ),
       CourseParticipation::createdDateTime,
@@ -131,7 +129,7 @@ constructor(
         source = null,
         detail = null,
         setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
-        outcome = CourseOutcome(status = null, detail = null, yearStarted = null, yearCompleted = null),
+        outcome = CourseOutcome(status = null, yearStarted = null, yearCompleted = null),
       ),
     ).id!!
 
@@ -149,7 +147,7 @@ constructor(
         source = null,
         detail = null,
         setting = CourseParticipationSetting(type = CourseSetting.CUSTODY, location = null),
-        outcome = CourseOutcome(status = null, detail = null, yearStarted = null, yearCompleted = null),
+        outcome = CourseOutcome(status = null, yearStarted = null, yearCompleted = null),
         createdByUsername = TEST_USER_NAME,
         lastModifiedByUsername = TEST_USER_NAME,
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationControllerTest.kt
@@ -59,7 +59,7 @@ class CourseParticipationControllerTest(
           source = "Source of information",
           detail = "Course detail",
           prisonNumber = "A1234AA",
-          outcome = CourseOutcome(status = CourseStatus.COMPLETE, detail = "Course outcome detail", yearStarted = Year.of(2020)),
+          outcome = CourseOutcome(status = CourseStatus.COMPLETE, yearStarted = Year.of(2020)),
           setting = CourseParticipationSetting(type = CourseSetting.CUSTODY),
           otherCourseName = null,
         )
@@ -79,7 +79,6 @@ class CourseParticipationControllerTest(
             },
             "outcome": {
               "status": "complete",
-              "detail": "Course outcome detail",
               "yearStarted": 2020
             }
           }"""
@@ -98,7 +97,6 @@ class CourseParticipationControllerTest(
         detail = "Course detail",
         outcome = CourseOutcome(
           status = CourseStatus.COMPLETE,
-          detail = "Course outcome detail",
           yearStarted = Year.of(2020),
         ),
         setting = CourseParticipationSetting(type = CourseSetting.CUSTODY),
@@ -143,7 +141,6 @@ class CourseParticipationControllerTest(
             },
             "outcome": {
               "status": "complete",
-              "detail": "Course outcome detail",
               "yearStarted": 2020
             }
           }"""
@@ -170,7 +167,6 @@ class CourseParticipationControllerTest(
         setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY),
         outcome = CourseOutcome(
           status = CourseStatus.INCOMPLETE,
-          detail = "Course outcome detail",
           yearStarted = Year.of(2020),
         ),
       )
@@ -195,7 +191,6 @@ class CourseParticipationControllerTest(
               },
               "outcome": {
                 "status": "incomplete",
-                "detail": "Course outcome detail",
                 "yearStarted": 2020
               }
             }""",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationIntegrationTest.kt
@@ -60,7 +60,6 @@ constructor(
           status = CourseParticipationOutcome.Status.complete,
           yearStarted = 2021,
           yearCompleted = 2022,
-          detail = "Course outcome detail",
         ),
       ),
     )
@@ -85,7 +84,6 @@ constructor(
           status = CourseParticipationOutcome.Status.complete,
           yearStarted = 2021,
           yearCompleted = 2022,
-          detail = "Course outcome detail",
         ),
         addedBy = TEST_USER_NAME,
         createdAt = LocalDateTime.MAX.format(DateTimeFormatter.ISO_DATE_TIME),
@@ -120,6 +118,7 @@ constructor(
         id = cpa.id,
         courseId = courseId,
         prisonNumber = prisonNumber,
+        source = null,
         detail = null,
         setting = CourseParticipationSetting(),
         outcome = CourseParticipationOutcome(),
@@ -138,6 +137,8 @@ constructor(
       courseId = courseId,
       otherCourseName = "A Course",
       prisonNumber = "A1234AA",
+      source = "Source of information",
+      detail = "Course detail",
       setting = CourseParticipationSetting(type = CourseParticipationSettingType.custody),
       outcome = CourseParticipationOutcome(),
     )
@@ -168,20 +169,18 @@ constructor(
     val courseParticipationId = createCourseParticipation(minimalCourseParticipation(courseId, "A1234AA")).id
     val updatedSource = "Source of information"
     val updatedDetail = "Updated course participation detail"
-    val updatedOutcomeDetail = "Updated course participation outcome detail"
 
     val courseParticipationFromUpdate = updateCourseParticipation(
       courseParticipationId,
       CourseParticipationUpdate(
         courseId = courseId,
-        source = updatedSource,
         setting = CourseParticipationSetting(
           type = CourseParticipationSettingType.custody,
         ),
+        source = updatedSource,
         detail = updatedDetail,
         outcome = CourseParticipationOutcome(
           status = CourseParticipationOutcome.Status.incomplete,
-          detail = updatedOutcomeDetail,
           yearStarted = 2020,
         ),
       ),
@@ -198,7 +197,6 @@ constructor(
       detail = updatedDetail,
       outcome = CourseParticipationOutcome(
         status = CourseParticipationOutcome.Status.incomplete,
-        detail = updatedOutcomeDetail,
         yearStarted = 2020,
       ),
       addedBy = TEST_USER_NAME,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
@@ -64,7 +64,7 @@ class PeopleControllerTest(
           source = "Source of information 1",
           detail = "Course detail 1",
           setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = "A location"),
-          outcome = CourseOutcome(status = CourseStatus.INCOMPLETE, detail = "Course outcome detail", yearStarted = Year.of(2018), yearCompleted = Year.of(2023)),
+          outcome = CourseOutcome(status = CourseStatus.INCOMPLETE, yearStarted = Year.of(2018), yearCompleted = Year.of(2023)),
           createdByUsername = username,
           createdDateTime = createdAt,
         ),
@@ -102,7 +102,7 @@ class PeopleControllerTest(
                 "source": "Source of information 1",
                 "detail": "Course detail 1",
                 "setting": { "type": "community", "location": "A location" },
-                "outcome": { "status": "incomplete", "detail": "Course outcome detail", "yearStarted": 2018, "yearCompleted": 2023 },
+                "outcome": { "status": "incomplete", "yearStarted": 2018, "yearCompleted": 2023 },
                 "addedBy": "$username",
                 "createdAt": "${createdAt.format(DateTimeFormatter.ISO_DATE_TIME)}"
               },
@@ -114,7 +114,7 @@ class PeopleControllerTest(
                 "source": "Source of information 2",
                 "detail": "Course detail 2",
                 "setting": { "type": "custody", "location": null },
-                "outcome": { "detail":  null, "status":  null, "yearStarted":  null, "yearCompleted":  null },
+                "outcome": { "status":  null, "yearStarted":  null, "yearCompleted":  null },
                 "addedBy": "$username",
                 "createdAt": "${createdAt.format(DateTimeFormatter.ISO_DATE_TIME)}"
               }


### PR DESCRIPTION
## Context

>see #137 and [#953 on the Accredited Programmes Trello board.](https://trello.com/c/FKoplgky/953-separate-out-detail-field-from-outcome-on-courseparticipation)

## Changes in this PR

This PR follows on from #137's migration of the `detail` field from within the `CourseOutcome` embedded object to the top-level `CourseParticipation`, due to a refinement of requirements which decouples course participation details from the outcome of that course - namely by removing the now-deprecated original field.

Associated unit and integration tests are similarly updated.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
