### PR TITLE
Use `Hibernate.getClass(this)` in entity `equals` methods 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseEntity.kt
@@ -14,6 +14,7 @@ import jakarta.persistence.ManyToMany
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.persistence.Transient
+import org.hibernate.Hibernate
 import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode.SUBSELECT
 import org.hibernate.annotations.Immutable
@@ -64,7 +65,8 @@ class CourseEntity(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other == null || other !is CourseEntity) return false
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as CourseEntity
     return id != null && id == other.id
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/CourseService.kt
@@ -139,7 +139,7 @@ class CourseService(
       )
     }
 
-    val toUpdate = updatesByPrisonId.keys.intersect(offeringsByOrganisationId.keys)
+    val toUpdate = updatesByPrisonId.keys intersect offeringsByOrganisationId.keys
     toUpdate.forEach {
       val update = updatesByPrisonId[it]
       offeringsByOrganisationId[it]?.run {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/Offering.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/course/domain/Offering.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import org.hibernate.Hibernate
 import java.util.UUID
 
 @Entity
@@ -28,9 +29,12 @@ class Offering(
 
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
-    if (other == null || other !is Offering) return false
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as Offering
     return organisationId == other.organisationId
   }
 
   override fun hashCode(): Int = organisationId.hashCode()
+
+  public override fun toString(): String = "Offering($id, $organisationId, $contactEmail, $secondaryContactEmail, $withdrawn)"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/referral/domain/Referral.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.EnumType.STRING
 import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
+import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.ASSESSMENT_STARTED
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.AWAITING_ASSESSMENT
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.referral.domain.Referral.Status.REFERRAL_STARTED
@@ -30,6 +31,15 @@ class Referral(
   @Enumerated(STRING)
   var status: Status = REFERRAL_STARTED,
 ) {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as Referral
+    return id != null && id == other.id
+  }
+
+  override fun hashCode(): Int = 1004284837
 
   enum class Status {
     REFERRAL_STARTED,


### PR DESCRIPTION
Hibernate `equals` methods should be written in a particular way so that they honour the contract for `equals`:
* If the compared objects are the same by reference then they are equal
* If the compared object is null then they are not equal.
* If both objects are instances of the same class according to the `Hibernate.getClass()` method and both ids are non-null and equal then the objects are equal, otherwise they are not.

Updates `CourseEntity`, `Offering` and `Referral`.

Also changed `CourseService` to use the inline version of the Set method `intersect`.

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
