### PR TITLE
Fix: remove `detail` from CourseParticipation.CourseOutcome domain object

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipation.kt
@@ -89,10 +89,6 @@ data class CourseOutcome(
   @Column(name = "outcome_status")
   var status: CourseStatus? = null,
 
-  @Column(name = "outcome_detail")
-  @Deprecated("use CourseParticipation.detail instead")
-  var detail: String? = null,
-
   var yearStarted: Year? = null,
   var yearCompleted: Year? = null,
 


### PR DESCRIPTION
## Context

This is a tiny housekeeping fix which snuck through the PRs to remove legacy `detail` from the `CourseParticipation`.`CourseOutcome` domain object.

## Changes in this PR

- removes `detail` from `CourseParticipation`.`CourseOutcome`

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
