### PR TITLE
874 Add `courseName` to `CourseParticipation`

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipation.kt
@@ -29,8 +29,14 @@ class CourseParticipation(
   val id: UUID? = null,
 
   val prisonNumber: String,
+  var courseName: String?,
+
+  @Deprecated("please use CourseParticipation.courseName instead")
   var courseId: UUID? = null,
+
+  @Deprecated("please use CourseParticipation.courseName instead")
   var otherCourseName: String?,
+
   var source: String?,
   var detail: String?,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationService.kt
@@ -34,6 +34,7 @@ class CourseParticipationService(
 
 private fun CourseParticipation.applyUpdate(update: CourseParticipationUpdate): CourseParticipation =
   apply {
+    courseName = update.courseName
     courseId = update.courseId
     otherCourseName = update.otherCourseName
     source = update.source

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationUpdate.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.participationh
 import java.util.UUID
 
 data class CourseParticipationUpdate(
+  val courseName: String?,
   val courseId: UUID? = null,
   val otherCourseName: String?,
   val source: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/Transformers.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Cours
 
 fun CreateCourseParticipation.toDomain() =
   CourseParticipation(
+    courseName = courseName,
     prisonNumber = prisonNumber,
     courseId = courseId,
     otherCourseName = otherCourseName,
@@ -27,6 +28,7 @@ fun CreateCourseParticipation.toDomain() =
   )
 
 fun ApiCourseParticipationUpdate.toDomain() = CourseParticipationUpdate(
+  courseName = courseName,
   courseId = courseId,
   otherCourseName = otherCourseName,
   source = source,
@@ -73,6 +75,7 @@ fun CourseStatus.toApi() = when (this) {
 }
 
 fun CourseParticipation.toApi() = ApiCourseParticipation(
+  courseName = courseName,
   id = id!!,
   prisonNumber = prisonNumber,
   setting = setting?.toApi(),

--- a/src/main/resources/db/migration/V21__add_course_name_to_course_participation.sql
+++ b/src/main/resources/db/migration/V21__add_course_name_to_course_participation.sql
@@ -1,0 +1,2 @@
+ALTER TABLE course_participation
+    ADD COLUMN course_name text;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -787,9 +787,14 @@ components:
                         for the course in otherCourseName."
           type: string
           format: uuid
+          deprecated: true
         otherCourseName:
           description: "The name of the course taken by the participant.  It should only be used when this course is not managed
                         by this service or cannot be identified. See courseId."
+          type: string
+          deprecated: true
+        courseName:
+          description: "The name of the course taken by the participant."
           type: string
         setting:
           $ref: '#/components/schemas/CourseParticipationSetting'

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/domain/CourseParticipationEntityFactory.kt
@@ -9,6 +9,7 @@ class CourseParticipationEntityFactory : Factory<CourseParticipation> {
 
   private var id: Yielded<UUID?> = { UUID.randomUUID() }
   private var prisonNumber: Yielded<String> = { randomPrisonNumber() }
+  private var courseName: Yielded<String?> = { null }
   private var courseId: Yielded<UUID?> = { UUID.randomUUID() }
   private var otherCourseName: Yielded<String?> = { null }
   private var source: Yielded<String?> = { null }
@@ -22,6 +23,10 @@ class CourseParticipationEntityFactory : Factory<CourseParticipation> {
 
   fun withPrisonNumber(prisonNumber: String) = apply {
     this.prisonNumber = { prisonNumber }
+  }
+
+  fun withCourseName(courseName: String?) = apply {
+    this.courseName = { courseName }
   }
 
   fun withCourseId(courseId: UUID?) = apply {
@@ -50,6 +55,7 @@ class CourseParticipationEntityFactory : Factory<CourseParticipation> {
 
   override fun produce(): CourseParticipation {
     return CourseParticipation(
+      courseName = this.courseName(),
       id = this.id(),
       prisonNumber = this.prisonNumber(),
       courseId = this.courseId(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/repositories/JpaCourseParticipationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/repositories/JpaCourseParticipationRepositoryTest.kt
@@ -38,6 +38,7 @@ constructor(
     val participationId = courseParticipationRepository.save(
       CourseParticipation(
         courseId = courseId,
+        courseName = "Course name",
         prisonNumber = prisonNumber,
         otherCourseName = null,
         source = "Source of information",
@@ -60,6 +61,7 @@ constructor(
     persistentHistory.shouldBeEqualToIgnoringFields(
       CourseParticipation(
         id = participationId,
+        courseName = "Course name",
         courseId = courseId,
         prisonNumber = prisonNumber,
         otherCourseName = null,
@@ -84,6 +86,7 @@ constructor(
 
     val participationId = courseParticipationRepository.save(
       CourseParticipation(
+        courseName = null,
         courseId = null,
         prisonNumber = prisonNumber,
         otherCourseName = "Other course name",
@@ -103,6 +106,7 @@ constructor(
     persistentHistory.shouldBeEqualToIgnoringFields(
       CourseParticipation(
         id = participationId,
+        courseName = null,
         courseId = null,
         prisonNumber = prisonNumber,
         otherCourseName = "Other course name",
@@ -123,6 +127,7 @@ constructor(
 
     val participationId = courseParticipationRepository.save(
       CourseParticipation(
+        courseName = null,
         courseId = null,
         prisonNumber = prisonNumber,
         otherCourseName = "Other course name",
@@ -141,6 +146,7 @@ constructor(
     persistentHistory.shouldBeEqualToIgnoringFields(
       CourseParticipation(
         id = participationId,
+        courseName = null,
         courseId = null,
         prisonNumber = prisonNumber,
         otherCourseName = "Other course name",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationControllerTest.kt
@@ -54,6 +54,7 @@ class CourseParticipationControllerTest(
       val courseParticipationSlot = slot<CourseParticipation>()
       every { courseParticipationService.addCourseParticipation(capture(courseParticipationSlot)) } returns
         CourseParticipation(
+          courseName = "Course name",
           id = uuid,
           courseId = courseId,
           source = "Source of information",
@@ -69,6 +70,7 @@ class CourseParticipationControllerTest(
         header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
         content = """
           { 
+            "courseName": "Course name",
             "otherCourseName": null,
             "courseId": "$courseId",
             "prisonNumber": "A1234AA",
@@ -90,6 +92,7 @@ class CourseParticipationControllerTest(
       }
       verify { courseParticipationService.addCourseParticipation(any()) }
       courseParticipationSlot.captured shouldBeEqualToComparingFields CourseParticipation(
+        courseName = "Course name",
         courseId = courseId,
         otherCourseName = null,
         prisonNumber = "A1234AA",
@@ -131,6 +134,7 @@ class CourseParticipationControllerTest(
         contentType = MediaType.APPLICATION_JSON
         content = """
           { 
+            "courseName": "Course name",
             "otherCourseName": null,
             "courseId": "${UUID.randomUUID()}",
             "prisonNumber": "A1234AA",
@@ -158,6 +162,7 @@ class CourseParticipationControllerTest(
       val courseId = UUID.randomUUID()
 
       every { courseParticipationService.getCourseParticipation(any()) } returns CourseParticipation(
+        courseName = "Course name",
         id = courseParticipationId,
         otherCourseName = null,
         courseId = courseId,
@@ -180,6 +185,7 @@ class CourseParticipationControllerTest(
           json(
             """
             { 
+              "courseName": "Course name",
               "id": "$courseParticipationId",
               "otherCourseName": null,
               "courseId": "$courseId",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/CourseParticipationIntegrationTest.kt
@@ -48,6 +48,7 @@ constructor(
 
     val cpa = createCourseParticipation(
       CreateCourseParticipation(
+        courseName = "Course name",
         courseId = courseId,
         prisonNumber = "A1234AA",
         source = "Source of information",
@@ -72,6 +73,7 @@ constructor(
     courseParticipation.shouldBeEqualToIgnoringFields(
       CourseParticipation(
         id = cpa.id,
+        courseName = "Course name",
         courseId = courseId,
         prisonNumber = "A1234AA",
         source = "Source of information",
@@ -101,6 +103,7 @@ constructor(
 
     val cpa = createCourseParticipation(
       CreateCourseParticipation(
+        courseName = null,
         courseId = courseId,
         prisonNumber = prisonNumber,
         setting = null,
@@ -113,6 +116,7 @@ constructor(
     courseParticipation.shouldBeEqualToIgnoringFields(
       CourseParticipation(
         id = cpa.id,
+        courseName = null,
         courseId = courseId,
         prisonNumber = prisonNumber,
         source = null,
@@ -131,6 +135,7 @@ constructor(
     val courseId = getFirstCourseId()
 
     val courseParticipation = CreateCourseParticipation(
+      courseName = "Course name",
       courseId = courseId,
       otherCourseName = "A Course",
       prisonNumber = "A1234AA",
@@ -166,10 +171,12 @@ constructor(
     val courseParticipationId = createCourseParticipation(minimalCourseParticipation(courseId, "A1234AA")).id
     val updatedSource = "Source of information"
     val updatedDetail = "Updated course participation detail"
+    val updatedCourseName = "Updated course name"
 
     val courseParticipationFromUpdate = updateCourseParticipation(
       courseParticipationId,
       CourseParticipationUpdate(
+        courseName = updatedCourseName,
         courseId = courseId,
         setting = CourseParticipationSetting(
           type = CourseParticipationSettingType.custody,
@@ -185,6 +192,7 @@ constructor(
 
     val expectedCourseParticipation = CourseParticipation(
       id = courseParticipationId,
+      courseName = updatedCourseName,
       courseId = courseId,
       setting = CourseParticipationSetting(
         type = CourseParticipationSettingType.custody,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/participationhistory/restapi/PeopleControllerTest.kt
@@ -57,6 +57,7 @@ class PeopleControllerTest(
 
       val courseParticipations = listOf(
         CourseParticipation(
+          courseName = "Course name 1",
           id = UUID.randomUUID(),
           otherCourseName = null,
           courseId = UUID.randomUUID(),
@@ -69,6 +70,7 @@ class PeopleControllerTest(
           createdDateTime = createdAt,
         ),
         CourseParticipation(
+          courseName = "Course name 2",
           id = UUID.randomUUID(),
           otherCourseName = "A Course Name",
           courseId = null,
@@ -95,6 +97,7 @@ class PeopleControllerTest(
             jsonContent =
             """[
               {
+                "courseName": "Course name 1",
                 "id": "${courseParticipations[0].id}",
                 "otherCourseName": null,
                 "courseId": "${courseParticipations[0].courseId}",
@@ -107,6 +110,7 @@ class PeopleControllerTest(
                 "createdAt": "${createdAt.format(DateTimeFormatter.ISO_DATE_TIME)}"
               },
               {
+                "courseName": "Course name 2",
                 "id": "${courseParticipations[1].id}",
                 "otherCourseName": "A Course Name",
                 "courseId": null,


### PR DESCRIPTION
## Context

> [see #874 on theAccredited Programmes Trello board.](https://trello.com/c/xWq77vNY/874-add-coursename-field-to-courseparticipation-api-m)

## Changes in this PR

We currently store a `courseId` of an existing course in our service or `otherName` field on a `CourseParticipation`.

Given that `CourseParticipation` is (currently) used to represent courses that a person in prison may have attended that predate courses recorded in our service, it doesn’t feel right to store a `courseId` against it.

This PR adds a `courseName` field in place of these other two fields, whilst maintaining backwards-compatibility.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
