### PR TITLE
973 remove course id and other course name from course participation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 .idea/
 .gradle/
 build/
-
+gradle.properties
 # CMake
 cmake-build-debug/
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseParticipationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseParticipationEntity.kt
@@ -31,12 +31,6 @@ data class CourseParticipationEntity(
   val prisonNumber: String,
   var courseName: String?,
 
-  @Deprecated("please use CourseParticipationEntity.courseName instead")
-  var courseId: UUID? = null,
-
-  @Deprecated("please use CourseParticipationEntity.courseName instead")
-  var otherCourseName: String?,
-
   var source: String?,
   var detail: String?,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/CourseParticipationUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/CourseParticipationUpdate.kt
@@ -2,12 +2,9 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.
 
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationSetting
-import java.util.UUID
 
 data class CourseParticipationUpdate(
   val courseName: String?,
-  val courseId: UUID? = null,
-  val otherCourseName: String?,
   val source: String?,
   val detail: String?,
   val setting: CourseParticipationSetting? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/CourseParticipationTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/CourseParticipationTransformers.kt
@@ -19,8 +19,6 @@ fun ApiCreateCourseParticipation.toDomain() =
   CourseParticipationEntity(
     courseName = courseName,
     prisonNumber = prisonNumber,
-    courseId = courseId,
-    otherCourseName = otherCourseName,
     source = source,
     detail = detail,
     setting = setting?.toDomain(),
@@ -29,8 +27,6 @@ fun ApiCreateCourseParticipation.toDomain() =
 
 fun ApiCourseParticipationUpdate.toDomain() = CourseParticipationUpdate(
   courseName = courseName,
-  courseId = courseId,
-  otherCourseName = otherCourseName,
   source = source,
   detail = detail,
   setting = setting?.toDomain(),
@@ -79,8 +75,6 @@ fun CourseParticipationEntity.toApi() = ApiCourseParticipation(
   id = id!!,
   prisonNumber = prisonNumber,
   setting = setting?.toApi(),
-  courseId = courseId,
-  otherCourseName = otherCourseName,
   source = source,
   detail = detail,
   outcome = outcome?.let {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseParticipationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseParticipationService.kt
@@ -38,8 +38,6 @@ constructor(
 private fun CourseParticipationEntity.applyUpdate(update: CourseParticipationUpdate): CourseParticipationEntity =
   apply {
     courseName = update.courseName
-    courseId = update.courseId
-    otherCourseName = update.otherCourseName
     source = update.source
     detail = update.detail
 

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -784,19 +784,6 @@ components:
     CourseParticipationUpdate:
       type: object
       properties:
-        courseId:
-          description: "The identifier of a course currently or previously managed by this service.  
-                        Must be the unique identifier of a course. If the participant's course is not known to this service
-                        or cannot be identified, then this field should not be supplied. Instead, add an arbitrary name 
-                        for the course in otherCourseName."
-          type: string
-          format: uuid
-          deprecated: true
-        otherCourseName:
-          description: "The name of the course taken by the participant.  It should only be used when this course is not managed
-                        by this service or cannot be identified. See courseId."
-          type: string
-          deprecated: true
         courseName:
           description: "The name of the course taken by the participant."
           type: string

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationIntegrationTest.kt
@@ -39,7 +39,6 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     val created = createCourseParticipation(
       CourseParticipationCreate(
         courseName = "Course name",
-        courseId = getFirstCourseId(),
         prisonNumber = "A1234AA",
         source = "Source of information",
         detail = "Course detail",
@@ -64,7 +63,6 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
       CourseParticipation(
         id = created.id,
         courseName = created.courseName,
-        courseId = created.courseId,
         prisonNumber = created.prisonNumber,
         source = created.source,
         detail = created.detail,
@@ -91,7 +89,6 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     val created = createCourseParticipation(
       CourseParticipationCreate(
         courseName = null,
-        courseId = getFirstCourseId(),
         prisonNumber = randomPrisonNumber(),
         setting = null,
         outcome = null,
@@ -104,7 +101,6 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
       CourseParticipation(
         id = created.id,
         courseName = null,
-        courseId = created.courseId,
         prisonNumber = created.prisonNumber,
         source = null,
         detail = null,
@@ -123,7 +119,6 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
 
     val created = createCourseParticipation(
       CourseParticipationCreate(
-        courseId = getFirstCourseId(),
         prisonNumber = "A1234AA",
       ),
     )
@@ -132,7 +127,6 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
       created.id,
       CourseParticipationUpdate(
         courseName = "Course name",
-        courseId = created.courseId,
         setting = CourseParticipationSetting(
           type = CourseParticipationSettingType.custody,
         ),
@@ -151,7 +145,6 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
       CourseParticipation(
         id = created.id,
         courseName = updated.courseName,
-        courseId = created.courseId,
         setting = CourseParticipationSetting(
           type = updated.setting!!.type,
         ),
@@ -180,7 +173,6 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     val expectedPrisonNumberCourseIds = getCourseIds().map {
       createCourseParticipation(
         CourseParticipationCreate(
-          courseId = it,
           prisonNumber = expectedPrisonNumber,
         ),
       ).id
@@ -191,7 +183,6 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     val randomPrisonNumber = getCourseIds().map {
       createCourseParticipation(
         CourseParticipationCreate(
-          courseId = it,
           prisonNumber = otherPrisonNumber,
         ),
       ).id
@@ -208,7 +199,6 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     getCourseIds().forEach {
       createCourseParticipation(
         CourseParticipationCreate(
-          courseId = it,
           prisonNumber = randomPrisonNumber(),
         ),
       )
@@ -221,7 +211,6 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
   fun `Deleting a course participation by id should return 204 with no body`() {
     val created = createCourseParticipation(
       CourseParticipationCreate(
-        courseId = getFirstCourseId(),
         prisonNumber = "X9999XX",
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseParticipationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseParticipationEntityFactory.kt
@@ -63,8 +63,6 @@ class CourseParticipationEntityFactory : Factory<CourseParticipationEntity> {
       courseName = this.courseName(),
       id = this.id(),
       prisonNumber = this.prisonNumber(),
-      courseId = this.courseId(),
-      otherCourseName = this.otherCourseName(),
       source = this.source(),
       detail = this.detail(),
       setting = this.setting(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/JpaCourseParticipationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/JpaCourseParticipationRepositoryTest.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.TEST_USER_NAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomPrisonNumber
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationSetting
@@ -30,16 +29,13 @@ constructor(
 ) : RepositoryTestBase(jdbcTemplate) {
   @Test
   fun `CourseParticipationRepository should save and retrieve CourseParticipationEntity objects`() {
-    val courseId = courseEntityRepository.save(CourseEntity(name = "A Course", identifier = "ID")).id!!
     val startTime = LocalDateTime.now()
     val prisonNumber = randomPrisonNumber()
 
     val participationId = courseParticipationRepository.save(
       CourseParticipationEntity(
-        courseId = courseId,
         courseName = "Course name",
         prisonNumber = prisonNumber,
-        otherCourseName = null,
         source = "Source of information",
         detail = "Course detail",
         outcome = CourseParticipationOutcome(
@@ -61,9 +57,7 @@ constructor(
       CourseParticipationEntity(
         id = participationId,
         courseName = "Course name",
-        courseId = courseId,
         prisonNumber = prisonNumber,
-        otherCourseName = null,
         source = "Source of information",
         detail = "Course detail",
         outcome = CourseParticipationOutcome(
@@ -86,9 +80,7 @@ constructor(
     val participationId = courseParticipationRepository.save(
       CourseParticipationEntity(
         courseName = null,
-        courseId = null,
         prisonNumber = prisonNumber,
-        otherCourseName = "Other course name",
         source = null,
         detail = null,
         setting = null,
@@ -106,9 +98,7 @@ constructor(
       CourseParticipationEntity(
         id = participationId,
         courseName = null,
-        courseId = null,
         prisonNumber = prisonNumber,
-        otherCourseName = "Other course name",
         source = null,
         detail = null,
         setting = null,
@@ -127,9 +117,7 @@ constructor(
     val participationId = courseParticipationRepository.save(
       CourseParticipationEntity(
         courseName = null,
-        courseId = null,
         prisonNumber = prisonNumber,
-        otherCourseName = "Other course name",
         source = null,
         detail = null,
         setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
@@ -146,9 +134,7 @@ constructor(
       CourseParticipationEntity(
         id = participationId,
         courseName = null,
-        courseId = null,
         prisonNumber = prisonNumber,
-        otherCourseName = "Other course name",
         source = null,
         detail = null,
         setting = CourseParticipationSetting(type = CourseSetting.CUSTODY, location = null),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseParticipationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseParticipationControllerTest.kt
@@ -53,13 +53,11 @@ constructor(
         CourseParticipationEntity(
           courseName = "Course name",
           id = uuid,
-          courseId = courseId,
           source = "Source of information",
           detail = "Course detail",
           prisonNumber = "A1234AA",
           outcome = CourseParticipationOutcome(status = CourseStatus.COMPLETE, yearStarted = Year.of(2020)),
           setting = CourseParticipationSetting(type = CourseSetting.CUSTODY),
-          otherCourseName = null,
         )
       mockMvc.post("/course-participations") {
         accept = MediaType.APPLICATION_JSON
@@ -90,8 +88,6 @@ constructor(
       verify { courseParticipationService.createCourseParticipation(any()) }
       courseParticipationSlot.captured shouldBeEqualToComparingFields CourseParticipationEntity(
         courseName = "Course name",
-        courseId = courseId,
-        otherCourseName = null,
         prisonNumber = "A1234AA",
         source = "Source of information",
         detail = "Course detail",
@@ -156,13 +152,10 @@ constructor(
     @Test
     fun `getCourseParticipationById with JWT returns 200 with correct body`() {
       val courseParticipationId = UUID.randomUUID()
-      val courseId = UUID.randomUUID()
 
       every { courseParticipationService.getCourseParticipationById(any()) } returns CourseParticipationEntity(
         courseName = "Course name",
         id = courseParticipationId,
-        otherCourseName = null,
-        courseId = courseId,
         prisonNumber = "A1234BC",
         source = "Source of information",
         detail = "Course detail",
@@ -184,8 +177,6 @@ constructor(
             { 
               "courseName": "Course name",
               "id": "$courseParticipationId",
-              "otherCourseName": null,
-              "courseId": "$courseId",
               "prisonNumber": "A1234BC",
               "source": "Source of information",
               "detail": "Course detail",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/PeopleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/PeopleControllerTest.kt
@@ -54,8 +54,6 @@ constructor(
         CourseParticipationEntity(
           courseName = "Course name 1",
           id = UUID.randomUUID(),
-          otherCourseName = null,
-          courseId = UUID.randomUUID(),
           prisonNumber = prisonNumber,
           source = "Source of information 1",
           detail = "Course detail 1",
@@ -67,8 +65,6 @@ constructor(
         CourseParticipationEntity(
           courseName = "Course name 2",
           id = UUID.randomUUID(),
-          otherCourseName = "A Course Name",
-          courseId = null,
           prisonNumber = prisonNumber,
           source = "Source of information 2",
           detail = "Course detail 2",
@@ -94,8 +90,6 @@ constructor(
               {
                 "courseName": "Course name 1",
                 "id": "${courseParticipations[0].id}",
-                "otherCourseName": null,
-                "courseId": "${courseParticipations[0].courseId}",
                 "prisonNumber": "$prisonNumber",
                 "source": "Source of information 1",
                 "detail": "Course detail 1",
@@ -107,8 +101,6 @@ constructor(
               {
                 "courseName": "Course name 2",
                 "id": "${courseParticipations[1].id}",
-                "otherCourseName": "A Course Name",
-                "courseId": null,
                 "prisonNumber": "$prisonNumber",
                 "source": "Source of information 2",
                 "detail": "Course detail 2",


### PR DESCRIPTION
## Context

https://trello.com/c/8EEamFWG
No env variables needed
No change to architecture. No ADR required

## Changes in this PR
Remove deprecated fields courseId and otherCourseParticipation. Now that we are using a `name` instead of these fields, we have removed these fields. 

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
