### PR TITLE
#958 Add new `courses/course-names` endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseController.kt
@@ -75,4 +75,13 @@ constructor(
           .getAllOfferingsByCourseId(id)
           .map(OfferingEntity::toApi),
       )
+  override fun getAllCourseNames(): ResponseEntity<List<String>> =
+    ResponseEntity
+      .ok(
+        courseService
+          .getAllCourses()
+          .map(CourseEntity::toApi)
+          .map(Course::name)
+          .distinct(),
+      )
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -55,6 +55,22 @@ paths:
                 items:
                   $ref: '#/components/schemas/CourseRecord'
 
+  /courses/course-names:
+    get:
+      tags:
+        - Courses
+      summary: Get all unique course names
+      operationId: getAllCourseNames
+      responses:
+        200:
+          description: Return a JSON representation of all unique course names that are not withdrawn.
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  type: string
+
   /courses/prerequisites/csv:
     put:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
@@ -55,6 +55,28 @@ class CourseIntegrationTest : IntegrationTestBase() {
       .expectStatus().isUnauthorized
   }
 
+  @DirtiesContext
+  @Test
+  fun `Searching for all course names with JWT returns 200 with correct body`() {
+    val courseRecords = generateCourseRecords(3)
+    updateCourses(courseRecords.toCourseCsv())
+
+    val expectedCourseNames = courseRecords.map { it.name }.distinct()
+
+    val responseBodySpec = webTestClient
+      .get()
+      .uri("/courses/course-names")
+      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody()
+
+    expectedCourseNames.forEachIndexed { index, courseName ->
+      responseBodySpec.jsonPath("$[$index]").isEqualTo(courseName)
+    }
+  }
+
   @Test
   fun `Searching for a course with JWT and valid id returns 200 with correct body`() {
     webTestClient


### PR DESCRIPTION
## Context

> see [#958 on the Accredited Programmes Trello board.](https://trello.com/c/ZbZb6IUc/958-add-course-names-endpoint)

## Changes in this PR

The current way in which course names are retrieved do not account for duplicate named results. Whilst the front-end could feasibly deal with each individual request dynamically, by filtering the response from the standard `/courses/` endpoint, we felt it was more prudent to enshrine this sort of filtering functionality in the back-end, in preparation for (and therefore to remain consistent with) later planned tickets for filtering, sorting, and pagination.

In this case, rather than define a `/course-names` endpoint, which would have the OpenApi generator define an entirely new `CourseNamesController` flow, I have implemented this new endpoint under the existing `/courses/` URI string, thus `courses/course-names`.

In the future, if we ever needed to filter further, this endpoint can scope out to e.g. include a filtering term as a path parameter or request body. For now, however, I have kept things simple for the sake of easy integration.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
