### PR TITLE
Housekeeping/testing cleanup

### DIFF
--- a/doc/architecture/diagrams/data-structures/refer.wsd
+++ b/doc/architecture/diagrams/data-structures/refer.wsd
@@ -17,12 +17,10 @@ package "Things we own" {
 
   entity HistoricCourse {
     e.g. Previous course that the person has been on, that aren't in our own service
-    Will have either a courseId or otherCourseName
     --
     * id: uuid
     * prisonNumber: text
-    courseId?: uuid
-    otherCourseName?: text
+    courseName: text
     yearStarted?: integer
     setting?: "Custody" | "Community"
     outcome?: Outcome

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseParticipationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseParticipationEntityFactory.kt
@@ -15,8 +15,6 @@ class CourseParticipationEntityFactory : Factory<CourseParticipationEntity> {
   private var id: Yielded<UUID?> = { UUID.randomUUID() }
   private var prisonNumber: Yielded<String> = { randomPrisonNumber() }
   private var courseName: Yielded<String?> = { null }
-  private var courseId: Yielded<UUID?> = { UUID.randomUUID() }
-  private var otherCourseName: Yielded<String?> = { null }
   private var source: Yielded<String?> = { null }
   private var detail: Yielded<String?> = { null }
   private var setting: Yielded<CourseParticipationSetting> = { CourseParticipationSetting(type = CourseSetting.CUSTODY) }
@@ -32,14 +30,6 @@ class CourseParticipationEntityFactory : Factory<CourseParticipationEntity> {
 
   fun withCourseName(courseName: String?) = apply {
     this.courseName = { courseName }
-  }
-
-  fun withCourseId(courseId: UUID?) = apply {
-    this.courseId = { courseId }
-  }
-
-  fun withOtherCourseName(otherCourseName: String?) = apply {
-    this.otherCourseName = { otherCourseName }
   }
 
   fun withSource(source: String?) = apply {
@@ -60,8 +50,8 @@ class CourseParticipationEntityFactory : Factory<CourseParticipationEntity> {
 
   override fun produce(): CourseParticipationEntity {
     return CourseParticipationEntity(
-      courseName = this.courseName(),
       id = this.id(),
+      courseName = this.courseName(),
       prisonNumber = this.prisonNumber(),
       source = this.source(),
       detail = this.detail(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseParticipationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseParticipationControllerTest.kt
@@ -46,13 +46,12 @@ constructor(
   inner class AddCourseParticipationTests {
     @Test
     fun `createCourseParticipation with JWT and valid payload with valid id returns 201 with correct body`() {
-      val uuid = UUID.randomUUID()
-      val courseId = UUID.randomUUID()
+      val courseParticipationId = UUID.randomUUID()
       val courseParticipationSlot = slot<CourseParticipationEntity>()
       every { courseParticipationService.createCourseParticipation(capture(courseParticipationSlot)) } returns
         CourseParticipationEntity(
+          id = courseParticipationId,
           courseName = "Course name",
-          id = uuid,
           source = "Source of information",
           detail = "Course detail",
           prisonNumber = "A1234AA",
@@ -65,9 +64,8 @@ constructor(
         header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
         content = """
           { 
+            "id": "$courseParticipationId",
             "courseName": "Course name",
-            "otherCourseName": null,
-            "courseId": "$courseId",
             "prisonNumber": "A1234AA",
             "source": "Source of information",
             "detail": "Course detail",
@@ -82,7 +80,7 @@ constructor(
       }.andExpect {
         status { isCreated() }
         content {
-          json(""" { "id": "$uuid" } """)
+          json(""" { "id": "$courseParticipationId" } """)
         }
       }
       verify { courseParticipationService.createCourseParticipation(any()) }
@@ -128,8 +126,6 @@ constructor(
         content = """
           { 
             "courseName": "Course name",
-            "otherCourseName": null,
-            "courseId": "${UUID.randomUUID()}",
             "prisonNumber": "A1234AA",
             "source": "Source of information",
             "detail": "Course detail",
@@ -154,8 +150,8 @@ constructor(
       val courseParticipationId = UUID.randomUUID()
 
       every { courseParticipationService.getCourseParticipationById(any()) } returns CourseParticipationEntity(
-        courseName = "Course name",
         id = courseParticipationId,
+        courseName = "Course name",
         prisonNumber = "A1234BC",
         source = "Source of information",
         detail = "Course detail",
@@ -175,8 +171,8 @@ constructor(
           json(
             """
             { 
-              "courseName": "Course name",
               "id": "$courseParticipationId",
+              "courseName": "Course name",
               "prisonNumber": "A1234BC",
               "source": "Source of information",
               "detail": "Course detail",


### PR DESCRIPTION
## Context

## Changes in this PR

- Slight housekeeping ticket to remove all references to `CourseParticipation`'s legacy `courseId` and `otherCourseName` fields.
- Update service-layer testing for better/cleaner MockK integration.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
