### PR TITLE
#1018 remove legacy reason referral

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
@@ -26,8 +26,6 @@ data class ReferralEntity(
   val offeringId: UUID,
   val prisonNumber: String,
   val referrerId: String,
-  @Deprecated(message = "please use ReferralEntity.additionalInformation instead")
-  var reason: String? = null,
   var additionalInformation: String? = null,
   var oasysConfirmed: Boolean = false,
   var hasReviewedProgrammeHistory: Boolean = false,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/ReferralUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/ReferralUpdate.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update
 
 data class ReferralUpdate(
-  val reason: String?,
   val additionalInformation: String?,
   val oasysConfirmed: Boolean,
   val hasReviewedProgrammeHistory: Boolean,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
@@ -14,7 +14,6 @@ fun ReferralEntity.toApi(): ApiReferral = ApiReferral(
   referrerId = referrerId,
   oasysConfirmed = oasysConfirmed,
   hasReviewedProgrammeHistory = hasReviewedProgrammeHistory,
-  reason = reason,
   additionalInformation = additionalInformation,
   status = status.toApi(),
 )
@@ -34,14 +33,12 @@ fun ApiReferralStatus.toDomain(): ReferralStatus = when (this) {
 }
 
 fun ApiReferralUpdate.toDomain() = ReferralUpdate(
-  reason = reason,
   additionalInformation = additionalInformation,
   oasysConfirmed = oasysConfirmed,
   hasReviewedProgrammeHistory = hasReviewedProgrammeHistory,
 )
 
 fun ReferralUpdate.toApi() = ApiReferralUpdate(
-  reason = reason,
   additionalInformation = additionalInformation,
   oasysConfirmed = oasysConfirmed,
   hasReviewedProgrammeHistory = hasReviewedProgrammeHistory,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -27,7 +27,6 @@ constructor(
 
   fun updateReferralById(referralId: UUID, update: ReferralUpdate) {
     val referral = referralRepository.getReferenceById(referralId)
-    referral.reason = update.reason
     referral.additionalInformation = update.additionalInformation
     referral.oasysConfirmed = update.oasysConfirmed
     referral.hasReviewedProgrammeHistory = update.hasReviewedProgrammeHistory

--- a/src/main/resources/db/migration/V23__migrate_referral_reason_to_additional_information.sql
+++ b/src/main/resources/db/migration/V23__migrate_referral_reason_to_additional_information.sql
@@ -1,0 +1,9 @@
+-- Update additional_information column with values from reason
+-- only if additional_information is empty or null.
+UPDATE referral
+SET additional_information = reason
+WHERE (additional_information IS NULL OR additional_information = '')
+  AND reason IS NOT NULL;
+
+-- Drop the reason column.
+ALTER TABLE referral DROP COLUMN reason;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -900,9 +900,6 @@ components:
     ReferralUpdate:
       type: object
       properties:
-        reason:
-          type: string
-          deprecated: true
         additionalInformation:
           type: string
         oasysConfirmed:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -40,7 +40,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       referrerId = REFERRER_ID,
       prisonNumber = PRISON_NUMBER,
       status = ReferralStatus.referralStarted,
-      reason = null,
       additionalInformation = null,
       oasysConfirmed = false,
       hasReviewedProgrammeHistory = false,
@@ -60,7 +59,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(
         ReferralUpdate(
-          reason = "A Reason",
           additionalInformation = "Additional information",
           oasysConfirmed = true,
           hasReviewedProgrammeHistory = true,
@@ -75,7 +73,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       referrerId = REFERRER_ID,
       prisonNumber = PRISON_NUMBER,
       status = ReferralStatus.referralStarted,
-      reason = "A Reason",
       additionalInformation = "Additional information",
       oasysConfirmed = true,
       hasReviewedProgrammeHistory = true,
@@ -91,7 +88,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(
         ReferralUpdate(
-          reason = "A Reason",
           additionalInformation = "Additional information",
           oasysConfirmed = true,
         ),
@@ -124,7 +120,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       prisonNumber = PRISON_NUMBER,
       status = ReferralStatus.referralSubmitted,
       oasysConfirmed = false,
-      reason = null,
       additionalInformation = null,
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralEntityFactory.kt
@@ -13,7 +13,6 @@ class ReferralEntityFactory : Factory<ReferralEntity> {
   private var offeringId: Yielded<UUID> = { UUID.randomUUID() }
   private var prisonNumber: Yielded<String> = { randomPrisonNumber() }
   private var referrerId: Yielded<String> = { randomUppercaseAlphanumericString(6) }
-  private var reason: Yielded<String?> = { null }
   private var additionalInformation: Yielded<String?> = { null }
   private var oasysConfirmed: Yielded<Boolean> = { false }
   private var hasReviewedProgrammeHistory: Yielded<Boolean> = { false }
@@ -33,10 +32,6 @@ class ReferralEntityFactory : Factory<ReferralEntity> {
 
   fun withReferrerId(referrerId: String) = apply {
     this.referrerId = { referrerId }
-  }
-
-  fun withReason(reason: String?) = apply {
-    this.reason = { reason }
   }
 
   fun withAdditionalInformation(additionalInformation: String?) = apply {
@@ -60,7 +55,6 @@ class ReferralEntityFactory : Factory<ReferralEntity> {
     offeringId = offeringId(),
     prisonNumber = prisonNumber(),
     referrerId = referrerId(),
-    reason = reason(),
     additionalInformation = additionalInformation(),
     oasysConfirmed = oasysConfirmed(),
     hasReviewedProgrammeHistory = hasReviewedProgrammeHistory(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -95,7 +95,6 @@ constructor(
         jsonPath("$.status") { REFERRAL_STARTED }
         jsonPath("$.oasysConfirmed") { value(true) }
         jsonPath("$.hasReviewedProgrammeHistory") { value(true) }
-        jsonPath("$.reason") { doesNotExist() }
         jsonPath("$.additionalInformation") { doesNotExist() }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/transformer/ReferralTransformersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/transformer/ReferralTransformersTest.kt
@@ -47,14 +47,12 @@ class ReferralTransformersTest {
   @Test
   fun `Transforming a ReferralUpdate with all fields should convert to its Domain equivalent`() {
     val apiModel = ApiReferralUpdate(
-      reason = "Some reason",
       additionalInformation = "Additional Info",
       oasysConfirmed = true,
       hasReviewedProgrammeHistory = true,
     )
 
     with(apiModel.toDomain()) {
-      reason shouldBe apiModel.reason
       additionalInformation shouldBe apiModel.additionalInformation
       oasysConfirmed shouldBe apiModel.oasysConfirmed
       hasReviewedProgrammeHistory shouldBe apiModel.hasReviewedProgrammeHistory
@@ -64,14 +62,12 @@ class ReferralTransformersTest {
   @Test
   fun `Transforming a ReferralUpdate with all nullable fields should tolerantly convert to Domain`() {
     val apiModel = ApiReferralUpdate(
-      reason = null,
       additionalInformation = null,
       oasysConfirmed = false,
       hasReviewedProgrammeHistory = false,
     )
 
     with(apiModel.toDomain()) {
-      reason shouldBe null
       additionalInformation shouldBe null
       oasysConfirmed shouldBe false
       hasReviewedProgrammeHistory shouldBe false
@@ -81,14 +77,12 @@ class ReferralTransformersTest {
   @Test
   fun `Transforming a ReferralUpdate with all fields should convert to its API equivalent`() {
     val domainModel = DomainReferralUpdate(
-      reason = "Some reason",
       additionalInformation = "Additional Info",
       oasysConfirmed = true,
       hasReviewedProgrammeHistory = true,
     )
 
     with(domainModel.toApi()) {
-      reason shouldBe domainModel.reason
       additionalInformation shouldBe domainModel.additionalInformation
       oasysConfirmed shouldBe domainModel.oasysConfirmed
       hasReviewedProgrammeHistory shouldBe domainModel.hasReviewedProgrammeHistory
@@ -98,14 +92,12 @@ class ReferralTransformersTest {
   @Test
   fun `Transforming a ReferralUpdate with all nullable fields should tolerantly convert to API`() {
     val domainModel = DomainReferralUpdate(
-      reason = null,
       additionalInformation = null,
       oasysConfirmed = false,
       hasReviewedProgrammeHistory = false,
     )
 
     with(domainModel.toApi()) {
-      reason shouldBe null
       additionalInformation shouldBe null
       oasysConfirmed shouldBe false
       hasReviewedProgrammeHistory shouldBe false


### PR DESCRIPTION
## Context

> [see #1018 on the Accredited Programmes Trello board.](https://trello.com/c/x51DKI0K/1018-remove-legacy-referral-reason-field-in-the-data-model-and-api)
> [for further context, see #860 on the Accredited Programmes Trello board.](https://trello.com/c/ktEadiIa/860-rename-reason-field-to-additionalinformation-in-the-data-model-and-api)

## Changes in this PR

This is the second part of the process to add a column called `additional_information` to the `referral` table.
The first part of this process added the new column and marked its legacy counterpart, `reason`, as deprecated. The associated PR is #152.

- add new Flyway migration to migrate any stored information from `referral.reason` to `referral.additional_information` (giving precedence to the latest changes to either column), then delete `referral.reason`.
- update the OpenApi specification to remove the deprecated `reason` field from all referral components.
- update the entity objects and control flow to account for this change.
- update unit and integration tests for the referral control flow.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [x] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
