### PR TITLE
1033 submit referral

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.c
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.AWAITING_ASSESSMENT
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.REFERRAL_STARTED
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.REFERRAL_SUBMITTED
+import java.time.LocalDateTime
 import java.util.EnumMap
 import java.util.EnumSet
 import java.util.UUID
@@ -24,13 +25,21 @@ data class ReferralEntity(
   val id: UUID? = null,
 
   val offeringId: UUID,
+
   val prisonNumber: String,
+
   val referrerId: String,
+
   var additionalInformation: String? = null,
+
   var oasysConfirmed: Boolean = false,
+
   var hasReviewedProgrammeHistory: Boolean = false,
+
   @Enumerated(STRING)
   var status: ReferralStatus = REFERRAL_STARTED,
+
+  var submittedOn: LocalDateTime? = null,
 ) {
 
   enum class ReferralStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -50,4 +50,11 @@ constructor(
       referralService.updateReferralStatusById(id, status.toDomain())
       ResponseEntity.noContent().build()
     }
+
+  override fun submitReferralById(id: UUID): ResponseEntity<Unit> {
+    referralService.getReferralById(id)?.let {
+      referralService.submitReferralById(id)
+      return ResponseEntity.noContent().build()
+    } ?: throw NotFoundException("No referral found at /referral/$id")
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
@@ -16,6 +16,7 @@ fun ReferralEntity.toApi(): ApiReferral = ApiReferral(
   hasReviewedProgrammeHistory = hasReviewedProgrammeHistory,
   additionalInformation = additionalInformation,
   status = status.toApi(),
+  submittedOn = submittedOn?.toString(),
 )
 
 fun ReferralStatus.toApi(): ApiReferralStatus = when (this) {

--- a/src/main/resources/db/migration/V24__add_submitted_on_to_referral.sql
+++ b/src/main/resources/db/migration/V24__add_submitted_on_to_referral.sql
@@ -1,0 +1,2 @@
+ALTER TABLE referral
+    ADD COLUMN submitted_on TIMESTAMP;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -406,6 +406,30 @@ paths:
         409:
           description: The referral may not change its status to the supplied value.
 
+  /referrals/{id}/submit:
+    post:
+      summary: Submit a completed referral
+      tags:
+        - Referrals
+      operationId: submitReferralById
+      parameters:
+        - name: id
+          in: path
+          description: The id (UUID) of a referral
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        204:
+          description: Submitted a completed referral.
+        401:
+          description: The request was unauthorised.
+        403:
+          description: Forbidden. The client is not authorised to access this referral.
+        404:
+          description: The referral does not exist.
+
   /offerings/{id}/course:
     get:
       tags:
@@ -924,6 +948,8 @@ components:
               format: uuid
             status:
               $ref: "#/components/schemas/ReferralStatus"
+            submittedOn:
+              type: string
           required:
             - id
             - offeringId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/RandomDataGenerators.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/RandomDataGenerators.kt
@@ -31,6 +31,7 @@ fun capitalisedWord(length: IntRange) = upperCase(1) + lowerCase((length).random
 fun randomEmailAddress() = (lowerCase(5) + ".".asSequence() + lowerCase(8) + "@".asSequence() + lowerCase(6) + ".com".asSequence()).asString()
 
 fun randomPrisonNumber(): String = (upperCase(1) + digits(4) + upperCase(2)).asString()
+fun randomReferrerId(): String = (upperCase(3) + digits(4) + upperCase(2)).asString()
 
 fun Sequence<Char>.asString() = fold(StringBuilder(), StringBuilder::append).toString()
 

--- a/src/test/resources/db/migration/R__test_data.sql
+++ b/src/test/resources/db/migration/R__test_data.sql
@@ -24,7 +24,7 @@ VALUES
        ('7fffcc6a-11f8-4713-be35-cf5ff1aee517', 'd3abc217-75ee-46e9-a010-368f30282367', 'MDI', 'nobody-mdi@digital.justice.gov.uk', 'nobody2-mdi@digital.justice.gov.uk'),
        ('7f98826a-616c-4414-a278-525fc02505a0', 'd3abc217-75ee-46e9-a010-368f30282368', 'MDI', 'nobody-mdi@digital.justice.gov.uk', 'nobody2-mdi@digital.justice.gov.uk'),
        ('fee62dde-87f5-4dfd-9a44-e80d48f64be9', 'd3abc217-75ee-46e9-a010-368f30282369', 'MDI', 'nobody-mdi@digital.justice.gov.uk', 'nobody2-mdi@digital.justice.gov.uk'),
-       ('77632e62-135c-4848-a5b9-d3dc6acfc690', 'd3abc217-75ee-46e9-a010-368f30282370', 'MDI', 'nobody-mdi@digital.justice.gov.uk', 'nobody2-mdi@digital.justice.gov.uk');
+       ('be1d407c-3cb5-4c7e-bfee-d104bc79213f', 'd3abc217-75ee-46e9-a010-368f30282370', 'MDI', 'nobody-mdi@digital.justice.gov.uk', 'nobody2-mdi@digital.justice.gov.uk');
 
 INSERT INTO referral (referral_id, offering_id, prison_number, referrer_id, additional_information, oasys_confirmed, has_reviewed_programme_history, status, submitted_on)
 VALUES

--- a/src/test/resources/db/migration/R__test_data.sql
+++ b/src/test/resources/db/migration/R__test_data.sql
@@ -26,7 +26,7 @@ VALUES
        ('fee62dde-87f5-4dfd-9a44-e80d48f64be9', 'd3abc217-75ee-46e9-a010-368f30282369', 'MDI', 'nobody-mdi@digital.justice.gov.uk', 'nobody2-mdi@digital.justice.gov.uk'),
        ('77632e62-135c-4848-a5b9-d3dc6acfc690', 'd3abc217-75ee-46e9-a010-368f30282370', 'MDI', 'nobody-mdi@digital.justice.gov.uk', 'nobody2-mdi@digital.justice.gov.uk');
 
-INSERT INTO referral (referral_id, offering_id, prison_number, referrer_id, additional_information, oasys_confirmed, has_reviewed_programme_history, status)
+INSERT INTO referral (referral_id, offering_id, prison_number, referrer_id, additional_information, oasys_confirmed, has_reviewed_programme_history, status, submitted_on)
 VALUES
-    ('0c46ed09-170b-4c0f-aee8-a24eeaeeddaa', 'd460428c-5cb8-4d73-a3ae-b7ac37b65fbc','1uXTfdH','038019','',false,false,'REFERRAL_STARTED'),
-    ('fae2ed00-057e-4179-9e55-f6a4f4874cf0', 'd460428c-5cb8-4d73-a3ae-b7ac37b65fbc','1uXTfdH','038019','',false,false,'REFERRAL_STARTED');
+    ('0c46ed09-170b-4c0f-aee8-a24eeaeeddaa', 'd460428c-5cb8-4d73-a3ae-b7ac37b65fbc','1uXTfdH','038019','',false,false,'REFERRAL_STARTED',null),
+    ('fae2ed00-057e-4179-9e55-f6a4f4874cf0', 'd460428c-5cb8-4d73-a3ae-b7ac37b65fbc','1uXTfdH','038019','',false,false,'REFERRAL_STARTED',null);


### PR DESCRIPTION
## Context

> [see #1033 on the Accredited Programmes Trello board.](https://trello.com/c/052kKyeR/1033-add-post-referrals-id-submit-endpoint-and-submittedat-field-to-referral-model)

## Changes in this PR

- added a new `submittedOn` property to `ReferralEntity`.
- exposed a new POST endpoint for submitting a referral at `/referrals/{id}/submit`, which changes `status` to `REFERRAL_SUBMITTED` and `submittedOn` to `LocalDateTime.now()`
- added minimal but functional validation to check a referral isn't already submitted.
- updated unit and integration tests.
- updated pact tests (with Anand's assistance).

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
