### PR TITLE
1045 endpoint for returning an organisations referrals only from db

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/JpaReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/JpaReferralRepository.kt
@@ -8,7 +8,9 @@ import java.util.*
 
 @Repository
 interface JpaReferralRepository : JpaRepository<ReferralEntity, UUID> {
-  @Query
-  ("SELECT r.id, r.status, r.prisonNumber, r.referrerId, r.offeringId from ReferralEntity r INNER JOIN OfferingEntity o ON o.id = r.offeringId where o.organisationId = :orgId")
-  fun getReferralsByOrgId(orgId: String): List<ReferralEntity>
+  @Query(
+    value = "SELECT r.* FROM referral r INNER JOIN offering o ON o.offering_id = r.offering_id WHERE o.organisation_id = :organisationId",
+    nativeQuery = true,
+  )
+  fun getReferralsByOrganisationId(organisationId: String): List<ReferralEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/JpaReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/JpaReferralRepository.kt
@@ -1,9 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
-import java.util.UUID
+import java.util.*
 
 @Repository
-interface JpaReferralRepository : JpaRepository<ReferralEntity, UUID>
+interface JpaReferralRepository : JpaRepository<ReferralEntity, UUID> {
+  @Query
+  ("SELECT r.id, r.status, r.prisonNumber, r.referrerId, r.offeringId from ReferralEntity r INNER JOIN OfferingEntity o ON o.id = r.offeringId where o.organisationId = :orgId")
+  fun getReferralsByOrgId(orgId: String): List<ReferralEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -9,10 +9,12 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Refer
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralCreate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralCreated
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatusUpdate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralSummary
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toApi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toDomain
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toReferralSummary
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralService
 import java.util.UUID
 
@@ -57,4 +59,10 @@ constructor(
       return ResponseEntity.noContent().build()
     } ?: throw NotFoundException("No referral found at /referral/$id")
   }
+
+  override fun getReferralSummaryByOrgId(organisationId: String): ResponseEntity<List<ReferralSummary>> =
+    referralService
+      .getReferralSummaryByOrgId(organisationId)
+      .let { ResponseEntity.ok(it.map { referral -> referral.toReferralSummary() }) }
+      ?: throw NotFoundException("No ReferralSummary found at /referrals/organisation/$organisationId/dashboard")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -60,9 +60,8 @@ constructor(
     } ?: throw NotFoundException("No referral found at /referral/$id")
   }
 
-  override fun getReferralSummaryByOrgId(organisationId: String): ResponseEntity<List<ReferralSummary>> =
-    referralService
-      .getReferralSummaryByOrgId(organisationId)
+  override fun getReferralSummariesByOrganisationId(organisationId: String): ResponseEntity<List<ReferralSummary>> =
+    referralService.getReferralsByOrganisationId(organisationId)
       .let { ResponseEntity.ok(it.map { referral -> referral.toReferralSummary() }) }
       ?: throw NotFoundException("No ReferralSummary found at /referrals/organisation/$organisationId/dashboard")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer
 
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Person
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralSummary
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.ReferralUpdate
@@ -44,3 +46,12 @@ fun ReferralUpdate.toApi() = ApiReferralUpdate(
   oasysConfirmed = oasysConfirmed,
   hasReviewedProgrammeHistory = hasReviewedProgrammeHistory,
 )
+
+fun ReferralEntity.toReferralSummary(): ReferralSummary =
+  ReferralSummary(
+    referralId = id!!,
+    referralStatus = status.toApi(),
+    person = Person(
+      prisonNumber = prisonNumber,
+    ),
+  )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer
 
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Person
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralSummary
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.ReferralUpdate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Person as ApiPerson
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Referral as ApiReferral
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus as ApiReferralStatus
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralSummary as ApiReferralSummary
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralUpdate as ApiReferralUpdate
 
 fun ReferralEntity.toApi(): ApiReferral = ApiReferral(
@@ -47,11 +47,10 @@ fun ReferralUpdate.toApi() = ApiReferralUpdate(
   hasReviewedProgrammeHistory = hasReviewedProgrammeHistory,
 )
 
-fun ReferralEntity.toReferralSummary(): ReferralSummary =
-  ReferralSummary(
-    referralId = id!!,
-    referralStatus = status.toApi(),
-    person = Person(
-      prisonNumber = prisonNumber,
-    ),
-  )
+fun ReferralEntity.toReferralSummary() = ApiReferralSummary(
+  referralId = id!!,
+  referralStatus = status.toApi(),
+  person = ApiPerson(
+    prisonNumber = prisonNumber,
+  ),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -78,4 +78,6 @@ constructor(
       }
     }
   }
+
+  fun getReferralSummaryByOrgId(orgId: String) = referralRepository.getReferralsByOrgId(orgId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -25,7 +25,7 @@ constructor(
     referrerId: String,
   ): UUID? = referralRepository.save(ReferralEntity(offeringId = offeringId, prisonNumber = prisonNumber, referrerId = referrerId)).id
 
-  fun getReferralById(referralId: UUID) = referralRepository.findById(referralId).getOrNull()
+  fun getReferralById(referralId: UUID): ReferralEntity? = referralRepository.findById(referralId).getOrNull()
 
   fun updateReferralById(referralId: UUID, update: ReferralUpdate) {
     val referral = referralRepository.getReferenceById(referralId)
@@ -79,5 +79,5 @@ constructor(
     }
   }
 
-  fun getReferralSummaryByOrgId(orgId: String) = referralRepository.getReferralsByOrgId(orgId)
+  fun getReferralsByOrganisationId(organisationId: String) = referralRepository.getReferralsByOrganisationId(organisationId)
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -430,7 +430,7 @@ paths:
         404:
           description: The referral does not exist.
 
-  /referrals/organisation/:organisationId/dashboard:
+  /referrals/organisation/{organisationId}/dashboard:
     get:
       summary: Get referrals by organisationId
       tags:
@@ -439,11 +439,11 @@ paths:
       parameters:
         - name: organisationId
           in: path
-          description: The organisationId (UUID) of an organisation
+          description: The organisationId  of an organisation
           required: true
           schema:
             type: string
-            format: uuid
+            format: string
       responses:
         200:
           description: Summary of referrals for an organisation

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -435,11 +435,11 @@ paths:
       summary: Get referrals by organisationId
       tags:
         - Referrals
-      operationId: getReferralSummaryByOrgId
+      operationId: getReferralSummariesByOrganisationId
       parameters:
         - name: organisationId
           in: path
-          description: The organisationId  of an organisation
+          description: The organisationId of an organisation
           required: true
           schema:
             type: string

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -430,6 +430,37 @@ paths:
         404:
           description: The referral does not exist.
 
+  /referrals/organisation/:organisationId/dashboard:
+    get:
+      summary: Get referrals by organisationId
+      tags:
+        - Referrals
+      operationId: getReferralSummaryByOrgId
+      parameters:
+        - name: organisationId
+          in: path
+          description: The organisationId (UUID) of an organisation
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: Summary of referrals for an organisation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ReferralSummary'
+        401:
+          description: The request was unauthorised
+        403:
+          description: Forbidden.  The client is not authorised to access this offering.
+        404:
+          description: No referrals for supplied organisationId (Not Found).
+
+
   /offerings/{id}/course:
     get:
       tags:
@@ -983,3 +1014,29 @@ components:
         - referral_submitted
         - awaiting_assessment
         - assessment_started
+    ReferralSummary:
+      type: object
+      properties:
+        referralId:
+          description: The unique id (UUID) of the new referral.
+          type: string
+          format: uuid
+        referralStatus:
+          $ref: "#/components/schemas/ReferralStatus"
+        person:
+          $ref: "#/components/schemas/Person"
+
+      required:
+      - referralId
+      - referralStatus
+      - person
+
+    Person:
+      type: object
+      properties:
+        prisonNumber:
+          description: The prison number of the person who is being referred.
+          example: "A1234AA"
+          type: string
+      required:
+        - prisonNumber

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
@@ -74,6 +74,9 @@ class PactContractTest {
   @State("Referral status can be updated")
   fun `ensure referral status can be updated`() {}
 
+  @State("Referral can be submitted")
+  fun `ensure referral can be submitted`() {}
+
   @TestTemplate
   @ExtendWith(PactVerificationSpringProvider::class)
   fun template(context: PactVerificationContext, request: HttpRequest) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseParticipationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseParticipationControllerTest.kt
@@ -151,7 +151,6 @@ constructor(
     )
     fun `createCourseParticipation with year below the floor returns 400 with validation error message`(
       field: String,
-      floor: Int,
       invalidYear: Int,
     ) {
       mockMvc.post("/course-participations") {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseParticipationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseParticipationControllerTest.kt
@@ -146,10 +146,10 @@ constructor(
 
     @ParameterizedTest
     @CsvSource(
-      "yearStarted, 1990, 1985",
-      "yearCompleted, 1990, 1985",
+      "yearStarted, 1989",
+      "yearCompleted, 1985",
     )
-    fun `createCourseParticipation with year below the floor returns 400 with validation error message`(
+    fun `createCourseParticipation with invalid year fields returns 400 with validation error message`(
       field: String,
       invalidYear: Int,
     ) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -275,7 +275,7 @@ constructor(
         .produce(),
     )
 
-    every { referralService.getReferralSummaryByOrgId(organisationId) } returns referrals
+    every { referralService.getReferralsByOrganisationId(organisationId) } returns referrals
 
     mockMvc.get("/referrals/organisation/$organisationId/dashboard") {
       header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
@@ -286,12 +286,12 @@ constructor(
         contentType(MediaType.APPLICATION_JSON)
         referrals.forEachIndexed { index, referral ->
           jsonPath("$[$index].referralId") { value(referral.id.toString()) }
-          jsonPath("$[$index].person.prisonNumber") { value(referral.prisonNumber.toString()) }
+          jsonPath("$[$index].person.prisonNumber") { value(referral.prisonNumber) }
           jsonPath("$[$index].status") { REFERRAL_STARTED }
         }
       }
     }
-    verify { referralService.getReferralSummaryByOrgId(organisationId) }
+    verify { referralService.getReferralsByOrganisationId(organisationId) }
   }
 
   @Test
@@ -307,7 +307,7 @@ constructor(
   fun `getReferralSummaryByOrgId with random orgId returns 200 with empty body`() {
     val orgId = UUID.randomUUID().toString()
 
-    every { referralService.getReferralSummaryByOrgId(orgId) } returns emptyList()
+    every { referralService.getReferralsByOrganisationId(orgId) } returns emptyList()
 
     mockMvc.get("/referrals/organisation/$orgId/dashboard") {
       accept = MediaType.APPLICATION_JSON
@@ -320,6 +320,6 @@ constructor(
       }
     }
 
-    verify { referralService.getReferralSummaryByOrgId(orgId) }
+    verify { referralService.getReferralsByOrganisationId(orgId) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/transformer/ReferralTransformersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/transformer/ReferralTransformersTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.restapi.transformer
 
 import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -8,18 +9,22 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Refer
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.awaitingAssessment
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.referralStarted
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.referralSubmitted
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.ASSESSMENT_STARTED
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.AWAITING_ASSESSMENT
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.REFERRAL_STARTED
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.REFERRAL_SUBMITTED
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toApi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toDomain
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toReferralSummary
+import java.util.*
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus as ApiReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralUpdate as ApiReferralUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus as DomainReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.ReferralUpdate as DomainReferralUpdate
 
 class ReferralTransformersTest {
+
   @ParameterizedTest
   @EnumSource
   fun `toApi should map status from domain to api`(domainStatus: DomainReferralStatus) {
@@ -102,5 +107,22 @@ class ReferralTransformersTest {
       oasysConfirmed shouldBe false
       hasReviewedProgrammeHistory shouldBe false
     }
+  }
+
+  @Test
+  fun `toReferralSummary should convert ReferralEntity to ReferralSummary`() {
+    val referralEntity = ReferralEntity(
+      id = UUID.randomUUID(),
+      offeringId = UUID.randomUUID(),
+      status = REFERRAL_STARTED,
+      prisonNumber = "ABC123",
+      referrerId = "Z123",
+    )
+
+    val referralSummary = referralEntity.toReferralSummary()
+
+    assertEquals(referralEntity.id, referralSummary.referralId)
+    assertEquals(referralEntity.prisonNumber, referralSummary.person.prisonNumber)
+    assertEquals("referralStarted", referralSummary.referralStatus.name)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -1,455 +1,61 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.service
 
-import io.kotest.matchers.collections.shouldBeEmpty
-import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
-import io.kotest.matchers.equals.shouldBeEqual
-import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
-import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.LineMessage
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.AudienceEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OfferingEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.PrerequisiteEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.CourseUpdate
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.NewPrerequisite
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.OfferingUpdate
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseRepository
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.CourseService
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.eqCourse
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.JpaReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralEntityFactory
 import java.util.UUID
 
-class CourseServiceTest {
+private const val prisonNumber = "ABC123"
+
+class ReferralServiceTest {
 
   @MockK(relaxed = true)
-  private lateinit var courseRepository: CourseRepository
+  private lateinit var referralRepository: JpaReferralRepository
 
-  private lateinit var courseService: CourseService
+  private lateinit var referralService: ReferralService
 
   @BeforeEach
   fun setup() {
     MockKAnnotations.init(this)
-    courseService = CourseService(courseRepository)
+    referralService = ReferralService(referralRepository)
   }
 
   @Nested
-  @DisplayName("Update Courses")
-  inner class UpdateCoursesTests {
+  @DisplayName("Get referral summary for an orgId")
+  inner class ReferralSummaryTest {
     @Test
-    fun `updateCourses with an empty list clears the repository`() {
-      courseService.updateCourses(emptyList())
-      verify { courseRepository.saveAudiences(emptySet()) }
-    }
-
-    @Test
-    fun `updateCourses with one valid CourseEntity object clears and persists to the repository`() {
-      val a1 = AudienceEntity("Audience 1", id = UUID.randomUUID())
-
-      every { courseRepository.getAllAudiences() } returns setOf(a1)
-
-      courseService.updateCourses(
-        listOf(
-          CourseUpdate(name = "Course", identifier = "C", description = "Description", audience = "Audience 1", alternateName = "CCC", referable = true),
-        ),
+    fun `list of referralEntities returned for an orgId`() {
+      val orgId = "MDI"
+      val id = UUID.randomUUID()
+      val referralEntities = listOf(
+        ReferralEntityFactory()
+          .withId(id)
+          .withOfferingId(id)
+          .withPrisonNumber(prisonNumber)
+          .withReferrerId(id.toString())
+          .withStatus(ReferralEntity.ReferralStatus.REFERRAL_STARTED)
+          .produce(),
       )
 
-      verify {
-        courseRepository.saveCourse(eqCourse(CourseEntity(name = "Course", identifier = "C", description = "Description", audiences = mutableSetOf(a1), referable = true)))
-      }
-    }
+      every { referralRepository.getReferralsByOrgId(orgId) } returns referralEntities
 
-    @Test
-    fun `updateCourses with two valid CourseEntity objects clears and persists to the repository`() {
-      val a1 = AudienceEntity("Audience 1", id = UUID.randomUUID())
-      val a2 = AudienceEntity("Audience 2", id = UUID.randomUUID())
-      val a3 = AudienceEntity("Audience 3", id = UUID.randomUUID())
-
-      every { courseRepository.getAllAudiences() } returns setOf(a1, a2, a3)
-
-      courseService.updateCourses(
-        listOf(
-          CourseUpdate(name = "Course 1", identifier = "C1", description = "Description 1", audience = "${a1.value}, ${a2.value} ", alternateName = "111", referable = true),
-          CourseUpdate(name = "Course 2", identifier = "C2", description = "Description 2", audience = "${a1.value}, ${a3.value}", alternateName = "222", referable = true),
-        ),
-      )
-      verify { courseRepository.saveCourse(eqCourse(CourseEntity(name = "Course 1", identifier = "C1", description = "Description 1", audiences = mutableSetOf(a1, a2), referable = true))) }
-      verify { courseRepository.saveCourse(eqCourse(CourseEntity(name = "Course 2", identifier = "C2", description = "Description 2", audiences = mutableSetOf(a1, a3), referable = true))) }
-    }
-
-    @Test
-    fun `updateCourses with duplicate AudienceEntity values only persists unique values to the repository`() {
-      val a1 = AudienceEntity("Audience 1", id = UUID.randomUUID())
-      val a2 = AudienceEntity("Audience 2", id = UUID.randomUUID())
-      val a3 = AudienceEntity("Audience 3", id = UUID.randomUUID())
-
-      every { courseRepository.getAllAudiences() } returns setOf()
-
-      courseService.updateCourses(
-        listOf(
-          CourseUpdate(name = "Course 1", identifier = "C1", description = "Description 1", audience = "${a1.value}, ${a2.value} ", alternateName = "111"),
-          CourseUpdate(name = "Course 2", identifier = "C2", description = "Description 2", audience = "${a1.value}, ${a3.value}", alternateName = "222"),
-          CourseUpdate(name = "Course 3", identifier = "C3", description = "Description 3", audience = a1.value, alternateName = "333"),
-          CourseUpdate(name = "Course 4", identifier = "C4", description = "Description 4", audience = a1.value, alternateName = "444"),
-        ),
-      )
-
-      verify { courseRepository.saveAudiences(setOf(AudienceEntity(a1.value), AudienceEntity(a2.value), AudienceEntity(a3.value))) }
-    }
-  }
-
-  @Nested
-  @DisplayName("Update Prerequisites")
-  inner class ReplaceAllPrerequisitesTests {
-    @Test
-    fun `updatePrerequisites with an empty list successfully clears the repository`() {
-      courseService.updatePrerequisites(emptyList()).shouldBeEmpty()
-    }
-
-    @Test
-    fun `updatePrerequisites should remove existing prerequisites when no new records are provided`() {
-      val allCourses = listOf(
-        CourseEntity(
-          name = "Course 1",
-          identifier = "C1",
-          description = "Description 1",
-          prerequisites = mutableSetOf(
-            PrerequisiteEntity(name = "PR 1", description = " PR Desc 1 "),
-          ),
-        ),
-      )
-      every { courseRepository.getAllCourses() } returns allCourses
-
-      courseService.updatePrerequisites(emptyList()).shouldBeEmpty()
-
-      allCourses.flatMap { it.prerequisites }.shouldBeEmpty()
-    }
-
-    @Test
-    fun `updatePrerequisites should replace existing prerequisites when a matching course is found`() {
-      val allCourses = listOf(
-        CourseEntity(
-          name = "Course 1",
-          identifier = "C1",
-          prerequisites = mutableSetOf(PrerequisiteEntity(name = "PR 1", description = " PR 1 Desc")),
-        ),
-      )
-      every { courseRepository.getAllCourses() } returns allCourses
-
-      courseService.updatePrerequisites(
-        listOf(
-          NewPrerequisite(name = "PR 2", description = "PR 2 Desc", identifier = "C1"),
-        ),
-      ).shouldBeEmpty()
-
-      allCourses[0].prerequisites shouldContainExactly listOf(PrerequisiteEntity(name = "PR 2", description = "PR 2 Desc"))
-    }
-
-    @Test
-    fun `updatePrerequisites should associate multiple prerequisites to multiple courses when all identifiers match`() {
-      val allCourses = listOf(
-        CourseEntity(name = "Course 1", identifier = "C1"),
-        CourseEntity(name = "Course 2", identifier = "C2"),
-      )
-      every { courseRepository.getAllCourses() } returns allCourses
-
-      courseService.updatePrerequisites(
-        listOf(
-          NewPrerequisite(name = "PR 1", description = "PR 1 Desc", identifier = "C1"),
-          NewPrerequisite(name = "PR 2", description = "PR 2 Desc", identifier = "C1"),
-          NewPrerequisite(name = "PR 3", description = "PR 3 Desc", identifier = "C2"),
-        ),
-      ).shouldBeEmpty()
-
-      allCourses.associateBy(CourseEntity::identifier, CourseEntity::prerequisites) shouldBeEqual mapOf(
-        "C1" to mutableSetOf(
-          PrerequisiteEntity(name = "PR 1", description = "PR 1 Desc"),
-          PrerequisiteEntity(name = "PR 2", description = "PR 2 Desc"),
-        ),
-        "C2" to mutableSetOf(
-          PrerequisiteEntity(name = "PR 3", description = "PR 3 Desc"),
-        ),
-      )
-    }
-
-    @Test
-    fun `updatePrerequisites should return an error when a prerequisite course identifier does matches no existing courses`() {
-      val allCourses = listOf(
-        CourseEntity(name = "Course 1", identifier = "C1"),
-        CourseEntity(name = "Course 2", identifier = "C2"),
-      )
-      every { courseRepository.getAllCourses() } returns allCourses
-
-      courseService.updatePrerequisites(
-        listOf(
-          NewPrerequisite(name = "PR 1", description = "Don't care", identifier = "C1"),
-          NewPrerequisite(name = "PR 1", description = "Don't care", identifier = "CX"),
-          NewPrerequisite(name = "PR 2", description = "Don't care", identifier = "C2"),
-        ),
-      )
-        .shouldContainExactly(
-          LineMessage(
-            lineNumber = 3,
-            level = LineMessage.Level.error,
-            message = "No match for course identifier 'CX'",
-          ),
-        )
-    }
-
-    @Test
-    fun `updatePrerequisites should associate prerequisites to multiple courses when multiple matching identifiers are provided`() {
-      val allCourses = listOf(
-        CourseEntity(name = "Course 1", identifier = "C-1"),
-        CourseEntity(name = "Course 2", identifier = "C-2"),
-      )
-      every { courseRepository.getAllCourses() } returns allCourses
-
-      courseService.updatePrerequisites(
-        listOf(
-          NewPrerequisite(name = "PR 1", description = "D1", identifier = " C-1 , C-2 "),
-          NewPrerequisite(name = "PR 2", description = "D2", identifier = "C-2,C-X"),
-        ),
-      )
-
-      allCourses.associateBy(CourseEntity::identifier, CourseEntity::prerequisites) shouldBeEqual mapOf(
-        "C-1" to mutableSetOf(PrerequisiteEntity(name = "PR 1", description = "D1")),
-        "C-2" to mutableSetOf(PrerequisiteEntity(name = "PR 1", description = "D1"), PrerequisiteEntity(name = "PR 2", description = "D2")),
-      )
-    }
-  }
-
-  @Nested
-  @DisplayName("Update Offerings")
-  inner class UpdateOfferingsTests {
-    @Test
-    fun `updateOfferings with an empty list clears the repository`() {
-      courseService.updateOfferings(emptyList()).shouldBeEmpty()
-    }
-
-    @Test
-    fun `Given no records and one course that has an offering, updateOfferings should withdraw that offering`() {
-      val theOffering = OfferingEntity(organisationId = "BWI", contactEmail = "a@b.com", secondaryContactEmail = "c@b.com")
-
-      val allCourses = listOf(
-        CourseEntity(
-          name = "Course 1",
-          identifier = "C1",
-          description = "Description 1",
-        ).apply {
-          addOffering(theOffering)
-        },
-      )
-      every { courseRepository.getAllCourses() } returns allCourses
-
-      courseService.updateOfferings(emptyList()).shouldBeEmpty()
-
-      val updatedOfferings = allCourses.flatMap { it.offerings }
-      updatedOfferings shouldHaveSize 1
-      updatedOfferings[0] shouldBeSameInstanceAs theOffering
-      theOffering.withdrawn shouldBe true
-    }
-
-    @Test
-    fun `Given one record matching an offering from a course, updateOfferings should update that offering`() {
-      val theOffering = OfferingEntity(organisationId = "BWI", contactEmail = "a@b.com", secondaryContactEmail = "c@b.com")
-      val allCourses = listOf(
-        CourseEntity(
-          name = "Course 1",
-          identifier = "C1",
-        ).apply {
-          addOffering(theOffering)
-        },
-      )
-      every { courseRepository.getAllCourses() } returns allCourses
-
-      courseService.updateOfferings(
-        listOf(
-          OfferingUpdate(identifier = "C1", prisonId = "BWI", contactEmail = "x@y.net", secondaryContactEmail = "z@y.net"),
-        ),
-      ).shouldBeEmpty()
-
-      val updatedOfferings = allCourses.flatMap { it.offerings }
-      updatedOfferings shouldHaveSize 1
-      updatedOfferings[0] shouldBeSameInstanceAs theOffering
-      theOffering.shouldBeEqualToIgnoringFields(
-        OfferingEntity(organisationId = "BWI", contactEmail = "x@y.net", secondaryContactEmail = "z@y.net"),
-        OfferingEntity::course,
-      )
-    }
-
-    @Test
-    fun `Given one record that matches a course, but not the course's offering, then updateOfferings should withdraw the old offering and add the new offering`() {
-      val oldOffering = OfferingEntity(organisationId = "BWI", contactEmail = "a@b.com", secondaryContactEmail = "c@b.com")
-      val allCourses = listOf(
-        CourseEntity(
-          name = "Course 1",
-          identifier = "C1",
-        ).apply {
-          addOffering(oldOffering)
-        },
-      )
-      every { courseRepository.getAllCourses() } returns allCourses
-
-      courseService.updateOfferings(
-        listOf(
-          OfferingUpdate(identifier = "C1", prisonId = "MDI", contactEmail = "x@y.net", secondaryContactEmail = "z@y.net"),
-        ),
-      ).shouldBeEmpty()
-
-      val offeringsByOrganisationId = allCourses[0].offerings.associateBy(OfferingEntity::organisationId)
-
-      offeringsByOrganisationId["MDI"]!!.shouldBeEqualToIgnoringFields(
-        OfferingEntity(organisationId = "MDI", contactEmail = "x@y.net", secondaryContactEmail = "z@y.net"),
-        OfferingEntity::course,
-      )
-
-      offeringsByOrganisationId["BWI"]!!.shouldBeSameInstanceAs(oldOffering)
-      offeringsByOrganisationId["BWI"]!!.shouldBeEqualToIgnoringFields(
-        OfferingEntity(organisationId = "BWI", contactEmail = "a@b.com", secondaryContactEmail = "c@b.com", withdrawn = true),
-        OfferingEntity::course,
-      )
-    }
-
-    @Test
-    fun `Given multiple matching courses and offerings, updateOfferings should associate the courses to their offerings`() {
-      val allCourses = listOf(
-        CourseEntity(name = "Course 1", identifier = "C1"),
-        CourseEntity(name = "Course 2", identifier = "C2"),
-      )
-      every { courseRepository.getAllCourses() } returns allCourses
-
-      courseService.updateOfferings(
-        listOf(
-          OfferingUpdate(identifier = "C1", prisonId = "MDI", contactEmail = "admin@mdi.net"),
-          OfferingUpdate(identifier = "C1", prisonId = "BWI", contactEmail = "admin@bwi.net", secondaryContactEmail = "admin2@bwi.net"),
-          OfferingUpdate(identifier = "C2", prisonId = "MDI", contactEmail = "admin@mdi.net"),
-        ),
-      ).shouldBeEmpty()
-
-      allCourses.associateBy(CourseEntity::name, CourseEntity::offerings) shouldBeEqual mapOf(
-        "Course 1" to mutableSetOf(
-          OfferingEntity(organisationId = "MDI", contactEmail = "admin@mdi.net"),
-          OfferingEntity(organisationId = "BWI", contactEmail = "admin@bwi.net", secondaryContactEmail = "admin2@bwi.net"),
-        ),
-        "Course 2" to mutableSetOf(
-          OfferingEntity(organisationId = "MDI", contactEmail = "admin@mdi.net"),
-        ),
-      )
-    }
-
-    @Test
-    fun `updateOfferings should return an error when an offering course identifier does not match any existing courses`() {
-      val allCourses = listOf(
-        CourseEntity(name = "Course 1", identifier = "C1"),
-        CourseEntity(name = "Course 2", identifier = "C2"),
-      )
-      every { courseRepository.getAllCourses() } returns allCourses
-
-      courseService.updateOfferings(
-        listOf(
-          OfferingUpdate(identifier = "C1", prisonId = "MDI", contactEmail = "x@y.net"),
-          OfferingUpdate(identifier = "C1", prisonId = "BWI", contactEmail = "x@y.net"),
-          OfferingUpdate(identifier = "CX", prisonId = "BWI", contactEmail = "x@y.net"),
-          OfferingUpdate(identifier = "C2", prisonId = "MDI", contactEmail = "x@y.net"),
-        ),
-      )
-        .shouldContainExactly(
-          LineMessage(
-            lineNumber = 4,
-            level = LineMessage.Level.error,
-            message = "No course matches offering with identifier 'CX' and prisonId 'BWI'",
-          ),
-        )
-    }
-
-    @Test
-    fun `updateOfferings should return a warning when the contact email for an offering is missing`() {
-      val allCourses = listOf(
-        CourseEntity(name = "Course 1", identifier = "C1"),
-        CourseEntity(name = "Course 2", identifier = "C2"),
-      )
-      every { courseRepository.getAllCourses() } returns allCourses
-
-      courseService.updateOfferings(
-        listOf(
-          OfferingUpdate(identifier = "C1", prisonId = "MDI"),
-          OfferingUpdate(identifier = "C1", prisonId = "BWI", contactEmail = "x@y.net"),
-        ),
-      )
-        .shouldContainExactly(
-          LineMessage(
-            lineNumber = 2,
-            level = LineMessage.Level.warning,
-            message = "Missing contactEmail for offering with identifier 'C1' at prisonId 'MDI'",
-          ),
-        )
-    }
-  }
-
-  @Nested
-  @DisplayName("Handle withdrawn Offerings")
-  inner class WithdrawnOfferingsTests {
-    @Test
-    fun `Withdrawn offerings should not be returned from getAllOfferingsByCourseId`() {
-      val withdrawnOffering = OfferingEntity(withdrawn = true, organisationId = "BWI", contactEmail = "a@b.com")
-      val offering = OfferingEntity(organisationId = "MDI", contactEmail = "a@b.com")
-
-      every { courseRepository.getAllOfferingsByCourseId(any()) } returns listOf(withdrawnOffering, offering)
-
-      courseService.getAllOfferingsByCourseId(UUID.randomUUID()).shouldContainExactly(offering)
-    }
-
-    @Test
-    fun `A withdrawn Offering should not be returned from getOfferingById`() {
-      val withdrawnOffering = OfferingEntity(withdrawn = true, organisationId = "BWI", contactEmail = "a@b.com")
-
-      every { courseRepository.getOfferingById(any()) } returns withdrawnOffering
-
-      courseService.getOfferingById(UUID.randomUUID()).shouldBeNull()
-    }
-
-    @Test
-    fun `An active Offering should be returned from getOfferingById`() {
-      val offering = OfferingEntity(organisationId = "MDI", contactEmail = "a@b.com")
-
-      every { courseRepository.getOfferingById(any()) } returns offering
-
-      courseService.getOfferingById(UUID.randomUUID()) shouldBe offering
-    }
-  }
-
-  @Nested
-  @DisplayName("Handle withdrawn CourseEntities")
-  inner class WithdrawnCourseTests {
-    @Test
-    fun `A withdrawn course should not be returned from getCourseById`() {
-      val withdrawnCourse = CourseEntity(name = "Course", identifier = "C", withdrawn = true)
-      every { courseRepository.getCourseById(any()) } returns withdrawnCourse
-      courseService.getCourseById(UUID.randomUUID()).shouldBeNull()
-    }
-
-    @Test
-    fun `An active course should  be returned from getCourseById`() {
-      val activeCourse = CourseEntity(name = "Course", identifier = "C")
-      every { courseRepository.getCourseById(any()) } returns activeCourse
-      courseService.getCourseById(UUID.randomUUID()) shouldBe activeCourse
-    }
-
-    @Test
-    fun `getAllCourses should exclude withdrawn courses`() {
-      val withdrawnCourse = CourseEntity(name = "Withdrawn", identifier = "W", withdrawn = true)
-      val activeCourse = CourseEntity(name = "Active", identifier = "A")
-      every { courseRepository.getAllCourses() } returns listOf(activeCourse, withdrawnCourse)
-      courseService.getAllCourses().shouldContainExactly(activeCourse)
+      val referralSummaries = referralService.getReferralSummaryByOrgId(orgId)
+      referralSummaries.shouldNotBeNull()
+      referralSummaries.size.shouldBe(referralEntities.size)
+      referralSummaries[0].prisonNumber.shouldBe(prisonNumber)
+      referralSummaries[0].id.shouldBe(id)
+      referralSummaries[0].offeringId.shouldBe(id)
+      referralSummaries[0].referrerId.shouldBe(id.toString())
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -1,0 +1,455 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.service
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.LineMessage
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.AudienceEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OfferingEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.PrerequisiteEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.CourseUpdate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.NewPrerequisite
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.OfferingUpdate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.CourseService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.eqCourse
+import java.util.UUID
+
+class CourseServiceTest {
+
+  @MockK(relaxed = true)
+  private lateinit var courseRepository: CourseRepository
+
+  private lateinit var courseService: CourseService
+
+  @BeforeEach
+  fun setup() {
+    MockKAnnotations.init(this)
+    courseService = CourseService(courseRepository)
+  }
+
+  @Nested
+  @DisplayName("Update Courses")
+  inner class UpdateCoursesTests {
+    @Test
+    fun `updateCourses with an empty list clears the repository`() {
+      courseService.updateCourses(emptyList())
+      verify { courseRepository.saveAudiences(emptySet()) }
+    }
+
+    @Test
+    fun `updateCourses with one valid CourseEntity object clears and persists to the repository`() {
+      val a1 = AudienceEntity("Audience 1", id = UUID.randomUUID())
+
+      every { courseRepository.getAllAudiences() } returns setOf(a1)
+
+      courseService.updateCourses(
+        listOf(
+          CourseUpdate(name = "Course", identifier = "C", description = "Description", audience = "Audience 1", alternateName = "CCC", referable = true),
+        ),
+      )
+
+      verify {
+        courseRepository.saveCourse(eqCourse(CourseEntity(name = "Course", identifier = "C", description = "Description", audiences = mutableSetOf(a1), referable = true)))
+      }
+    }
+
+    @Test
+    fun `updateCourses with two valid CourseEntity objects clears and persists to the repository`() {
+      val a1 = AudienceEntity("Audience 1", id = UUID.randomUUID())
+      val a2 = AudienceEntity("Audience 2", id = UUID.randomUUID())
+      val a3 = AudienceEntity("Audience 3", id = UUID.randomUUID())
+
+      every { courseRepository.getAllAudiences() } returns setOf(a1, a2, a3)
+
+      courseService.updateCourses(
+        listOf(
+          CourseUpdate(name = "Course 1", identifier = "C1", description = "Description 1", audience = "${a1.value}, ${a2.value} ", alternateName = "111", referable = true),
+          CourseUpdate(name = "Course 2", identifier = "C2", description = "Description 2", audience = "${a1.value}, ${a3.value}", alternateName = "222", referable = true),
+        ),
+      )
+      verify { courseRepository.saveCourse(eqCourse(CourseEntity(name = "Course 1", identifier = "C1", description = "Description 1", audiences = mutableSetOf(a1, a2), referable = true))) }
+      verify { courseRepository.saveCourse(eqCourse(CourseEntity(name = "Course 2", identifier = "C2", description = "Description 2", audiences = mutableSetOf(a1, a3), referable = true))) }
+    }
+
+    @Test
+    fun `updateCourses with duplicate AudienceEntity values only persists unique values to the repository`() {
+      val a1 = AudienceEntity("Audience 1", id = UUID.randomUUID())
+      val a2 = AudienceEntity("Audience 2", id = UUID.randomUUID())
+      val a3 = AudienceEntity("Audience 3", id = UUID.randomUUID())
+
+      every { courseRepository.getAllAudiences() } returns setOf()
+
+      courseService.updateCourses(
+        listOf(
+          CourseUpdate(name = "Course 1", identifier = "C1", description = "Description 1", audience = "${a1.value}, ${a2.value} ", alternateName = "111"),
+          CourseUpdate(name = "Course 2", identifier = "C2", description = "Description 2", audience = "${a1.value}, ${a3.value}", alternateName = "222"),
+          CourseUpdate(name = "Course 3", identifier = "C3", description = "Description 3", audience = a1.value, alternateName = "333"),
+          CourseUpdate(name = "Course 4", identifier = "C4", description = "Description 4", audience = a1.value, alternateName = "444"),
+        ),
+      )
+
+      verify { courseRepository.saveAudiences(setOf(AudienceEntity(a1.value), AudienceEntity(a2.value), AudienceEntity(a3.value))) }
+    }
+  }
+
+  @Nested
+  @DisplayName("Update Prerequisites")
+  inner class ReplaceAllPrerequisitesTests {
+    @Test
+    fun `updatePrerequisites with an empty list successfully clears the repository`() {
+      courseService.updatePrerequisites(emptyList()).shouldBeEmpty()
+    }
+
+    @Test
+    fun `updatePrerequisites should remove existing prerequisites when no new records are provided`() {
+      val allCourses = listOf(
+        CourseEntity(
+          name = "Course 1",
+          identifier = "C1",
+          description = "Description 1",
+          prerequisites = mutableSetOf(
+            PrerequisiteEntity(name = "PR 1", description = " PR Desc 1 "),
+          ),
+        ),
+      )
+      every { courseRepository.getAllCourses() } returns allCourses
+
+      courseService.updatePrerequisites(emptyList()).shouldBeEmpty()
+
+      allCourses.flatMap { it.prerequisites }.shouldBeEmpty()
+    }
+
+    @Test
+    fun `updatePrerequisites should replace existing prerequisites when a matching course is found`() {
+      val allCourses = listOf(
+        CourseEntity(
+          name = "Course 1",
+          identifier = "C1",
+          prerequisites = mutableSetOf(PrerequisiteEntity(name = "PR 1", description = " PR 1 Desc")),
+        ),
+      )
+      every { courseRepository.getAllCourses() } returns allCourses
+
+      courseService.updatePrerequisites(
+        listOf(
+          NewPrerequisite(name = "PR 2", description = "PR 2 Desc", identifier = "C1"),
+        ),
+      ).shouldBeEmpty()
+
+      allCourses[0].prerequisites shouldContainExactly listOf(PrerequisiteEntity(name = "PR 2", description = "PR 2 Desc"))
+    }
+
+    @Test
+    fun `updatePrerequisites should associate multiple prerequisites to multiple courses when all identifiers match`() {
+      val allCourses = listOf(
+        CourseEntity(name = "Course 1", identifier = "C1"),
+        CourseEntity(name = "Course 2", identifier = "C2"),
+      )
+      every { courseRepository.getAllCourses() } returns allCourses
+
+      courseService.updatePrerequisites(
+        listOf(
+          NewPrerequisite(name = "PR 1", description = "PR 1 Desc", identifier = "C1"),
+          NewPrerequisite(name = "PR 2", description = "PR 2 Desc", identifier = "C1"),
+          NewPrerequisite(name = "PR 3", description = "PR 3 Desc", identifier = "C2"),
+        ),
+      ).shouldBeEmpty()
+
+      allCourses.associateBy(CourseEntity::identifier, CourseEntity::prerequisites) shouldBeEqual mapOf(
+        "C1" to mutableSetOf(
+          PrerequisiteEntity(name = "PR 1", description = "PR 1 Desc"),
+          PrerequisiteEntity(name = "PR 2", description = "PR 2 Desc"),
+        ),
+        "C2" to mutableSetOf(
+          PrerequisiteEntity(name = "PR 3", description = "PR 3 Desc"),
+        ),
+      )
+    }
+
+    @Test
+    fun `updatePrerequisites should return an error when a prerequisite course identifier does matches no existing courses`() {
+      val allCourses = listOf(
+        CourseEntity(name = "Course 1", identifier = "C1"),
+        CourseEntity(name = "Course 2", identifier = "C2"),
+      )
+      every { courseRepository.getAllCourses() } returns allCourses
+
+      courseService.updatePrerequisites(
+        listOf(
+          NewPrerequisite(name = "PR 1", description = "Don't care", identifier = "C1"),
+          NewPrerequisite(name = "PR 1", description = "Don't care", identifier = "CX"),
+          NewPrerequisite(name = "PR 2", description = "Don't care", identifier = "C2"),
+        ),
+      )
+        .shouldContainExactly(
+          LineMessage(
+            lineNumber = 3,
+            level = LineMessage.Level.error,
+            message = "No match for course identifier 'CX'",
+          ),
+        )
+    }
+
+    @Test
+    fun `updatePrerequisites should associate prerequisites to multiple courses when multiple matching identifiers are provided`() {
+      val allCourses = listOf(
+        CourseEntity(name = "Course 1", identifier = "C-1"),
+        CourseEntity(name = "Course 2", identifier = "C-2"),
+      )
+      every { courseRepository.getAllCourses() } returns allCourses
+
+      courseService.updatePrerequisites(
+        listOf(
+          NewPrerequisite(name = "PR 1", description = "D1", identifier = " C-1 , C-2 "),
+          NewPrerequisite(name = "PR 2", description = "D2", identifier = "C-2,C-X"),
+        ),
+      )
+
+      allCourses.associateBy(CourseEntity::identifier, CourseEntity::prerequisites) shouldBeEqual mapOf(
+        "C-1" to mutableSetOf(PrerequisiteEntity(name = "PR 1", description = "D1")),
+        "C-2" to mutableSetOf(PrerequisiteEntity(name = "PR 1", description = "D1"), PrerequisiteEntity(name = "PR 2", description = "D2")),
+      )
+    }
+  }
+
+  @Nested
+  @DisplayName("Update Offerings")
+  inner class UpdateOfferingsTests {
+    @Test
+    fun `updateOfferings with an empty list clears the repository`() {
+      courseService.updateOfferings(emptyList()).shouldBeEmpty()
+    }
+
+    @Test
+    fun `Given no records and one course that has an offering, updateOfferings should withdraw that offering`() {
+      val theOffering = OfferingEntity(organisationId = "BWI", contactEmail = "a@b.com", secondaryContactEmail = "c@b.com")
+
+      val allCourses = listOf(
+        CourseEntity(
+          name = "Course 1",
+          identifier = "C1",
+          description = "Description 1",
+        ).apply {
+          addOffering(theOffering)
+        },
+      )
+      every { courseRepository.getAllCourses() } returns allCourses
+
+      courseService.updateOfferings(emptyList()).shouldBeEmpty()
+
+      val updatedOfferings = allCourses.flatMap { it.offerings }
+      updatedOfferings shouldHaveSize 1
+      updatedOfferings[0] shouldBeSameInstanceAs theOffering
+      theOffering.withdrawn shouldBe true
+    }
+
+    @Test
+    fun `Given one record matching an offering from a course, updateOfferings should update that offering`() {
+      val theOffering = OfferingEntity(organisationId = "BWI", contactEmail = "a@b.com", secondaryContactEmail = "c@b.com")
+      val allCourses = listOf(
+        CourseEntity(
+          name = "Course 1",
+          identifier = "C1",
+        ).apply {
+          addOffering(theOffering)
+        },
+      )
+      every { courseRepository.getAllCourses() } returns allCourses
+
+      courseService.updateOfferings(
+        listOf(
+          OfferingUpdate(identifier = "C1", prisonId = "BWI", contactEmail = "x@y.net", secondaryContactEmail = "z@y.net"),
+        ),
+      ).shouldBeEmpty()
+
+      val updatedOfferings = allCourses.flatMap { it.offerings }
+      updatedOfferings shouldHaveSize 1
+      updatedOfferings[0] shouldBeSameInstanceAs theOffering
+      theOffering.shouldBeEqualToIgnoringFields(
+        OfferingEntity(organisationId = "BWI", contactEmail = "x@y.net", secondaryContactEmail = "z@y.net"),
+        OfferingEntity::course,
+      )
+    }
+
+    @Test
+    fun `Given one record that matches a course, but not the course's offering, then updateOfferings should withdraw the old offering and add the new offering`() {
+      val oldOffering = OfferingEntity(organisationId = "BWI", contactEmail = "a@b.com", secondaryContactEmail = "c@b.com")
+      val allCourses = listOf(
+        CourseEntity(
+          name = "Course 1",
+          identifier = "C1",
+        ).apply {
+          addOffering(oldOffering)
+        },
+      )
+      every { courseRepository.getAllCourses() } returns allCourses
+
+      courseService.updateOfferings(
+        listOf(
+          OfferingUpdate(identifier = "C1", prisonId = "MDI", contactEmail = "x@y.net", secondaryContactEmail = "z@y.net"),
+        ),
+      ).shouldBeEmpty()
+
+      val offeringsByOrganisationId = allCourses[0].offerings.associateBy(OfferingEntity::organisationId)
+
+      offeringsByOrganisationId["MDI"]!!.shouldBeEqualToIgnoringFields(
+        OfferingEntity(organisationId = "MDI", contactEmail = "x@y.net", secondaryContactEmail = "z@y.net"),
+        OfferingEntity::course,
+      )
+
+      offeringsByOrganisationId["BWI"]!!.shouldBeSameInstanceAs(oldOffering)
+      offeringsByOrganisationId["BWI"]!!.shouldBeEqualToIgnoringFields(
+        OfferingEntity(organisationId = "BWI", contactEmail = "a@b.com", secondaryContactEmail = "c@b.com", withdrawn = true),
+        OfferingEntity::course,
+      )
+    }
+
+    @Test
+    fun `Given multiple matching courses and offerings, updateOfferings should associate the courses to their offerings`() {
+      val allCourses = listOf(
+        CourseEntity(name = "Course 1", identifier = "C1"),
+        CourseEntity(name = "Course 2", identifier = "C2"),
+      )
+      every { courseRepository.getAllCourses() } returns allCourses
+
+      courseService.updateOfferings(
+        listOf(
+          OfferingUpdate(identifier = "C1", prisonId = "MDI", contactEmail = "admin@mdi.net"),
+          OfferingUpdate(identifier = "C1", prisonId = "BWI", contactEmail = "admin@bwi.net", secondaryContactEmail = "admin2@bwi.net"),
+          OfferingUpdate(identifier = "C2", prisonId = "MDI", contactEmail = "admin@mdi.net"),
+        ),
+      ).shouldBeEmpty()
+
+      allCourses.associateBy(CourseEntity::name, CourseEntity::offerings) shouldBeEqual mapOf(
+        "Course 1" to mutableSetOf(
+          OfferingEntity(organisationId = "MDI", contactEmail = "admin@mdi.net"),
+          OfferingEntity(organisationId = "BWI", contactEmail = "admin@bwi.net", secondaryContactEmail = "admin2@bwi.net"),
+        ),
+        "Course 2" to mutableSetOf(
+          OfferingEntity(organisationId = "MDI", contactEmail = "admin@mdi.net"),
+        ),
+      )
+    }
+
+    @Test
+    fun `updateOfferings should return an error when an offering course identifier does not match any existing courses`() {
+      val allCourses = listOf(
+        CourseEntity(name = "Course 1", identifier = "C1"),
+        CourseEntity(name = "Course 2", identifier = "C2"),
+      )
+      every { courseRepository.getAllCourses() } returns allCourses
+
+      courseService.updateOfferings(
+        listOf(
+          OfferingUpdate(identifier = "C1", prisonId = "MDI", contactEmail = "x@y.net"),
+          OfferingUpdate(identifier = "C1", prisonId = "BWI", contactEmail = "x@y.net"),
+          OfferingUpdate(identifier = "CX", prisonId = "BWI", contactEmail = "x@y.net"),
+          OfferingUpdate(identifier = "C2", prisonId = "MDI", contactEmail = "x@y.net"),
+        ),
+      )
+        .shouldContainExactly(
+          LineMessage(
+            lineNumber = 4,
+            level = LineMessage.Level.error,
+            message = "No course matches offering with identifier 'CX' and prisonId 'BWI'",
+          ),
+        )
+    }
+
+    @Test
+    fun `updateOfferings should return a warning when the contact email for an offering is missing`() {
+      val allCourses = listOf(
+        CourseEntity(name = "Course 1", identifier = "C1"),
+        CourseEntity(name = "Course 2", identifier = "C2"),
+      )
+      every { courseRepository.getAllCourses() } returns allCourses
+
+      courseService.updateOfferings(
+        listOf(
+          OfferingUpdate(identifier = "C1", prisonId = "MDI"),
+          OfferingUpdate(identifier = "C1", prisonId = "BWI", contactEmail = "x@y.net"),
+        ),
+      )
+        .shouldContainExactly(
+          LineMessage(
+            lineNumber = 2,
+            level = LineMessage.Level.warning,
+            message = "Missing contactEmail for offering with identifier 'C1' at prisonId 'MDI'",
+          ),
+        )
+    }
+  }
+
+  @Nested
+  @DisplayName("Handle withdrawn Offerings")
+  inner class WithdrawnOfferingsTests {
+    @Test
+    fun `Withdrawn offerings should not be returned from getAllOfferingsByCourseId`() {
+      val withdrawnOffering = OfferingEntity(withdrawn = true, organisationId = "BWI", contactEmail = "a@b.com")
+      val offering = OfferingEntity(organisationId = "MDI", contactEmail = "a@b.com")
+
+      every { courseRepository.getAllOfferingsByCourseId(any()) } returns listOf(withdrawnOffering, offering)
+
+      courseService.getAllOfferingsByCourseId(UUID.randomUUID()).shouldContainExactly(offering)
+    }
+
+    @Test
+    fun `A withdrawn Offering should not be returned from getOfferingById`() {
+      val withdrawnOffering = OfferingEntity(withdrawn = true, organisationId = "BWI", contactEmail = "a@b.com")
+
+      every { courseRepository.getOfferingById(any()) } returns withdrawnOffering
+
+      courseService.getOfferingById(UUID.randomUUID()).shouldBeNull()
+    }
+
+    @Test
+    fun `An active Offering should be returned from getOfferingById`() {
+      val offering = OfferingEntity(organisationId = "MDI", contactEmail = "a@b.com")
+
+      every { courseRepository.getOfferingById(any()) } returns offering
+
+      courseService.getOfferingById(UUID.randomUUID()) shouldBe offering
+    }
+  }
+
+  @Nested
+  @DisplayName("Handle withdrawn CourseEntities")
+  inner class WithdrawnCourseTests {
+    @Test
+    fun `A withdrawn course should not be returned from getCourseById`() {
+      val withdrawnCourse = CourseEntity(name = "Course", identifier = "C", withdrawn = true)
+      every { courseRepository.getCourseById(any()) } returns withdrawnCourse
+      courseService.getCourseById(UUID.randomUUID()).shouldBeNull()
+    }
+
+    @Test
+    fun `An active course should  be returned from getCourseById`() {
+      val activeCourse = CourseEntity(name = "Course", identifier = "C")
+      every { courseRepository.getCourseById(any()) } returns activeCourse
+      courseService.getCourseById(UUID.randomUUID()) shouldBe activeCourse
+    }
+
+    @Test
+    fun `getAllCourses should exclude withdrawn courses`() {
+      val withdrawnCourse = CourseEntity(name = "Withdrawn", identifier = "W", withdrawn = true)
+      val activeCourse = CourseEntity(name = "Active", identifier = "A")
+      every { courseRepository.getAllCourses() } returns listOf(activeCourse, withdrawnCourse)
+      courseService.getAllCourses().shouldContainExactly(activeCourse)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -47,9 +47,9 @@ class ReferralServiceTest {
           .produce(),
       )
 
-      every { referralRepository.getReferralsByOrgId(orgId) } returns referralEntities
+      every { referralRepository.getReferralsByOrganisationId(orgId) } returns referralEntities
 
-      val referralSummaries = referralService.getReferralSummaryByOrgId(orgId)
+      val referralSummaries = referralService.getReferralsByOrganisationId(orgId)
       referralSummaries.shouldNotBeNull()
       referralSummaries.size.shouldBe(referralEntities.size)
       referralSummaries[0].prisonNumber.shouldBe(prisonNumber)

--- a/src/test/resources/db/migration/R__test_data.sql
+++ b/src/test/resources/db/migration/R__test_data.sql
@@ -28,5 +28,5 @@ VALUES
 
 INSERT INTO referral (referral_id, offering_id, prison_number, referrer_id, additional_information, oasys_confirmed, has_reviewed_programme_history, status, submitted_on)
 VALUES
-    ('0c46ed09-170b-4c0f-aee8-a24eeaeeddaa', 'd460428c-5cb8-4d73-a3ae-b7ac37b65fbc','1uXTfdH','038019','',false,false,'REFERRAL_STARTED',null),
-    ('fae2ed00-057e-4179-9e55-f6a4f4874cf0', 'd460428c-5cb8-4d73-a3ae-b7ac37b65fbc','1uXTfdH','038019','',false,false,'REFERRAL_STARTED',null);
+    ('0c46ed09-170b-4c0f-aee8-a24eeaeeddaa', 'd460428c-5cb8-4d73-a3ae-b7ac37b65fbc','1uXTfdH','038019','more information',false,false,'REFERRAL_STARTED',null),
+    ('fae2ed00-057e-4179-9e55-f6a4f4874cf0', 'd460428c-5cb8-4d73-a3ae-b7ac37b65fbc','1uXTfdH','038019','more information',false,false,'REFERRAL_STARTED',null);


### PR DESCRIPTION
## Context

https://trello.com/c/vEOIj7KP/1045-build-endpoint-for-returning-an-organisations-referrals-containing-only-data-in-our-service-l

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
