### PR TITLE
#1048 Implemented pagination across the Referral control flow.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
@@ -1,16 +1,19 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
-import java.util.*
+import java.util.UUID
 
 @Repository
-interface JpaReferralRepository : JpaRepository<ReferralEntity, UUID> {
+interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
   @Query(
     value = "SELECT r.* FROM referral r INNER JOIN offering o ON o.offering_id = r.offering_id WHERE o.organisation_id = :organisationId",
+    countQuery = "SELECT count(*) FROM referral r INNER JOIN offering o ON o.offering_id = r.offering_id WHERE o.organisation_id = :organisationId",
     nativeQuery = true,
   )
-  fun getReferralsByOrganisationId(organisationId: String): List<ReferralEntity>
+  fun getReferralsByOrganisationId(organisationId: String, pageable: Pageable): Page<ReferralEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -2,12 +2,14 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service
 
 import jakarta.validation.ValidationException
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.ReferralUpdate
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.JpaReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
 import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
@@ -17,7 +19,7 @@ import kotlin.jvm.optionals.getOrNull
 class ReferralService
 @Autowired
 constructor(
-  private val referralRepository: JpaReferralRepository,
+  private val referralRepository: ReferralRepository,
 ) {
   fun createReferral(
     prisonNumber: String,
@@ -79,5 +81,6 @@ constructor(
     }
   }
 
-  fun getReferralsByOrganisationId(organisationId: String) = referralRepository.getReferralsByOrganisationId(organisationId)
+  fun getReferralsByOrganisationId(organisationId: String, pageable: Pageable): Page<ReferralEntity> =
+    referralRepository.getReferralsByOrganisationId(organisationId, pageable)
 }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -432,7 +432,7 @@ paths:
 
   /referrals/organisation/{organisationId}/dashboard:
     get:
-      summary: Get referrals by organisationId
+      summary: Get paginated referrals by organisationId
       tags:
         - Referrals
       operationId: getReferralSummariesByOrganisationId
@@ -443,23 +443,33 @@ paths:
           required: true
           schema:
             type: string
-            format: string
+        - name: page
+          in: query
+          description: Page number of the requested page
+          required: false
+          schema:
+            type: integer
+            default: 0
+        - name: size
+          in: query
+          description: Number of items per page
+          required: false
+          schema:
+            type: integer
+            default: 10
       responses:
         200:
-          description: Summary of referrals for an organisation
+          description: Paginated summary of referrals for an organisation
           content:
             'application/json':
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ReferralSummary'
+                $ref: '#/components/schemas/PaginatedReferralSummary'
         401:
           description: The request was unauthorised
         403:
-          description: Forbidden.  The client is not authorised to access this offering.
+          description: Forbidden. The client is not authorised to access this offering.
         404:
           description: No referrals for supplied organisationId (Not Found).
-
 
   /offerings/{id}/course:
     get:
@@ -1014,6 +1024,7 @@ components:
         - referral_submitted
         - awaiting_assessment
         - assessment_started
+
     ReferralSummary:
       type: object
       properties:
@@ -1025,11 +1036,28 @@ components:
           $ref: "#/components/schemas/ReferralStatus"
         person:
           $ref: "#/components/schemas/Person"
-
       required:
       - referralId
       - referralStatus
       - person
+
+    PaginatedReferralSummary:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/ReferralSummary'
+        totalPages:
+          type: integer
+        totalElements:
+          type: integer
+        pageSize:
+          type: integer
+        pageNumber:
+          type: integer
+        pageIsEmpty:
+          type: boolean
 
     Person:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
@@ -12,16 +12,16 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ran
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseAlphanumericString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseRepository
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.JpaReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.CourseEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OfferingEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralEntityFactory
 import java.util.UUID
 
-class JpaReferralRepositoryTest
+class ReferralRepositoryTest
 @Autowired
 constructor(
-  val referralRepository: JpaReferralRepository,
+  val referralRepository: ReferralRepository,
   val courseRepository: CourseRepository,
   jdbcTemplate: JdbcTemplate,
 ) : RepositoryTestBase(jdbcTemplate) {


### PR DESCRIPTION
## Context

> [see ticket #1048 on the Accredited Programmes Trello board.](https://trello.com/c/8sm2MfBU/1048-implement-pagination-for-the-caselist-endpoint-m)

## Changes in this PR

- Updated the OpenApi specification to have the `ReferralController` return a paginated version of the usual list of `ReferralSummary` objects. The UI can now call the back-end at, e.g., `/referrals/organisation/{organisationId}/dashboard?page=0&size=3`, to return paginated responses.
- Implemented pagination in the `ReferralRepository`, which makes use of Spring Data JPA's inbuilt paging and sorting.
- Updated unit and integration tests for the referral control flow.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
