### PR TITLE
(1057-adjacent) Add seeded submitted referral

### DIFF
--- a/src/main/resources/seed/db/migration/R__Seed_Data.sql
+++ b/src/main/resources/seed/db/migration/R__Seed_Data.sql
@@ -53,5 +53,6 @@ VALUES ('28e47d30-30bf-4dab-a8eb-9fda3f6400e8', '7fffcc6a-11f8-4713-be35-cf5ff1a
        ('1811faa6-d568-4fc4-83ce-41118b90242e', '7fffcc6a-11f8-4713-be35-cf5ff1aee519'),
        ('2280539a-9b98-44e0-bf7b-f0fc8baf1524', '7fffcc6a-11f8-4713-be35-cf5ff1aee510');
 
-INSERT INTO referral (referral_id, offering_id, prison_number, referrer_id)
-VALUES ('c11fab18-dc8d-420c-9c82-d0edd373732d', '20f3abc8-dd92-43ae-b88e-5797a0ad3f4b', 'ABC1234', '5105a589-75b3-4ca0-9433-b96228c1c8f3');
+INSERT INTO referral (referral_id, offering_id, prison_number, referrer_id, additional_information, oasys_confirmed, has_reviewed_programme_history, status, submitted_on)
+VALUES ('c11fab18-dc8d-420c-9c82-d0edd373732d', '20f3abc8-dd92-43ae-b88e-5797a0ad3f4b', 'ABC1234', '5105a589-75b3-4ca0-9433-b96228c1c8f3', '', false, false, 'REFERRAL_STARTED', null);
+VALUES ('9d38204c-bfe9-42e6-b751-f46cec067e57', '20f3abc8-dd92-43ae-b88e-5797a0ad3f4b', 'ABC1234', '5105a589-75b3-4ca0-9433-b96228c1c8f3', 'Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua. Ut enin ad ninin venian, quis nostrun exercitationen ullan corporis suscipit laboriosan, nisi ut aliquid ex ea connodi consequatur. Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit anin id est laborun.', true, true, 'REFERRAL_SUBMITTED', '2023-10-05T12:48:20');


### PR DESCRIPTION
This will help in local development as we move to restricting submitted referral pages to submitted referrals (we'll want a seeded referral we can easily open up)

I've added in the same fields as set in `R__test_data.sql`

## Context

We're moving to restrict submitted referral pages so that you can't view a draft referral's details via them

## Changes in this PR

- Add seeded submitted referral for use in UI locally

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
