### PR TITLE
Revert possible db-breaking changes to latest flyway migrations

### DIFF
--- a/src/main/resources/db/migration/V24__add_submitted_on_to_referral.sql
+++ b/src/main/resources/db/migration/V24__add_submitted_on_to_referral.sql
@@ -1,2 +1,2 @@
 ALTER TABLE referral
-    ADD COLUMN IF NOT EXISTS submitted_on TIMESTAMP;
+    ADD COLUMN submitted_on TIMESTAMP;

--- a/src/test/resources/db/migration/R__test_data.sql
+++ b/src/test/resources/db/migration/R__test_data.sql
@@ -1,10 +1,3 @@
-DELETE from course_audience;
-DELETE from offering;
-DELETE from prerequisite;
-DELETE from audience;
-DELETE from course;
-DELETE from referral;
-
 INSERT INTO course(course_id, identifier, name, description, alternate_name, referable)
 VALUES ('d3abc217-75ee-46e9-a010-368f30282367', 'LC', 'Lime Course', 'Sample description', 'LC', true),
        ('1811faa6-d568-4fc4-83ce-41118b902421', 'SC', 'Super Course', 'Sample description', 'AC++', true),


### PR DESCRIPTION
## Context

Recent builds have caused significant issues with the dev environment. 

This PR, using the affected branch identified in PR #162 which has since been reverted in #167, investigates the flyway migration changes made previously.

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
