### PR TITLE
(775) Restrict preprod and prod to HMPPS group IPs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.3.1
+  hmpps: ministryofjustice/hmpps@7
   node: circleci/node@4.5.2
 
 parameters:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,6 +14,12 @@ generic-service:
     PRISON-REGISTER-API_BASE-URL: https://prison-register-preprod.hmpps.service.justice.gov.uk
     SENTRY_ENVIRONMENT: preprod
 
+  allowlist:
+    groups:
+      - internal
+      - prisons
+      - private_prisons
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -13,6 +13,12 @@ generic-service:
     PRISON-REGISTER-API_BASE-URL: https://prison-register.hmpps.service.justice.gov.uk
     SENTRY_ENVIRONMENT: prod
 
+  allowlist:
+    groups:
+      - internal
+      - prisons
+      - private_prisons
+
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/3n25jR0i/775-restrict-the-service-to-ips-in-preprod-and-prod-m
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

For security, we should have our preprod and prod environments to whitelisted IP addresses, so they're available to users at the MOJ and in prisons.

## Changes in this PR

This restricts access to the site to IPs in the following groups:
  - Internal
  - Prisons
  - Private prisons

The IPs are listed in [a config file in another repo](https://github.com/ministryofjustice/hmpps-ip-allowlists/blob/main/ip-allowlist-groups.yaml), then published as environment variables in the `hmpps-common-vars` CircleCI context. These are fetched in the `deploy_env` job in CircleCI.

Once this is merged, we'll need to use the MOJ VPN to access these environments.

**N.B** Before merging, we'll need to investigate how this will affect our monitoring with ApplicationInsights as we may need to proxy our health checks through another service now that these can't be queried directly.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
