### PR TITLE
#996 Filtering by `audience`, `status`, and `courseName` for the caselist endpoint (only internal API data for now)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/projection/ReferralSummaryProjection.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/projection/ReferralSummaryProjection.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.read
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection
 
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import java.time.LocalDateTime

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
@@ -27,6 +27,7 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
     WHERE o.organisationId = :organisationId
       AND (:status IS NULL OR r.status = :status)
       AND (:audience IS NULL OR a.value = :audience)
+      AND (:courseName IS NULL OR LOWER(c.name) LIKE LOWER(CONCAT('%', :courseName, '%')))
   """,
     countQuery = """
     SELECT COUNT(DISTINCT r.id)
@@ -37,6 +38,7 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
     WHERE o.organisationId = :organisationId
       AND (:status IS NULL OR r.status = :status)
       AND (:audience IS NULL OR a.value = :audience)
+      AND (:courseName IS NULL OR LOWER(c.name) LIKE LOWER(CONCAT('%', :courseName, '%')))
   """,
     nativeQuery = false,
   )
@@ -45,5 +47,6 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
     pageable: Pageable,
     status: ReferralEntity.ReferralStatus?,
     audience: String?,
+    courseName: String?,
   ): Page<ReferralSummaryProjection>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
@@ -6,14 +6,14 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.read.ReferralSummaryProjection
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
 import java.util.*
 
 @Repository
 interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
   @Query(
     value = """
-    SELECT NEW uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.read.ReferralSummaryProjection(
+    SELECT NEW uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection(
       r.id AS referralId,
       c.name AS courseName, 
       a.value as audience,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
@@ -13,26 +13,37 @@ import java.util.*
 interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
   @Query(
     value = """
-      SELECT NEW uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.read.ReferralSummaryProjection(
-        r.id AS referralId,
-        c.name AS courseName, 
-        a.value as audience,
-        r.status AS status,
-        r.submittedOn AS submittedOn,
-        r.prisonNumber AS prisonNumber
-      ) FROM ReferralEntity r
-      JOIN r.offering o
-      JOIN o.course c
-      JOIN c.audiences a
-      WHERE o.organisationId = :organisationId
-    """,
+    SELECT NEW uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.read.ReferralSummaryProjection(
+      r.id AS referralId,
+      c.name AS courseName, 
+      a.value as audience,
+      r.status AS status,
+      r.submittedOn AS submittedOn,
+      r.prisonNumber AS prisonNumber
+    ) FROM ReferralEntity r
+    JOIN r.offering o
+    JOIN o.course c
+    JOIN c.audiences a
+    WHERE o.organisationId = :organisationId
+      AND (:status IS NULL OR r.status = :status)
+      AND (:audience IS NULL OR a.value = :audience)
+  """,
     countQuery = """
-      SELECT COUNT(DISTINCT r.id)
-      FROM ReferralEntity r
-      INNER JOIN r.offering o
-      WHERE o.organisationId = :organisationId
-    """,
+    SELECT COUNT(DISTINCT r.id)
+    FROM ReferralEntity r
+    INNER JOIN r.offering o
+    INNER JOIN o.course c
+    INNER JOIN c.audiences a
+    WHERE o.organisationId = :organisationId
+      AND (:status IS NULL OR r.status = :status)
+      AND (:audience IS NULL OR a.value = :audience)
+  """,
     nativeQuery = false,
   )
-  fun getReferralsByOrganisationId(organisationId: String, pageable: Pageable): Page<ReferralSummaryProjection>
+  fun getReferralsByOrganisationId(
+    organisationId: String,
+    pageable: Pageable,
+    status: ReferralEntity.ReferralStatus?,
+    audience: String?,
+  ): Page<ReferralSummaryProjection>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.contro
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
@@ -69,7 +70,7 @@ constructor(
     @RequestParam(value = "audience", required = false) audience: String?,
     @RequestParam(value = "courseName", required = false) courseName: String?,
   ): ResponseEntity<PaginatedReferralSummary> {
-    val pageable = PageRequest.of(page, size)
+    val pageable = PageRequest.of(page, size, Sort.by("referralId"))
     val apiReferralSummaryPage = referralService.getReferralsByOrganisationId(organisationId, pageable, status, audience, courseName)
 
     return ResponseEntity.ok(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -65,19 +65,21 @@ constructor(
     organisationId: String,
     @RequestParam(value = "page", defaultValue = "0") page: Int,
     @RequestParam(value = "size", defaultValue = "10") size: Int,
+    @RequestParam(value = "status", required = false) status: String?,
+    @RequestParam(value = "audience", required = false) audience: String?,
   ): ResponseEntity<PaginatedReferralSummary> {
     val pageable = PageRequest.of(page, size)
-    val apiReferralSummaryPage = referralService.getReferralsByOrganisationId(organisationId, pageable)
+    val apiReferralSummaryPage = referralService.getReferralsByOrganisationId(organisationId, pageable, status, audience)
 
-    val paginatedReferralSummary = PaginatedReferralSummary(
-      content = apiReferralSummaryPage.content,
-      totalPages = apiReferralSummaryPage.totalPages,
-      totalElements = apiReferralSummaryPage.totalElements.toInt(),
-      pageSize = apiReferralSummaryPage.size,
-      pageNumber = apiReferralSummaryPage.number,
-      pageIsEmpty = apiReferralSummaryPage.isEmpty,
+    return ResponseEntity.ok(
+      PaginatedReferralSummary(
+        content = apiReferralSummaryPage.content,
+        totalPages = apiReferralSummaryPage.totalPages,
+        totalElements = apiReferralSummaryPage.totalElements.toInt(),
+        pageSize = apiReferralSummaryPage.size,
+        pageNumber = apiReferralSummaryPage.number,
+        pageIsEmpty = apiReferralSummaryPage.isEmpty,
+      ),
     )
-
-    return ResponseEntity.ok(paginatedReferralSummary)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -67,9 +67,10 @@ constructor(
     @RequestParam(value = "size", defaultValue = "10") size: Int,
     @RequestParam(value = "status", required = false) status: String?,
     @RequestParam(value = "audience", required = false) audience: String?,
+    @RequestParam(value = "courseName", required = false) courseName: String?,
   ): ResponseEntity<PaginatedReferralSummary> {
     val pageable = PageRequest.of(page, size)
-    val apiReferralSummaryPage = referralService.getReferralsByOrganisationId(organisationId, pageable, status, audience)
+    val apiReferralSummaryPage = referralService.getReferralsByOrganisationId(organisationId, pageable, status, audience, courseName)
 
     return ResponseEntity.ok(
       PaginatedReferralSummary(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transf
 
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.read.ReferralSummaryProjection
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.ReferralUpdate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Referral as ApiReferral
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus as ApiReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralSummary as ApiReferralSummary

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -94,9 +94,10 @@ constructor(
     pageable: Pageable,
     status: String?,
     audience: String?,
+    courseName: String?,
   ): Page<ReferralSummary> {
     val statusEnum = status?.let { ReferralEntity.ReferralStatus.valueOf(it) }
-    val referralProjectionPage = referralRepository.getReferralsByOrganisationId(organisationId, pageable, statusEnum, audience)
+    val referralProjectionPage = referralRepository.getReferralsByOrganisationId(organisationId, pageable, statusEnum, audience, courseName)
     val apiContent = referralProjectionPage.content.toApi()
     return PageImpl(apiContent, pageable, referralProjectionPage.totalElements)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -89,8 +89,14 @@ constructor(
     }
   }
 
-  fun getReferralsByOrganisationId(organisationId: String, pageable: Pageable): Page<ReferralSummary> {
-    val referralProjectionPage = referralRepository.getReferralsByOrganisationId(organisationId, pageable)
+  fun getReferralsByOrganisationId(
+    organisationId: String,
+    pageable: Pageable,
+    status: String?,
+    audience: String?,
+  ): Page<ReferralSummary> {
+    val statusEnum = status?.let { ReferralEntity.ReferralStatus.valueOf(it) }
+    val referralProjectionPage = referralRepository.getReferralsByOrganisationId(organisationId, pageable, statusEnum, audience)
     val apiContent = referralProjectionPage.content.toApi()
     return PageImpl(apiContent, pageable, referralProjectionPage.totalElements)
   }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -457,6 +457,18 @@ paths:
           schema:
             type: integer
             default: 10
+        - name: status
+          in: query
+          description: Filter by the status of the referral
+          required: false
+          schema:
+            type: string
+        - name: audience
+          in: query
+          description: Filter by the audience of the referral
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Paginated summary of referrals for an organisation

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -469,6 +469,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: courseName
+          in: query
+          description: Filter by the name of the course associated with this referral
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Paginated summary of referrals for an organisation

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
@@ -77,6 +77,9 @@ class PactContractTest {
   @State("Referral can be submitted")
   fun `ensure referral can be submitted`() {}
 
+  @State("Referral summaries exist for an organisation with the ID a026cc07-8e0b-40dd-9b66-1b3dacecc63d")
+  fun `ensure referral summaries exist for an organisation with the ID a026cc07-8e0b-40dd-9b66-1b3dacecc63d`() {}
+
   @TestTemplate
   @ExtendWith(PactVerificationSpringProvider::class)
   fun template(context: PactVerificationContext, request: HttpRequest) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralSummaryProjectionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralSummaryProjectionFactory.kt
@@ -5,7 +5,7 @@ import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomPrisonNumber
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomSentence
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.read.ReferralSummaryProjection
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
 import java.time.LocalDateTime
 import java.util.*
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -21,6 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
@@ -344,7 +345,7 @@ constructor(
   @Test
   fun `getReferralsByOrganisationId with valid organisationId returns 200 with paginated body`() {
     val organisationId = "MDI"
-    val pageable = PageRequest.of(0, 10)
+    val pageable = PageRequest.of(0, 10, Sort.by("referralId"))
 
     val firstReferralId = UUID.randomUUID()
     val audiencesForFirstReferral = listOf("Audience 1", "Audience 2", "Audience 3")
@@ -419,6 +420,8 @@ constructor(
   fun `getReferralsByOrganisationId with valid organisationId and custom pagination count will return 200 with paginated body for each page`() {
     val organisationId = "MDI"
     val pageSize = 1
+    val pageableFirstPage = PageRequest.of(0, pageSize, Sort.by("referralId"))
+    val pageableSecondPage = PageRequest.of(1, pageSize, Sort.by("referralId"))
 
     val firstReferralId = UUID.randomUUID()
     val audiencesForFirstReferral = listOf("Audience 1", "Audience 2", "Audience 3")
@@ -445,11 +448,11 @@ constructor(
         .produce()
     }
 
-    every { referralService.getReferralsByOrganisationId(organisationId, PageRequest.of(0, pageSize), null, null, null) } returns
-      PageImpl(projectionsForFirstReferral.toApi(), PageRequest.of(0, pageSize), 2)
+    every { referralService.getReferralsByOrganisationId(organisationId, pageableFirstPage, null, null, null) } returns
+      PageImpl(projectionsForFirstReferral.toApi(), pageableFirstPage, 2)
 
-    every { referralService.getReferralsByOrganisationId(organisationId, PageRequest.of(1, pageSize), null, null, null) } returns
-      PageImpl(projectionsForSecondReferral.toApi(), PageRequest.of(1, pageSize), 2)
+    every { referralService.getReferralsByOrganisationId(organisationId, pageableSecondPage, null, null, null) } returns
+      PageImpl(projectionsForSecondReferral.toApi(), pageableSecondPage, 2)
 
     val firstPageResult = mockMvc.get("/referrals/organisation/$organisationId/dashboard") {
       param("page", "0")
@@ -502,8 +505,8 @@ constructor(
       referral.prisonNumber shouldBe PRISON_NUMBER
     }
 
-    verify(exactly = 1) { referralService.getReferralsByOrganisationId(organisationId, PageRequest.of(0, pageSize), null, null, null) }
-    verify(exactly = 1) { referralService.getReferralsByOrganisationId(organisationId, PageRequest.of(1, pageSize), null, null, null) }
+    verify(exactly = 1) { referralService.getReferralsByOrganisationId(organisationId, pageableFirstPage, null, null, null) }
+    verify(exactly = 1) { referralService.getReferralsByOrganisationId(organisationId, pageableSecondPage, null, null, null) }
   }
 
   @ParameterizedTest
@@ -515,7 +518,7 @@ constructor(
     expectedReferralSummaries: List<ReferralSummary>,
   ) {
     val organisationId = "MDI"
-    val pageable = PageRequest.of(0, 10)
+    val pageable = PageRequest.of(0, 10, Sort.by("referralId"))
 
     every { referralService.getReferralsByOrganisationId(organisationId, pageable, statusFilter, audienceFilter, courseNameFilter) } returns
       PageImpl(expectedReferralSummaries, pageable, 1)
@@ -555,7 +558,7 @@ constructor(
   @Test
   fun `getReferralsByOrganisationId with random organisationId returns 200 with paginated empty body`() {
     val orgId = UUID.randomUUID().toString()
-    val pageable = PageRequest.of(0, 10)
+    val pageable = PageRequest.of(0, 10, Sort.by("referralId"))
 
     every { referralService.getReferralsByOrganisationId(orgId, pageable, null, null, null) } returns
       PageImpl(emptyList(), pageable, 0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -1,31 +1,76 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.service
 
-import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.read.ReferralSummaryProjection
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.JpaOfferingRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toApi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralSummaryProjectionFactory
-import java.time.LocalDateTime
 import java.util.UUID
+import java.util.stream.Stream
 
 class ReferralServiceTest {
 
   companion object {
-    const val PRISON_NUMBER = "A1234AA"
+    private const val PRISON_NUMBER = "A1234AA"
+
+    @JvmStatic
+    fun parametersForGetReferralsByOrganisationId(): Stream<Arguments> {
+      val projections1 = listOf("Audience 1", "Audience 2").map { audience ->
+        ReferralSummaryProjectionFactory()
+          .withReferralId(UUID.randomUUID())
+          .withCourseName("Course for referralSummary1")
+          .withAudience(audience)
+          .withStatus(ReferralEntity.ReferralStatus.REFERRAL_STARTED)
+          .withPrisonNumber(PRISON_NUMBER)
+          .produce()
+      }
+
+      val projections2 = listOf("Audience 2", "Audience 3").map { audience ->
+        ReferralSummaryProjectionFactory()
+          .withReferralId(UUID.randomUUID())
+          .withCourseName("Course for referralSummary2")
+          .withAudience(audience)
+          .withStatus(ReferralEntity.ReferralStatus.REFERRAL_SUBMITTED)
+          .withPrisonNumber(PRISON_NUMBER)
+          .produce()
+      }
+
+      val projections3 = listOf("Audience 3", "Audience 4").map { audience ->
+        ReferralSummaryProjectionFactory()
+          .withReferralId(UUID.randomUUID())
+          .withCourseName("Course for referralSummary3")
+          .withAudience(audience)
+          .withStatus(ReferralEntity.ReferralStatus.REFERRAL_SUBMITTED)
+          .withPrisonNumber(PRISON_NUMBER)
+          .produce()
+      }
+
+      return Stream.of(
+        Arguments.of("REFERRAL_STARTED", null, projections1),
+        Arguments.of(null, "Audience 2", projections1 + projections2),
+        Arguments.of("REFERRAL_SUBMITTED", "Audience 3", projections2 + projections3),
+        Arguments.of("REFERRAL_SUBMITTED", "Audience 4", projections3),
+        Arguments.of(null, null, projections1 + projections2 + projections3),
+        Arguments.of("AWAITING_ASSESSMENT", null, emptyList<ReferralSummaryProjection>()),
+        Arguments.of(null, "Audience X", emptyList<ReferralSummaryProjection>()),
+      )
+    }
   }
 
   @MockK(relaxed = true)
@@ -42,86 +87,44 @@ class ReferralServiceTest {
     referralService = ReferralService(referralRepository, offeringRepository)
   }
 
-  @Nested
-  @DisplayName("Get Referral Summaries")
-  inner class ReferralSummaryTests {
-    @Test
-    fun `getReferralsByOrganisationId with valid organisationId should return pageable ReferralSummary objects`() {
-      val orgId = "MDI"
-      val pageable = PageRequest.of(0, 10)
+  @ParameterizedTest
+  @MethodSource("parametersForGetReferralsByOrganisationId")
+  fun `getReferralsByOrganisationId with valid organisationId and filtering should return pageable ReferralSummary objects`(
+    statusFilter: String?,
+    audienceFilter: String?,
+    expectedReferralSummaryProjections: List<ReferralSummaryProjection>,
+  ) {
+    val orgId = "MDI"
+    val pageable = PageRequest.of(0, 10)
+    val status = statusFilter?.let { ReferralEntity.ReferralStatus.valueOf(it) }
 
-      val firstReferralId = UUID.randomUUID()
-      val audiencesForFirstReferral = listOf("Audience 1", "Audience 2", "Audience 3")
-      val projectionsForFirstReferral = audiencesForFirstReferral.map { audience ->
-        ReferralSummaryProjectionFactory()
-          .withReferralId(firstReferralId)
-          .withCourseName("Course name")
-          .withAudience(audience)
-          .withStatus(ReferralEntity.ReferralStatus.REFERRAL_STARTED)
-          .withPrisonNumber(PRISON_NUMBER)
-          .produce()
-      }
+    every { referralRepository.getReferralsByOrganisationId(orgId, pageable, status, audienceFilter) } returns
+      PageImpl(expectedReferralSummaryProjections, pageable, expectedReferralSummaryProjections.size.toLong())
 
-      val secondReferralId = UUID.randomUUID()
-      val audiencesForSecondReferral = listOf("Audience 4", "Audience 5", "Audience 6")
-      val projectionsForSecondReferral = audiencesForSecondReferral.map { audience ->
-        ReferralSummaryProjectionFactory()
-          .withReferralId(secondReferralId)
-          .withCourseName("Another course name")
-          .withAudience(audience)
-          .withStatus(ReferralEntity.ReferralStatus.REFERRAL_SUBMITTED)
-          .withSubmittedOn(LocalDateTime.MIN)
-          .withPrisonNumber(PRISON_NUMBER)
-          .produce()
-      }
+    val resultPage = referralService.getReferralsByOrganisationId(orgId, pageable, statusFilter, audienceFilter)
 
-      every { referralRepository.getReferralsByOrganisationId(orgId, pageable) } returns
-        PageImpl(projectionsForFirstReferral + projectionsForSecondReferral, pageable, 2L)
+    resultPage.totalElements shouldBe expectedReferralSummaryProjections.size.toLong()
 
-      val resultPage = referralService.getReferralsByOrganisationId(orgId, pageable)
+    val expectedTotalPages = (expectedReferralSummaryProjections.size + pageable.pageSize - 1) / pageable.pageSize
+    resultPage.totalPages shouldBe expectedTotalPages
 
-      resultPage.totalPages shouldBe 1
-      resultPage.content shouldHaveSize 2
-      resultPage.totalElements shouldBe 2
+    val expectedApiReferralSummaries = expectedReferralSummaryProjections.toApi()
+    resultPage.content shouldContainAll expectedApiReferralSummaries
 
-      val firstReferral = resultPage.content.find { it.id == firstReferralId }
-      firstReferral shouldNotBe null
-      firstReferral?.let { referral ->
-        with(referral) {
-          courseName shouldBe "Course name"
-          audiences shouldBe listOf("Audience 1", "Audience 2", "Audience 3")
-          status shouldBe ReferralStatus.referralStarted
-          prisonNumber shouldBe PRISON_NUMBER
-        }
-      }
+    verify { referralRepository.getReferralsByOrganisationId(orgId, pageable, status, audienceFilter) }
+  }
 
-      val secondReferral = resultPage.content.find { it.id == secondReferralId }
-      secondReferral shouldNotBe null
-      secondReferral?.let { referral ->
-        with(referral) {
-          courseName shouldBe "Another course name"
-          audiences shouldBe listOf("Audience 4", "Audience 5", "Audience 6")
-          status shouldBe ReferralStatus.referralSubmitted
-          submittedOn shouldBe LocalDateTime.MIN.toString()
-          prisonNumber shouldBe PRISON_NUMBER
-        }
-      }
+  @Test
+  fun `getReferralsByOrganisationId with random organisationId should return pageable empty list`() {
+    val orgId = UUID.randomUUID().toString()
+    val pageable = PageRequest.of(0, 10)
 
-      verify { referralRepository.getReferralsByOrganisationId(orgId, pageable) }
-    }
+    every { referralRepository.getReferralsByOrganisationId(orgId, pageable, null, null) } returns PageImpl(emptyList())
 
-    @Test
-    fun `getReferralsByOrganisationId with random organisationId should return pageable empty list`() {
-      val orgId = UUID.randomUUID().toString()
-      val pageable = PageRequest.of(0, 10)
+    val resultPage = referralService.getReferralsByOrganisationId(orgId, pageable, null, null)
+    resultPage.content shouldBe emptyList()
+    resultPage.totalElements shouldBe 0
 
-      every { referralRepository.getReferralsByOrganisationId(orgId, pageable) } returns PageImpl(emptyList())
-
-      val resultPage = referralService.getReferralsByOrganisationId(orgId, pageable)
-      resultPage.content shouldBe emptyList()
-      resultPage.totalElements shouldBe 0
-
-      verify { referralRepository.getReferralsByOrganisationId(orgId, pageable) }
-    }
+    verify { referralRepository.getReferralsByOrganisationId(orgId, pageable, null, null) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -14,7 +14,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.read.ReferralSummaryProjection
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.JpaOfferingRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toApi


### PR DESCRIPTION
## Context

> [See #996 on the Accredited Programmes Trello board.](https://trello.com/c/b6nK2Ryc/996-add-filtering-for-caselist-endpoint-m)

We wanted to apply filtering to the various referral summaries a user would retrieve from the db - namely, for `audience` and `status` aspects of referrals. As with pagination, this is applied across the controller layer, meaning that any subsequent changes to the underlying shape of the data - e.g. when implementing data retrieved from calls to other APIs - should have a negligible effect upon the logic used to filter results.

## Changes in this PR

- Added filtering to the referral endpoint for `audience`, `status`, and `courseName` which may be used in any combination.
- Updated unit testing to reflect this flexibility with several `@ParameterizedTest`s.
- Updated integration testing to replace the original non-parameterised test with a parameterised one.
- Updated service and repository layer to correctly account for the new passed parameters. This meant changing a `String` to a `ReferralStatus` in the repository layer so that the db is happy, and performing that transformation in the service layer.
- Added a pact test for the referral status endpoint, as CI was moaning that we didn't have one.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
