### PR TITLE
1166 add route for fetching all courses for an organisation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/OrganisationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/OrganisationController.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.controller
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.OrganisationsApiDelegate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Course
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toApi
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.CourseService
+
+@Service
+class OrganisationController
+@Autowired
+constructor(
+  private val courseService: CourseService,
+) : OrganisationsApiDelegate {
+  override fun getAllCoursesByOrganisationId(organisationId: String): ResponseEntity<List<Course>> =
+    ResponseEntity
+      .ok(
+        courseService
+          .getAllOfferingsByOrganisationId(organisationId)
+          .map { it.course }
+          .map { it.toApi() },
+      )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
@@ -27,6 +27,7 @@ constructor(
   fun getCourseByOfferingId(offeringId: UUID): CourseEntity? = courseRepository.getCourseByOfferingId(offeringId)
 
   fun getAllOfferings(): List<OfferingEntity> = courseRepository.getAllOfferings().filterNot(OfferingEntity::withdrawn)
+  fun getAllOfferingsByOrganisationId(organisationId: String): List<OfferingEntity> = courseRepository.getAllOfferings().filter { it.organisationId == organisationId }
 
   fun getAllOfferingsByCourseId(courseId: UUID): List<OfferingEntity> = courseRepository
     .getAllOfferingsByCourseId(courseId)

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -164,6 +164,29 @@ paths:
                 items:
                   $ref: '#/components/schemas/CourseOffering'
 
+  /organisations/{organisationId}/courses:
+    get:
+      tags:
+        - Course Offerings
+      summary: List all courses for an organisationId
+      operationId: getAllCoursesByOrganisationId
+      parameters:
+        - name: organisationId
+          in: path
+          description: A organisation identifier
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Course'
+
   /offerings/csv:
     put:
       tags:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/OrganisationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/OrganisationControllerTest.kt
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.restapi.controller
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders.AUTHORIZATION
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.CourseService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.CourseEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OfferingEntityFactory
+
+private const val ORG_ID = "OF1"
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(JwtAuthHelper::class)
+class OrganisationControllerTest
+@Autowired
+constructor(
+  val mockMvc: MockMvc,
+  val jwtAuthHelper: JwtAuthHelper,
+) {
+
+  @MockkBean
+  private lateinit var courseService: CourseService
+
+  @Nested
+  inner class GetCoursesByOrganisationIdTests {
+    @Test
+    fun `getAllCoursesByOrganisationId with JWT returns 200 with correct body`() {
+      val offeringEntity1 = OfferingEntityFactory().withOrganisationId(ORG_ID).withContactEmail("of1@digital.justice.gov.uk")
+        .produce()
+      offeringEntity1.course = CourseEntityFactory().produce()
+
+      val offeringEntity2 = OfferingEntityFactory().withOrganisationId(ORG_ID).withContactEmail("of2@digital.justice.gov.uk")
+        .produce()
+      offeringEntity2.course = CourseEntityFactory().produce()
+
+      val offerings = listOf(offeringEntity1, offeringEntity2)
+
+      every { courseService.getAllOfferingsByOrganisationId(ORG_ID) } returns offerings
+
+      mockMvc.get("/organisations/$ORG_ID/courses") {
+        accept = MediaType.APPLICATION_JSON
+        header(AUTHORIZATION, jwtAuthHelper.bearerToken())
+      }.andExpect {
+        status { isOk() }
+        content {
+          contentType(MediaType.APPLICATION_JSON)
+          assertThat(offerings.size).isEqualTo(2)
+
+          assertThat(offerings[0].organisationId).isEqualTo(ORG_ID)
+          assertThat(offerings[1].organisationId).isEqualTo(ORG_ID)
+          assertThat(offerings[0].contactEmail).isEqualTo("of1@digital.justice.gov.uk")
+          assertThat(offerings[1].contactEmail).isEqualTo("of2@digital.justice.gov.uk")
+        }
+      }
+    }
+
+    @Test
+    fun `getAllCoursesByOrganisationId without JWT returns 401`() {
+      mockMvc.get("/organisations/$ORG_ID/courses") {
+        accept = MediaType.APPLICATION_JSON
+      }.andExpect {
+        status { isUnauthorized() }
+      }
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/CourseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/CourseServiceTest.kt
@@ -452,4 +452,28 @@ class CourseServiceTest {
       courseService.getAllCourses().shouldContainExactly(activeCourse)
     }
   }
+
+  @Nested
+  @DisplayName("Get Offerings by organisationId")
+  inner class GetOfferingsByOrganisationId {
+
+    @Test
+    fun `should return empty list when no offerings exist for an organisationId`() {
+      val offering = OfferingEntity(withdrawn = true, organisationId = "BWI", contactEmail = "a@b.com")
+
+      every { courseRepository.getAllOfferings() } returns listOf(offering)
+
+      courseService.getAllOfferingsByOrganisationId("xxx").isEmpty()
+    }
+
+    @Test
+    fun `should return only offerings for requested organisationID`() {
+      val offering1 = OfferingEntity(withdrawn = true, organisationId = "BWI", contactEmail = "a@b.com")
+      val offering2 = OfferingEntity(organisationId = "MDI", contactEmail = "a@b.com")
+
+      every { courseRepository.getAllOfferings() } returns listOf(offering1, offering2)
+
+      courseService.getAllOfferingsByOrganisationId(offering1.organisationId).shouldContainExactly(offering1)
+    }
+  }
 }


### PR DESCRIPTION
## Context

https://trello.com/c/w2RX414a/1166-add-route-for-fetching-all-courses-for-an-organisation-m
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR
Fetches all courses based on organisation id

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
