### PR TITLE
Add workflow to check commit messages

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -1,0 +1,15 @@
+name: Git
+
+on:
+  pull_request:
+
+jobs:
+  message-check:
+    name: Block fixup, squash and merge commits
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Block fixup and squash commits
+        uses: 13rac1/block-fixup-merge-action@v2.0.0


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

There's currently a risk of fixup commits getting merged

## Changes in this PR

Add workflow to check commit messages to ensure there are no `fixup!` and `squash!` commits before merging to `main`

Squash commits will only be noted in the failing workflow step if there are no fixup commits - the workflow appears to exit early if fixup commits are found

Per UI: https://github.com/ministryofjustice/hmpps-accredited-programmes-ui/commit/7cf05806649879a1e32fc144f6390bddba29e4fb

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
