### PR TITLE
Add guard for empty `courseName` query

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
@@ -27,7 +27,7 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
     WHERE o.organisationId = :organisationId
       AND (:status IS NULL OR r.status = :status)
       AND (:audience IS NULL OR a.value = :audience)
-      AND (:courseName IS NULL OR LOWER(c.name) LIKE LOWER(CONCAT('%', :courseName, '%')))
+      AND (:courseName IS NULL OR :courseName = '' OR LOWER(c.name) LIKE LOWER(CONCAT('%', :courseName, '%')))
   """,
     countQuery = """
     SELECT COUNT(DISTINCT r.id)
@@ -38,7 +38,7 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
     WHERE o.organisationId = :organisationId
       AND (:status IS NULL OR r.status = :status)
       AND (:audience IS NULL OR a.value = :audience)
-      AND (:courseName IS NULL OR LOWER(c.name) LIKE LOWER(CONCAT('%', :courseName, '%')))
+      AND (:courseName IS NULL OR :courseName = '' OR LOWER(c.name) LIKE LOWER(CONCAT('%', :courseName, '%')))
   """,
     nativeQuery = false,
   )


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

`/referrals/organisation/:orgID/dashboard` was throwing an error on the local environment when not passing a query parameter, as we were trying to call `LIKE` on an empty string, which is apparently not allowed.

## Changes in this PR

Explicitly checks the value is not an empty string before trying to call `LIKE` on it.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
