### PR TITLE
#1122 Implement new ReferrerUser entity and update Referrer accordingly.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
   val springdocVersion = "2.2.0"
   val sentryVersion = "6.30.0"
   val jsonWebtokenVersion = "0.12.2"
+  val springSecurityVersion = "6.2.0"
 
   runtimeOnly("org.postgresql:postgresql:42.6.0")
 
@@ -43,6 +44,7 @@ dependencies {
   testImplementation("io.jsonwebtoken:jjwt-orgjson:$jsonWebtokenVersion")
   testImplementation("au.com.dius.pact.provider:junit5spring:4.6.3")
   testImplementation("io.github.bluegroundltd:kfactory:1.0.0")
+  testImplementation("org.springframework.security:spring-security-test:$springSecurityVersion")
 }
 
 java {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseParticipationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseParticipationEntity.kt
@@ -15,6 +15,7 @@ import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import org.springframework.security.core.context.SecurityContextHolder
 import java.time.LocalDateTime
 import java.time.Year
 import java.util.UUID
@@ -41,7 +42,7 @@ data class CourseParticipationEntity(
   var outcome: CourseParticipationOutcome? = null,
 
   @CreatedBy
-  var createdByUsername: String = "anonymous",
+  var createdByUsername: String = SecurityContextHolder.getContext().authentication?.name ?: "UNKNOWN_USER",
 
   @CreatedDate
   var createdDateTime: LocalDateTime = LocalDateTime.MIN,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
@@ -25,7 +25,7 @@ data class ReferralEntity(
   @Id
   @GeneratedValue
   @Column(name = "referral_id")
-  val id: UUID? = null,
+  var id: UUID? = null,
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "offering_id", referencedColumnName = "offering_id")
@@ -33,6 +33,11 @@ data class ReferralEntity(
 
   val prisonNumber: String,
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "referrer_username", referencedColumnName = "referrer_username")
+  var referrer: ReferrerUserEntity,
+
+  @Deprecated("Use referrer_user.username instead.")
   val referrerId: String,
 
   var additionalInformation: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferrerUserEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferrerUserEntity.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "referrer_user")
+data class ReferrerUserEntity(
+  @Id
+  @Column(name = "referrer_username", nullable = false)
+  var username: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/projection/ReferralSummaryProjection.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/projection/ReferralSummaryProjection.kt
@@ -11,4 +11,5 @@ data class ReferralSummaryProjection(
   val status: ReferralEntity.ReferralStatus,
   val submittedOn: LocalDateTime?,
   val prisonNumber: String,
+  val referrerUsername: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
@@ -19,11 +19,13 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
       a.value as audience,
       r.status AS status,
       r.submittedOn AS submittedOn,
-      r.prisonNumber AS prisonNumber
+      r.prisonNumber AS prisonNumber,
+      ru.username AS referralUsername
     ) FROM ReferralEntity r
     JOIN r.offering o
     JOIN o.course c
     JOIN c.audiences a
+    JOIN r.referrer ru
     WHERE o.organisationId = :organisationId
       AND (:status IS NULL OR r.status = :status)
       AND (:audience IS NULL OR a.value = :audience)
@@ -32,9 +34,9 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
     countQuery = """
     SELECT COUNT(DISTINCT r.id)
     FROM ReferralEntity r
-    INNER JOIN r.offering o
-    INNER JOIN o.course c
-    INNER JOIN c.audiences a
+    JOIN r.offering o
+    JOIN o.course c
+    JOIN c.audiences a
     WHERE o.organisationId = :organisationId
       AND (:status IS NULL OR r.status = :status)
       AND (:audience IS NULL OR a.value = :audience)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferrerUserRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferrerUserRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferrerUserEntity
+
+@Repository
+interface ReferrerUserRepository : JpaRepository<ReferrerUserEntity, String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
@@ -13,6 +13,7 @@ fun ReferralEntity.toApi(): ApiReferral = ApiReferral(
   id = id!!,
   offeringId = offering.id!!,
   prisonNumber = prisonNumber,
+  referrerUsername = referrer.username,
   referrerId = referrerId,
   oasysConfirmed = oasysConfirmed,
   hasReviewedProgrammeHistory = hasReviewedProgrammeHistory,
@@ -54,6 +55,7 @@ fun List<ReferralSummaryProjection>.toApi(): List<ApiReferralSummary> {
 
       ApiReferralSummary(
         id = id,
+        referrerUsername = firstProjection.referrerUsername,
         courseName = firstProjection.courseName,
         audiences = projections.map { it.audience }.distinct(),
         status = firstProjection.status.toApi(),

--- a/src/main/resources/db/migration/V25__create_user_table.sql
+++ b/src/main/resources/db/migration/V25__create_user_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS referrer_user
+(
+    referrer_username TEXT NOT NULL,
+    CONSTRAINT referrer_user_username_pk PRIMARY KEY (referrer_username)
+);
+
+ALTER TABLE referral
+    ADD COLUMN referrer_username TEXT;
+
+ALTER TABLE referral
+    ADD CONSTRAINT referrer_user_username_fk
+        FOREIGN KEY (referrer_username) REFERENCES referrer_user(referrer_username);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -998,6 +998,7 @@ components:
         referrerId:
           description: A permanent identifier for the person creating the referral. StaffId for prison staff.
           type: string
+          deprecated: true
       required:
         - offeringId
         - prisonNumber
@@ -1030,12 +1031,15 @@ components:
               format: uuid
             status:
               $ref: "#/components/schemas/ReferralStatus"
+            referrerUsername:
+              type: string
             submittedOn:
               type: string
           required:
             - id
             - offeringId
             - prisonNumber
+            - referrerUsername
             - referrerId
             - oasysConfirmed
             - status
@@ -1073,6 +1077,9 @@ components:
           description: The unique id (UUID) of the new referral.
           type: string
           format: uuid
+        referrerUsername:
+          description: The unique HMPPS username of the user who created this referral.
+          type: string
         courseName:
           type: string
         audiences:
@@ -1087,6 +1094,7 @@ components:
           type: string
       required:
       - id
+      - referrerUsername
       - courseName
       - audiences
       - status

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
@@ -1,3 +1,4 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util
 
 const val TEST_USER_NAME = "TestUsername"
+const val CLIENT_USERNAME = "TEST_REFERRER_USER_1"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
@@ -1,4 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util
 
-const val TEST_USER_NAME = "TestUsername"
+import java.util.UUID
+
+const val PRISON_NUMBER = "A1234AA"
+const val REFERRER_ID = "MWX001"
 const val CLIENT_USERNAME = "TEST_REFERRER_USER_1"
+val COURSE_ID: UUID = UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367")
+val COURSE_OFFERING_ID: UUID = UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
@@ -9,6 +9,7 @@ import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
@@ -66,7 +67,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
     val responseBodySpec = webTestClient
       .get()
       .uri("/courses/course-names")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -82,7 +83,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
     webTestClient
       .get()
       .uri("/courses/$COURSE_ID")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -98,7 +99,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
     webTestClient
       .get()
       .uri("/courses/$randomId")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isNotFound
@@ -116,7 +117,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
     webTestClient
       .get()
       .uri("/offerings/$COURSE_OFFERING_ID/course")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -130,7 +131,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
     webTestClient
       .get()
       .uri("/courses/$COURSE_ID/offerings")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -151,7 +152,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
     webTestClient
       .get()
       .uri("/offerings/$COURSE_OFFERING_ID")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -215,7 +216,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
     val downloadedCoursesCsv = webTestClient
       .get()
       .uri("/courses/csv")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MEDIA_TYPE_TEXT_CSV)
       .exchange()
       .expectStatus().isOk
@@ -263,7 +264,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
     val downloadedPrerequisitesCsv = webTestClient
       .get()
       .uri("/courses/prerequisites/csv")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MEDIA_TYPE_TEXT_CSV)
       .exchange()
       .expectStatus().isOk
@@ -340,7 +341,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
     val downloadedOfferingsCsv = webTestClient
       .get()
       .uri("/offerings/csv")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MEDIA_TYPE_TEXT_CSV)
       .exchange()
       .expectStatus().isOk
@@ -362,7 +363,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
     webTestClient
       .put()
       .uri("/courses/csv")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .contentType(MEDIA_TYPE_TEXT_CSV)
       .bodyValue(coursesCsvData)
       .exchange()
@@ -373,7 +374,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
     webTestClient
       .put()
       .uri("/offerings/csv")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .contentType(MEDIA_TYPE_TEXT_CSV)
       .bodyValue(offeringsCsvData)
       .exchange()
@@ -383,7 +384,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
     webTestClient
       .put()
       .uri("/courses/prerequisites/csv")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .contentType(MEDIA_TYPE_TEXT_CSV)
       .bodyValue(prerequisitesCsvData)
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
@@ -17,6 +17,8 @@ import org.springframework.test.web.reactive.server.EntityExchangeResult
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.COURSE_ID
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.COURSE_OFFERING_ID
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.MEDIA_TYPE_TEXT_CSV
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.generateCourseRecords
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.generateOfferingRecords
@@ -30,10 +32,6 @@ import java.util.UUID
 @ActiveProfiles("test")
 @Import(JwtAuthHelper::class)
 class CourseIntegrationTest : IntegrationTestBase() {
-  companion object {
-    val COURSE_ID: UUID = UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367")
-    val COURSE_OFFERING_ID: UUID = UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517")
-  }
 
   @Test
   fun `Searching for all courses with JWT returns 200 with correct body`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationIntegrationTest.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import org.springframework.http.MediaType
@@ -134,7 +135,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     webTestClient
       .post()
       .uri("/course-participations")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
       .bodyValue(invalidCourseParticipation)
@@ -217,7 +218,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     webTestClient
       .put()
       .uri("/course-participations/{id}", nonExistentId)
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
       .bodyValue(updateAttempt)
@@ -293,7 +294,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     webTestClient
       .post()
       .uri("/course-participations")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
       .bodyValue(courseParticipationToAdd)
@@ -306,7 +307,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     webTestClient
       .put()
       .uri("/course-participations/{id}", id)
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(update)
       .exchange()
@@ -318,7 +319,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     webTestClient
       .delete()
       .uri("/course-participations/{id}", id)
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
 
@@ -326,7 +327,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     webTestClient
       .get()
       .uri("/course-participations/{id}", id)
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -337,7 +338,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     webTestClient
       .get()
       .uri("/course-participations/{id}", id)
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .returnResult<Any>().status
@@ -346,7 +347,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     webTestClient
       .get()
       .uri("/people/{prisonNumber}/course-participations", prisonNumber)
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationIntegrationTest.kt
@@ -23,7 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Cours
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationSettingType
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.CourseParticipationUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.TEST_USER_NAME
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomPrisonNumber
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -76,7 +76,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
           yearStarted = created.outcome?.yearStarted,
           yearCompleted = created.outcome?.yearCompleted,
         ),
-        addedBy = TEST_USER_NAME,
+        addedBy = CLIENT_USERNAME,
         createdAt = LocalDateTime.MAX.format(DateTimeFormatter.ISO_DATE_TIME),
       ),
       CourseParticipation::createdAt,
@@ -107,7 +107,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
         detail = null,
         setting = null,
         outcome = null,
-        addedBy = TEST_USER_NAME,
+        addedBy = CLIENT_USERNAME,
         createdAt = LocalDateTime.MAX.format(DateTimeFormatter.ISO_DATE_TIME),
       ),
       CourseParticipation::createdAt,
@@ -188,7 +188,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
           yearStarted = updated.outcome?.yearStarted,
           yearCompleted = updated.outcome?.yearCompleted,
         ),
-        addedBy = TEST_USER_NAME,
+        addedBy = CLIENT_USERNAME,
         createdAt = LocalDateTime.MAX.format(DateTimeFormatter.ISO_DATE_TIME),
       ),
       CourseParticipation::createdAt,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/IntegrationTestBase.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
@@ -25,7 +26,7 @@ abstract class IntegrationTestBase {
     webTestClient
       .get()
       .uri("/courses")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -36,7 +37,7 @@ abstract class IntegrationTestBase {
     webTestClient
       .get()
       .uri("/courses/$courseId")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
@@ -51,7 +52,7 @@ abstract class IntegrationTestBase {
     webTestClient
       .get()
       .uri("/courses/$courseId/offerings")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.expectBody
@@ -87,7 +88,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     webTestClient
       .put()
       .uri("/referrals/${UUID.randomUUID()}")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(
         ReferralUpdate(
@@ -108,7 +109,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     webTestClient
       .put()
       .uri("/referrals/$createdReferralId/status")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .contentType(MediaType.APPLICATION_JSON)
       .bodyValue(
         ReferralStatusUpdate(
@@ -154,7 +155,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     webTestClient
       .post()
       .uri("/referrals/${UUID.randomUUID()}/submit")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isNotFound
@@ -203,48 +204,51 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     paginatedReferralSummaries.content?.shouldBeEmpty()
   }
 
-  fun createReferral(offeringId: UUID) = webTestClient
-    .post()
-    .uri("/referrals")
-    .headers(jwtAuthHelper.authorizationHeaderConfigurer())
-    .contentType(MediaType.APPLICATION_JSON)
-    .accept(MediaType.APPLICATION_JSON)
-    .bodyValue(
-      ReferralCreate(
-        offeringId = offeringId,
-        referrerId = REFERRER_ID,
-        prisonNumber = PRISON_NUMBER,
-      ),
-    )
-    .exchange()
-    .expectStatus().isCreated
-    .expectBody<ReferralCreated>()
-    .returnResult().responseBody!!
+  fun createReferral(offeringId: UUID) =
+    webTestClient
+      .post()
+      .uri("/referrals")
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      .contentType(MediaType.APPLICATION_JSON)
+      .accept(MediaType.APPLICATION_JSON)
+      .bodyValue(
+        ReferralCreate(
+          offeringId = offeringId,
+          prisonNumber = PRISON_NUMBER,
+          referrerId = REFERRER_ID,
+        ),
+      )
+      .exchange()
+      .expectStatus().isCreated
+      .expectBody<ReferralCreated>()
+      .returnResult().responseBody!!
 
-  fun getReferralById(createdReferralId: UUID) = webTestClient
-    .get()
-    .uri("/referrals/$createdReferralId")
-    .headers(jwtAuthHelper.authorizationHeaderConfigurer())
-    .accept(MediaType.APPLICATION_JSON)
-    .exchange()
-    .expectStatus().isOk
-    .expectBody<Referral>()
-    .returnResult().responseBody!!
+  fun getReferralById(createdReferralId: UUID) =
+    webTestClient
+      .get()
+      .uri("/referrals/$createdReferralId")
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<Referral>()
+      .returnResult().responseBody!!
 
-  fun updateReferral(referralId: UUID, referralUpdate: ReferralUpdate): Any = webTestClient
-    .put()
-    .uri("/referrals/$referralId")
-    .headers(jwtAuthHelper.authorizationHeaderConfigurer())
-    .contentType(MediaType.APPLICATION_JSON)
-    .bodyValue(referralUpdate)
-    .exchange()
-    .expectStatus().isNoContent
+  fun updateReferral(referralId: UUID, referralUpdate: ReferralUpdate): Any =
+    webTestClient
+      .put()
+      .uri("/referrals/$referralId")
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(referralUpdate)
+      .exchange()
+      .expectStatus().isNoContent
 
   fun submitReferral(createdReferralId: UUID) {
     webTestClient
       .post()
       .uri("/referrals/$createdReferralId/submit")
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isNoContent
@@ -262,7 +266,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     return webTestClient
       .get()
       .uri(uriBuilder.toUriString())
-      .headers(jwtAuthHelper.authorizationHeaderConfigurer())
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -22,6 +22,8 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Refer
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralSummary
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRER_ID
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toDomain
 import java.util.UUID
@@ -30,10 +32,6 @@ import java.util.UUID
 @ActiveProfiles("test")
 @Import(JwtAuthHelper::class)
 class ReferralIntegrationTest : IntegrationTestBase() {
-  companion object {
-    const val PRISON_NUMBER = "A1234AA"
-    const val REFERRER_ID = "MWX0001"
-  }
 
   @Test
   fun `Creating a referral should return 201 with correct body`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseParticipationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseParticipationEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.en
 
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomPrisonNumber
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationOutcome
@@ -17,8 +18,10 @@ class CourseParticipationEntityFactory : Factory<CourseParticipationEntity> {
   private var courseName: Yielded<String?> = { null }
   private var source: Yielded<String?> = { null }
   private var detail: Yielded<String?> = { null }
-  private var setting: Yielded<CourseParticipationSetting> = { CourseParticipationSetting(type = CourseSetting.CUSTODY) }
-  private var outcome: Yielded<CourseParticipationOutcome> = { CourseParticipationOutcome(status = CourseStatus.INCOMPLETE) }
+  private var setting: Yielded<CourseParticipationSetting?> = { CourseParticipationSetting(type = CourseSetting.CUSTODY) }
+  private var outcome: Yielded<CourseParticipationOutcome?> = { CourseParticipationOutcome(status = CourseStatus.INCOMPLETE) }
+  private var createdByUsername: Yielded<String> = { CLIENT_USERNAME }
+  private var lastModifiedByUsername: Yielded<String?> = { null }
 
   fun withId(id: UUID) = apply {
     this.id = { id }
@@ -40,12 +43,20 @@ class CourseParticipationEntityFactory : Factory<CourseParticipationEntity> {
     this.detail = { detail }
   }
 
-  fun withSetting(setting: CourseParticipationSetting) = apply {
+  fun withSetting(setting: CourseParticipationSetting?) = apply {
     this.setting = { setting }
   }
 
-  fun withOutcome(outcome: CourseParticipationOutcome) = apply {
+  fun withOutcome(outcome: CourseParticipationOutcome?) = apply {
     this.outcome = { outcome }
+  }
+
+  fun withCreatedByUsername(createdByUsername: String) = apply {
+    this.createdByUsername = { createdByUsername }
+  }
+
+  fun withLastModifiedByUsername(lastModifiedByUsername: String) = apply {
+    this.lastModifiedByUsername = { lastModifiedByUsername }
   }
 
   override fun produce(): CourseParticipationEntity {
@@ -57,6 +68,8 @@ class CourseParticipationEntityFactory : Factory<CourseParticipationEntity> {
       detail = this.detail(),
       setting = this.setting(),
       outcome = this.outcome(),
+      createdByUsername = this.createdByUsername(),
+      lastModifiedByUsername = this.lastModifiedByUsername(),
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralEntityFactory.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ran
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseAlphanumericString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OfferingEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferrerUserEntity
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -14,6 +15,7 @@ class ReferralEntityFactory : Factory<ReferralEntity> {
   private var id: Yielded<UUID?> = { UUID.randomUUID() }
   private var offering: Yielded<OfferingEntity> = { OfferingEntityFactory().produce() }
   private var prisonNumber: Yielded<String> = { randomPrisonNumber() }
+  private var referrer: Yielded<ReferrerUserEntity> = { ReferrerUserEntityFactory().produce() }
   private var referrerId: Yielded<String> = { randomUppercaseAlphanumericString(6) }
   private var additionalInformation: Yielded<String?> = { null }
   private var oasysConfirmed: Yielded<Boolean> = { false }
@@ -31,6 +33,10 @@ class ReferralEntityFactory : Factory<ReferralEntity> {
 
   fun withPrisonNumber(prisonNumber: String) = apply {
     this.prisonNumber = { prisonNumber }
+  }
+
+  fun withReferrer(referrer: ReferrerUserEntity) = apply {
+    this.referrer = { referrer }
   }
 
   fun withReferrerId(referrerId: String) = apply {
@@ -58,14 +64,15 @@ class ReferralEntityFactory : Factory<ReferralEntity> {
   }
 
   override fun produce(): ReferralEntity = ReferralEntity(
-    id = id(),
-    offering = offering(),
-    prisonNumber = prisonNumber(),
-    referrerId = referrerId(),
-    additionalInformation = additionalInformation(),
-    oasysConfirmed = oasysConfirmed(),
-    hasReviewedProgrammeHistory = hasReviewedProgrammeHistory(),
-    status = status(),
-    submittedOn = submittedOn(),
+    id = this.id(),
+    offering = this.offering(),
+    prisonNumber = this.prisonNumber(),
+    referrer = this.referrer(),
+    referrerId = this.referrerId(),
+    additionalInformation = this.additionalInformation(),
+    oasysConfirmed = this.oasysConfirmed(),
+    hasReviewedProgrammeHistory = this.hasReviewedProgrammeHistory(),
+    status = this.status(),
+    submittedOn = this.submittedOn(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralSummaryProjectionFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralSummaryProjectionFactory.kt
@@ -4,6 +4,7 @@ import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomPrisonNumber
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomSentence
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
 import java.time.LocalDateTime
@@ -17,6 +18,7 @@ class ReferralSummaryProjectionFactory : Factory<ReferralSummaryProjection> {
   private var status: Yielded<ReferralEntity.ReferralStatus> = { ReferralEntity.ReferralStatus.REFERRAL_STARTED }
   private var submittedOn: Yielded<LocalDateTime> = { LocalDateTime.now() }
   private var prisonNumber: Yielded<String> = { randomPrisonNumber() }
+  private var referrerUsername: Yielded<String> = { randomUppercaseString(9) }
 
   fun withReferralId(referralId: UUID) = apply {
     this.referralId = { referralId }
@@ -42,6 +44,10 @@ class ReferralSummaryProjectionFactory : Factory<ReferralSummaryProjection> {
     this.prisonNumber = { prisonNumber }
   }
 
+  fun withReferrerUsername(referrerUsername: String) = apply {
+    this.referrerUsername = { referrerUsername }
+  }
+
   override fun produce() = ReferralSummaryProjection(
     referralId = this.referralId(),
     courseName = this.courseName(),
@@ -49,5 +55,6 @@ class ReferralSummaryProjectionFactory : Factory<ReferralSummaryProjection> {
     status = this.status(),
     submittedOn = this.submittedOn(),
     prisonNumber = this.prisonNumber(),
+    referrerUsername = this.referrerUsername(),
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferrerUserEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferrerUserEntityFactory.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseString
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferrerUserEntity
+
+class ReferrerUserEntityFactory : Factory<ReferrerUserEntity> {
+
+  private var username: Yielded<String> = { randomUppercaseString(9) }
+
+  fun withUsername(username: String) = apply {
+    this.username = { username }
+  }
+
+  override fun produce() = ReferrerUserEntity(
+    username = username(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/JpaCourseParticipationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/JpaCourseParticipationRepositoryTest.kt
@@ -41,6 +41,7 @@ constructor(
           yearCompleted = Year.parse("2022"),
         ),
         setting = CourseParticipationSetting(type = CourseSetting.CUSTODY, location = "location"),
+        createdByUsername = CLIENT_USERNAME,
       ),
     ).id!!
 
@@ -80,6 +81,7 @@ constructor(
         detail = null,
         setting = null,
         outcome = null,
+        createdByUsername = CLIENT_USERNAME,
       ),
     ).id!!
 
@@ -105,7 +107,7 @@ constructor(
   }
 
   @Test
-  fun `CourseParticipationRepository should save and update CouseParticipationEntity objects, having all auditable fields set`() {
+  fun `CourseParticipationRepository should save and update CourseParticipationEntity objects, having all auditable fields set`() {
     val startTime = LocalDateTime.now()
 
     val participationId = courseParticipationRepository.save(
@@ -116,6 +118,7 @@ constructor(
         detail = null,
         setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
         outcome = CourseParticipationOutcome(status = CourseStatus.COMPLETE, yearStarted = null, yearCompleted = null),
+        createdByUsername = CLIENT_USERNAME,
       ),
     ).id!!
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/JpaCourseParticipationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/JpaCourseParticipationRepositoryTest.kt
@@ -6,14 +6,13 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.TEST_USER_NAME
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomPrisonNumber
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseStatus
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.JpaCourseEntityRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.JpaCourseParticipationRepository
 import java.time.Duration
 import java.time.LocalDateTime
@@ -24,18 +23,16 @@ class JpaCourseParticipationRepositoryTest
 @Autowired
 constructor(
   val courseParticipationRepository: JpaCourseParticipationRepository,
-  val courseEntityRepository: JpaCourseEntityRepository,
   jdbcTemplate: JdbcTemplate,
 ) : RepositoryTestBase(jdbcTemplate) {
   @Test
   fun `CourseParticipationRepository should save and retrieve CourseParticipationEntity objects`() {
     val startTime = LocalDateTime.now()
-    val prisonNumber = randomPrisonNumber()
 
     val participationId = courseParticipationRepository.save(
       CourseParticipationEntity(
         courseName = "Course name",
-        prisonNumber = prisonNumber,
+        prisonNumber = PRISON_NUMBER,
         source = "Source of information",
         detail = "Course detail",
         outcome = CourseParticipationOutcome(
@@ -57,7 +54,7 @@ constructor(
       CourseParticipationEntity(
         id = participationId,
         courseName = "Course name",
-        prisonNumber = prisonNumber,
+        prisonNumber = PRISON_NUMBER,
         source = "Source of information",
         detail = "Course detail",
         outcome = CourseParticipationOutcome(
@@ -66,7 +63,7 @@ constructor(
           yearCompleted = Year.parse("2022"),
         ),
         setting = CourseParticipationSetting(type = CourseSetting.CUSTODY, location = "location"),
-        createdByUsername = TEST_USER_NAME,
+        createdByUsername = CLIENT_USERNAME,
       ),
       CourseParticipationEntity::createdDateTime,
     )
@@ -75,12 +72,10 @@ constructor(
 
   @Test
   fun `CourseParticipationRepository should save and retrieve CourseParticipationEntity objects, having all nullable fields set to null`() {
-    val prisonNumber = randomPrisonNumber()
-
     val participationId = courseParticipationRepository.save(
       CourseParticipationEntity(
         courseName = null,
-        prisonNumber = prisonNumber,
+        prisonNumber = PRISON_NUMBER,
         source = null,
         detail = null,
         setting = null,
@@ -98,12 +93,12 @@ constructor(
       CourseParticipationEntity(
         id = participationId,
         courseName = null,
-        prisonNumber = prisonNumber,
+        prisonNumber = PRISON_NUMBER,
         source = null,
         detail = null,
         setting = null,
         outcome = null,
-        createdByUsername = TEST_USER_NAME,
+        createdByUsername = CLIENT_USERNAME,
       ),
       CourseParticipationEntity::createdDateTime,
     )
@@ -112,12 +107,11 @@ constructor(
   @Test
   fun `CourseParticipationRepository should save and update CouseParticipationEntity objects, having all auditable fields set`() {
     val startTime = LocalDateTime.now()
-    val prisonNumber = randomPrisonNumber()
 
     val participationId = courseParticipationRepository.save(
       CourseParticipationEntity(
         courseName = null,
-        prisonNumber = prisonNumber,
+        prisonNumber = PRISON_NUMBER,
         source = null,
         detail = null,
         setting = CourseParticipationSetting(type = CourseSetting.COMMUNITY, location = null),
@@ -134,13 +128,13 @@ constructor(
       CourseParticipationEntity(
         id = participationId,
         courseName = null,
-        prisonNumber = prisonNumber,
+        prisonNumber = PRISON_NUMBER,
         source = null,
         detail = null,
         setting = CourseParticipationSetting(type = CourseSetting.CUSTODY, location = null),
         outcome = CourseParticipationOutcome(status = CourseStatus.COMPLETE, yearStarted = null, yearCompleted = null),
-        createdByUsername = TEST_USER_NAME,
-        lastModifiedByUsername = TEST_USER_NAME,
+        createdByUsername = CLIENT_USERNAME,
+        lastModifiedByUsername = null,
       ),
       CourseParticipationEntity::createdDateTime,
       CourseParticipationEntity::lastModifiedDateTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
@@ -2,100 +2,37 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.re
 
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldBe
+import jakarta.persistence.EntityManager
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRER_ID
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomEmailAddress
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomLowercaseString
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomPrisonNumber
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomSentence
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseAlphanumericString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseString
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.CourseEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OfferingEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralEntityFactory
-import java.util.UUID
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferrerUserEntityFactory
 
 class ReferralRepositoryTest
 @Autowired
 constructor(
   val referralRepository: ReferralRepository,
-  val courseRepository: CourseRepository,
   jdbcTemplate: JdbcTemplate,
 ) : RepositoryTestBase(jdbcTemplate) {
-  @Test
-  fun `JpaReferralRepository should save and retrieve ReferralEntity objects`() {
-    val persistentOfferingId = persistAnOffering()
-    val prisonNumber = randomPrisonNumber()
-    val referrerId = randomUppercaseAlphanumericString(10)
 
-    val offering = OfferingEntityFactory()
-      .withId(persistentOfferingId)
-      .produce()
-
-    val referral = ReferralEntityFactory()
-      .withReferrerId(referrerId)
-      .withPrisonNumber(prisonNumber)
-      .withOffering(offering)
-      .produce()
-
-    val referralId = referralRepository.save(referral).id!!
-
-    commitAndStartNewTx()
-
-    referralRepository.findById(referralId) shouldBePresent {
-      referrerId shouldBe referrerId
-      prisonNumber shouldBe prisonNumber
-      offering shouldBe offering
-      oasysConfirmed shouldBe false
-      hasReviewedProgrammeHistory shouldBe false
-    }
-  }
+  @Autowired
+  private lateinit var entityManager: EntityManager
 
   @Test
-  fun `JpaReferralRepository should update and retrieve ReferralEntity objects`() {
-    val persistentOfferingId = persistAnOffering()
-    val prisonNumber = randomPrisonNumber()
-    val referrerId = randomUppercaseAlphanumericString(10)
-
-    val offering = OfferingEntityFactory()
-      .withId(persistentOfferingId)
-      .produce()
-
-    val referral = ReferralEntityFactory()
-      .withReferrerId(referrerId)
-      .withPrisonNumber(prisonNumber)
-      .withOffering(offering)
-      .produce()
-
-    val referralId = referralRepository.save(referral).id!!
-
-    commitAndStartNewTx()
-
-    val persistentReferral = referralRepository.findById(referralId).get()
-    with(persistentReferral) {
-      oasysConfirmed = true
-      hasReviewedProgrammeHistory = true
-    }
-
-    commitAndStartNewTx()
-
-    referralRepository.findById(referralId) shouldBePresent {
-      referrerId shouldBe referrerId
-      prisonNumber shouldBe prisonNumber
-      offering shouldBe offering
-      oasysConfirmed shouldBe true
-      hasReviewedProgrammeHistory shouldBe true
-    }
-  }
-
-  private fun persistAnOffering(): UUID {
-    val courseIdentifier = randomLowercaseString(6)
-
+  fun `ReferralRepository should save and retrieve ReferralEntity objects`() {
     val course = CourseEntityFactory()
-      .withIdentifier(courseIdentifier)
+      .withIdentifier(randomLowercaseString(6))
       .withName(randomSentence(1..3, 1..8))
       .withAlternateName(null)
       .produce()
@@ -105,8 +42,77 @@ constructor(
       .withContactEmail(randomEmailAddress())
       .produce()
 
-    courseRepository.saveCourse(course.apply { addOffering(offering) })
-    commitAndStartNewTx()
-    return courseRepository.getAllCourses()[0].offerings.first().id!!
+    entityManager.merge(course.apply { addOffering(offering) })
+
+    val referrer = ReferrerUserEntityFactory()
+      .withUsername(CLIENT_USERNAME)
+      .produce()
+
+    entityManager.persist(referrer)
+
+    val referral = ReferralEntityFactory()
+      .withReferrer(referrer)
+      .withReferrerId(REFERRER_ID)
+      .withPrisonNumber(PRISON_NUMBER)
+      .withOffering(offering)
+      .produce()
+
+    entityManager.merge(referral)
+
+    referralRepository.findById(referral.id!!) shouldBePresent {
+      referrer shouldBe referrer
+      referrerId shouldBe referrerId
+      prisonNumber shouldBe prisonNumber
+      offering shouldBe offering
+      offering.course shouldBe course
+      oasysConfirmed shouldBe false
+      hasReviewedProgrammeHistory shouldBe false
+    }
+  }
+
+  @Test
+  fun `ReferralRepository should update and retrieve ReferralEntity objects`() {
+    val course = CourseEntityFactory()
+      .withIdentifier(randomLowercaseString(6))
+      .withName(randomSentence(1..3, 1..8))
+      .withAlternateName(null)
+      .produce()
+
+    val offering = OfferingEntityFactory()
+      .withOrganisationId(randomUppercaseString(3))
+      .withContactEmail(randomEmailAddress())
+      .produce()
+
+    entityManager.merge(course.apply { addOffering(offering) })
+
+    val referrer = ReferrerUserEntityFactory()
+      .withUsername(CLIENT_USERNAME)
+      .produce()
+
+    entityManager.persist(referrer)
+
+    val referral = ReferralEntityFactory()
+      .withReferrer(referrer)
+      .withReferrerId(REFERRER_ID)
+      .withPrisonNumber(PRISON_NUMBER)
+      .withOffering(offering)
+      .produce()
+
+    entityManager.merge(referral)
+
+    referral.oasysConfirmed = true
+    referral.hasReviewedProgrammeHistory = true
+
+    entityManager.merge(referral)
+
+    referralRepository.findById(referral.id!!) shouldBePresent {
+      referrer shouldBe referrer
+      referrerId shouldBe referrerId
+      prisonNumber shouldBe prisonNumber
+      offering shouldBe offering
+      offering.course shouldBe course
+      oasysConfirmed shouldBe true
+      hasReviewedProgrammeHistory shouldBe true
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/RepositoryTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/RepositoryTestBase.kt
@@ -4,14 +4,10 @@ import org.junit.jupiter.api.BeforeEach
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.jdbc.core.JdbcTemplate
-import org.springframework.security.authentication.TestingAuthenticationToken
-import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.core.userdetails.User
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.transaction.TestTransaction
 import org.springframework.test.jdbc.JdbcTestUtils
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.TEST_USER_NAME
 
 @SpringBootTest
 @Transactional
@@ -33,11 +29,6 @@ abstract class RepositoryTestBase(
       "course",
     )
     commitAndStartNewTx()
-  }
-
-  @BeforeEach
-  fun setSecurityContextAuthentication() {
-    SecurityContextHolder.getContext().authentication = TestingAuthenticationToken(User(TEST_USER_NAME, "", emptyList()), null)
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseParticipationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseParticipationControllerTest.kt
@@ -21,6 +21,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationOutcome
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationSetting
@@ -59,6 +60,7 @@ constructor(
           prisonNumber = "A1234AA",
           outcome = CourseParticipationOutcome(status = CourseStatus.COMPLETE, yearStarted = Year.of(2020)),
           setting = CourseParticipationSetting(type = CourseSetting.CUSTODY),
+          createdByUsername = CLIENT_USERNAME,
         )
       mockMvc.post("/course-participations") {
         accept = MediaType.APPLICATION_JSON
@@ -96,6 +98,7 @@ constructor(
           yearStarted = Year.of(2020),
         ),
         setting = CourseParticipationSetting(type = CourseSetting.CUSTODY),
+        createdByUsername = CLIENT_USERNAME,
       )
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/PeopleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/PeopleControllerTest.kt
@@ -12,7 +12,6 @@ import org.springframework.context.annotation.Import
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.web.servlet.MockHttpServletRequestDsl
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
@@ -79,7 +78,7 @@ constructor(
 
       mockMvc.get("/people/{prisonNumber}/course-participations", "A1234AA") {
         accept = MediaType.APPLICATION_JSON
-        authorizationHeader()
+        header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       }.andExpect {
         status { isOk() }
         content {
@@ -123,7 +122,7 @@ constructor(
 
       mockMvc.get("/people/{prisonNumber}/course-participations", "A1234AA") {
         accept = MediaType.APPLICATION_JSON
-        authorizationHeader()
+        header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       }.andExpect {
         status { isOk() }
         content {
@@ -132,6 +131,4 @@ constructor(
       }
     }
   }
-
-  private fun MockHttpServletRequestDsl.authorizationHeader() = header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -60,8 +60,6 @@ constructor(
 ) {
 
   companion object {
-    const val PRISON_NUMBER = "A1234AA"
-
     private val referralSummary1 = ReferralSummary(
       id = UUID.randomUUID(),
       courseName = "Course for referralSummary1",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -24,6 +24,8 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
@@ -33,6 +35,8 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Pagin
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralSummary
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomPrisonNumber
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomReferrerId
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
@@ -44,6 +48,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.Referra
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OfferingEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralSummaryProjectionFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferrerUserEntityFactory
 import java.time.LocalDateTime
 import java.util.UUID
 import java.util.stream.Stream
@@ -66,6 +71,7 @@ constructor(
       audiences = listOf("Audience 1", "Audience 2"),
       status = ReferralStatus.referralStarted,
       prisonNumber = PRISON_NUMBER,
+      referrerUsername = CLIENT_USERNAME,
     )
 
     private val referralSummary2 = ReferralSummary(
@@ -75,6 +81,7 @@ constructor(
       status = ReferralStatus.referralSubmitted,
       submittedOn = LocalDateTime.MIN.toString(),
       prisonNumber = PRISON_NUMBER,
+      referrerUsername = CLIENT_USERNAME,
     )
 
     private val referralSummary3 = ReferralSummary(
@@ -84,6 +91,7 @@ constructor(
       status = ReferralStatus.referralSubmitted,
       submittedOn = LocalDateTime.MIN.toString(),
       prisonNumber = PRISON_NUMBER,
+      referrerUsername = CLIENT_USERNAME,
     )
 
     @JvmStatic
@@ -105,7 +113,7 @@ constructor(
   private lateinit var referralService: ReferralService
 
   @Test
-  fun `createReferral with JWT and valid payload returns 201 with correct body`() {
+  fun `createReferral with JWT, existing user, and valid payload returns 201 with correct body`() {
     val referral = ReferralEntityFactory()
       .withOffering(
         OfferingEntityFactory()
@@ -113,8 +121,56 @@ constructor(
           .produce(),
       )
       .withPrisonNumber(randomPrisonNumber())
+      .withReferrer(
+        ReferrerUserEntityFactory()
+          .withUsername(CLIENT_USERNAME)
+          .produce(),
+      )
       .withReferrerId(randomReferrerId())
       .produce()
+
+    val payload = mapOf(
+      "offeringId" to referral.offering.id,
+      "prisonNumber" to referral.prisonNumber,
+      "referrerId" to referral.referrerId,
+    )
+
+    every { referralService.createReferral(any(), any(), any()) } returns referral.id
+
+    mockMvc.post("/referrals") {
+      contentType = MediaType.APPLICATION_JSON
+      headers { set(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken()) }
+      content = jacksonObjectMapper().writeValueAsString(payload)
+    }.andExpect {
+      status { isCreated() }
+      content {
+        contentType(MediaType.APPLICATION_JSON)
+        jsonPath("$.referralId") { value(referral.id.toString()) }
+      }
+    }
+
+    verify { referralService.createReferral(referral.prisonNumber, referral.offering.id!!, referral.referrerId) }
+  }
+
+  @Test
+  @WithMockUser(username = "NONEXISTENT_USER")
+  fun `createReferral with JWT, nonexistent user, and valid payload returns 201 with correct body`() {
+    val referral = ReferralEntityFactory()
+      .withOffering(
+        OfferingEntityFactory()
+          .withId(UUID.randomUUID())
+          .produce(),
+      )
+      .withPrisonNumber(randomPrisonNumber())
+      .withReferrer(
+        ReferrerUserEntityFactory()
+          .withUsername(SecurityContextHolder.getContext().authentication?.name.toString())
+          .produce(),
+      )
+      .withReferrerId(randomReferrerId())
+      .produce()
+
+    SecurityContextHolder.getContext().authentication?.name shouldBe "NONEXISTENT_USER"
 
     val payload = mapOf(
       "offeringId" to referral.offering.id,
@@ -148,6 +204,11 @@ constructor(
           .withId(UUID.randomUUID())
           .produce(),
       )
+      .withReferrer(
+        ReferrerUserEntityFactory()
+          .withUsername(CLIENT_USERNAME)
+          .produce(),
+      )
       .withOasysConfirmed(true)
       .withHasReviewedProgrammeHistory(true)
       .produce()
@@ -163,6 +224,7 @@ constructor(
         contentType(MediaType.APPLICATION_JSON)
         jsonPath("$.offeringId") { value(referral.offering.id.toString()) }
         jsonPath("$.prisonNumber") { value(referral.prisonNumber) }
+        jsonPath("$.referrerUsername") { value(referral.referrer.username) }
         jsonPath("$.referrerId") { value(referral.referrerId) }
         jsonPath("$.status") { REFERRAL_STARTED }
         jsonPath("$.oasysConfirmed") { value(true) }
@@ -281,6 +343,11 @@ constructor(
           .produce(),
       )
       .withPrisonNumber(randomPrisonNumber())
+      .withReferrer(
+        ReferrerUserEntityFactory()
+          .withUsername(CLIENT_USERNAME)
+          .produce(),
+      )
       .withReferrerId(randomReferrerId())
       .withAdditionalInformation("Additional Info")
       .withOasysConfirmed(true)
@@ -324,6 +391,11 @@ constructor(
           .produce(),
       )
       .withPrisonNumber(randomPrisonNumber())
+      .withReferrer(
+        ReferrerUserEntityFactory()
+          .withUsername(CLIENT_USERNAME)
+          .produce(),
+      )
       .withReferrerId(randomReferrerId())
       .produce()
 
@@ -354,6 +426,7 @@ constructor(
         .withAudience(audience)
         .withStatus(ReferralEntity.ReferralStatus.REFERRAL_STARTED)
         .withPrisonNumber(PRISON_NUMBER)
+        .withReferrerUsername(CLIENT_USERNAME)
         .produce()
     }
 
@@ -367,6 +440,7 @@ constructor(
         .withStatus(ReferralEntity.ReferralStatus.REFERRAL_SUBMITTED)
         .withSubmittedOn(LocalDateTime.MIN)
         .withPrisonNumber(PRISON_NUMBER)
+        .withReferrerUsername(CLIENT_USERNAME)
         .produce()
     }
 
@@ -399,6 +473,7 @@ constructor(
       referral.audiences shouldContainExactlyInAnyOrder audiencesForFirstReferral
       referral.status shouldBe ReferralStatus.referralStarted
       referral.prisonNumber shouldBe PRISON_NUMBER
+      referral.referrerUsername shouldBe CLIENT_USERNAME
     }
 
     val secondReferral = paginatedReferralSummary.content?.find { it.id == secondReferralId }
@@ -409,6 +484,7 @@ constructor(
       referral.status shouldBe ReferralStatus.referralSubmitted
       referral.submittedOn shouldBe LocalDateTime.MIN.toString()
       referral.prisonNumber shouldBe PRISON_NUMBER
+      referral.referrerUsername shouldBe CLIENT_USERNAME
     }
 
     verify { referralService.getReferralsByOrganisationId(organisationId, pageable, null, null, null) }
@@ -430,6 +506,7 @@ constructor(
         .withAudience(audience)
         .withStatus(ReferralEntity.ReferralStatus.REFERRAL_STARTED)
         .withPrisonNumber(PRISON_NUMBER)
+        .withReferrerUsername(CLIENT_USERNAME)
         .produce()
     }
 
@@ -443,6 +520,7 @@ constructor(
         .withStatus(ReferralEntity.ReferralStatus.REFERRAL_SUBMITTED)
         .withSubmittedOn(LocalDateTime.MIN)
         .withPrisonNumber(PRISON_NUMBER)
+        .withReferrerUsername(CLIENT_USERNAME)
         .produce()
     }
 
@@ -475,6 +553,7 @@ constructor(
       referral.audiences shouldContainExactlyInAnyOrder audiencesForFirstReferral
       referral.status shouldBe ReferralStatus.referralStarted
       referral.prisonNumber shouldBe PRISON_NUMBER
+      referral.referrerUsername shouldBe CLIENT_USERNAME
     }
 
     val secondPageResult = mockMvc.get("/referrals/organisation/$organisationId/dashboard") {
@@ -501,6 +580,7 @@ constructor(
       referral.status shouldBe ReferralStatus.referralSubmitted
       referral.submittedOn shouldBe LocalDateTime.MIN.toString()
       referral.prisonNumber shouldBe PRISON_NUMBER
+      referral.referrerUsername shouldBe CLIENT_USERNAME
     }
 
     verify(exactly = 1) { referralService.getReferralsByOrganisationId(organisationId, pageableFirstPage, null, null, null) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/transformer/ReferralTransformersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/transformer/ReferralTransformersTest.kt
@@ -8,6 +8,8 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Refer
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.awaitingAssessment
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.referralStarted
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.referralSubmitted
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.ASSESSMENT_STARTED
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.AWAITING_ASSESSMENT
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.REFERRAL_STARTED
@@ -22,10 +24,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.c
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.ReferralUpdate as DomainReferralUpdate
 
 class ReferralTransformersTest {
-
-  companion object {
-    const val PRISON_NUMBER = "A1234AA"
-  }
 
   @ParameterizedTest
   @EnumSource
@@ -122,6 +120,7 @@ class ReferralTransformersTest {
         .withAudience(audience)
         .withStatus(REFERRAL_STARTED)
         .withPrisonNumber(PRISON_NUMBER)
+        .withReferrerUsername(CLIENT_USERNAME)
         .produce()
     }
 
@@ -131,6 +130,7 @@ class ReferralTransformersTest {
       audiences shouldBe collatedAudiences
       status shouldBe referralStarted
       prisonNumber shouldBe PRISON_NUMBER
+      referrerUsername shouldBe CLIENT_USERNAME
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.JpaOfferingRepository
@@ -26,7 +27,6 @@ import java.util.stream.Stream
 class ReferralServiceTest {
 
   companion object {
-    private const val PRISON_NUMBER = "A1234AA"
 
     @JvmStatic
     fun parametersForGetReferralsByOrganisationId(): Stream<Arguments> {

--- a/src/test/resources/db/migration/R__test_data.sql
+++ b/src/test/resources/db/migration/R__test_data.sql
@@ -19,7 +19,12 @@ INSERT INTO offering(offering_id, course_id, organisation_id, contact_email, sec
 VALUES ('790a2dfe-7de5-4504-bb9c-83e6e53a6537', 'd3abc217-75ee-46e9-a010-368f30282367', 'BWN', 'nobody-bwn@digital.justice.gov.uk', 'nobody2-bwn@digital.justice.gov.uk'),
        ('7fffcc6a-11f8-4713-be35-cf5ff1aee517', 'd3abc217-75ee-46e9-a010-368f30282367', 'MDI', 'nobody-mdi@digital.justice.gov.uk', 'nobody2-mdi@digital.justice.gov.uk');
 
-INSERT INTO referral (referral_id, offering_id, prison_number, referrer_id, additional_information, oasys_confirmed, has_reviewed_programme_history, status, submitted_on)
-VALUES ('0c46ed09-170b-4c0f-aee8-a24eeaeeddaa', '7fffcc6a-11f8-4713-be35-cf5ff1aee517', 'B2345BB', '123456', 'This referral will be updated', false, false, 'REFERRAL_STARTED', NULL),
-       ('fae2ed00-057e-4179-9e55-f6a4f4874cf0', '790a2dfe-7de5-4504-bb9c-83e6e53a6537','C3456CC', '234567', 'more information', true, true, 'REFERRAL_SUBMITTED', '2023-11-12T19:11:00'),
-       ('153383a4-b250-46a8-9950-43eb358c2805', '790a2dfe-7de5-4504-bb9c-83e6e53a6537','D3456DD', '234567', 'more information', true, true, 'REFERRAL_SUBMITTED', '2023-11-13T19:11:00');
+INSERT INTO referrer_user(referrer_username)
+VALUES ('TEST_REFERRER_USER_1'),
+       ('TEST_REFERRER_USER_2'),
+       ('TEST_REFERRER_USER_3');
+
+INSERT INTO referral (referral_id, offering_id, prison_number, referrer_username, referrer_id, additional_information, oasys_confirmed, has_reviewed_programme_history, status, submitted_on)
+VALUES ('0c46ed09-170b-4c0f-aee8-a24eeaeeddaa', '7fffcc6a-11f8-4713-be35-cf5ff1aee517', 'B2345BB', 'TEST_REFERRER_USER_1', '123456', 'This referral will be updated', false, false, 'REFERRAL_STARTED', NULL),
+       ('fae2ed00-057e-4179-9e55-f6a4f4874cf0', '790a2dfe-7de5-4504-bb9c-83e6e53a6537', 'C3456CC', 'TEST_REFERRER_USER_2', '234567', 'more information', true, true, 'REFERRAL_SUBMITTED', '2023-11-12T19:11:00'),
+       ('153383a4-b250-46a8-9950-43eb358c2805', '790a2dfe-7de5-4504-bb9c-83e6e53a6537', 'D3456DD', 'TEST_REFERRER_USER_2', '234567', 'more information', true, true, 'REFERRAL_SUBMITTED', '2023-11-13T19:11:00');


### PR DESCRIPTION
## Context

[> see #1122 on the Accredited Programmes Trello board.](https://trello.com/c/gulvnZLL/1122-add-new-user-model-and-link-to-referrals-to-replace-referrerid-l)

## Changes in this PR

A requirement for R&M is that a user can see specifically all referrals they have made, not just their organisation. Given this, we needed to represent users in our data structures. Currently we only use an API-generated referrerId when creating new referrals, which is no longer sufficient.

This PR introduces the usage of Spring Security's `SecurityContextHolder` to retrieve the username and role of the current logged-in user. This is used for creating a referral, and is persisted in its own table as `ReferrerUser`, named as such to allow scope for building other types of user (also, `user` is a protected keyword in all SQL dialects, so we needed some level of specificity). If a user already exists, a referral is simply assigned to them instead to avoid duplication. The referral table is now the source of truth for which users 'own' which referrals, and can be leveraged in later tickets relating specifically to reading user information.

- Add ReferrerUser entity and supporting table. Add new flyway migration and test information accordingly.
- Update Referrer to be the source of truth for which users own which referrals.
- Implement Spring Security to allow for username-based creation and reading of referrals.
- Add user-specific unit and integration testing for the new control flow.

Other smaller quality-of-life improvements have been made on the testing side to further assist this functional change, namely:
- cleaning up OAuth authentication to be homogenous across all testing that utilises it.
- moving duplicate testing constants to their own class.
- updating immediately-relevant tests which directly instantiate entities to instead use factory-based instantiation.
- updating the RepositoryTestBase to rely less on direct transaction management in favour of entity management.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
