### PR TITLE
#1191 Allow list of status values for caselist dashboard endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
@@ -27,8 +27,8 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
     JOIN c.audiences a
     JOIN r.referrer ru
     WHERE o.organisationId = :organisationId
-      AND (:status IS NULL OR r.status = :status)
-      AND (:audience IS NULL OR a.value = :audience)
+      AND (:status IS NULL OR r.status IN :status)
+      AND (:audience IS NULL OR :audience = '' OR a.value = :audience)
       AND (:courseName IS NULL OR :courseName = '' OR LOWER(c.name) LIKE LOWER(CONCAT('%', :courseName, '%')))
   """,
     countQuery = """
@@ -38,8 +38,8 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
     JOIN o.course c
     JOIN c.audiences a
     WHERE o.organisationId = :organisationId
-      AND (:status IS NULL OR r.status = :status)
-      AND (:audience IS NULL OR a.value = :audience)
+      AND (:status IS NULL OR :status = '' OR r.status IN :status)
+      AND (:audience IS NULL OR :audience = '' OR a.value = :audience)
       AND (:courseName IS NULL OR :courseName = '' OR LOWER(c.name) LIKE LOWER(CONCAT('%', :courseName, '%')))
   """,
     nativeQuery = false,
@@ -47,7 +47,7 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
   fun getReferralsByOrganisationId(
     organisationId: String,
     pageable: Pageable,
-    status: ReferralEntity.ReferralStatus?,
+    status: List<ReferralEntity.ReferralStatus>?,
     audience: String?,
     courseName: String?,
   ): Page<ReferralSummaryProjection>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -66,7 +66,7 @@ constructor(
     organisationId: String,
     @RequestParam(value = "page", defaultValue = "0") page: Int,
     @RequestParam(value = "size", defaultValue = "10") size: Int,
-    @RequestParam(value = "status", required = false) status: String?,
+    @RequestParam(value = "status", required = false) status: List<String>?,
     @RequestParam(value = "audience", required = false) audience: String?,
     @RequestParam(value = "courseName", required = false) courseName: String?,
   ): ResponseEntity<PaginatedReferralSummary> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -114,12 +114,12 @@ constructor(
   fun getReferralsByOrganisationId(
     organisationId: String,
     pageable: Pageable,
-    status: String?,
+    status: List<String>?,
     audience: String?,
     courseName: String?,
   ): Page<ReferralSummary> {
-    val statusEnum = status?.let { ReferralEntity.ReferralStatus.valueOf(it) }
-    val referralProjectionPage = referralRepository.getReferralsByOrganisationId(organisationId, pageable, statusEnum, audience, courseName)
+    val statusEnums = status?.map { ReferralEntity.ReferralStatus.valueOf(it) }
+    val referralProjectionPage = referralRepository.getReferralsByOrganisationId(organisationId, pageable, statusEnums, audience, courseName)
     val apiContent = referralProjectionPage.content.toApi()
     return PageImpl(apiContent, pageable, referralProjectionPage.totalElements)
   }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -484,8 +484,12 @@ paths:
           in: query
           description: Filter by the status of the referral
           required: false
+          style: form
+          explode: false
           schema:
-            type: string
+            type: array
+            items:
+              type: string
         - name: audience
           in: query
           description: Filter by the audience of the referral

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -198,7 +198,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     referralCreated.referralId.shouldNotBeNull()
     createdReferral.shouldNotBeNull()
 
-    val statusFilter = createdReferral.status.toDomain().name
+    val statusFilter = listOf(createdReferral.status.toDomain().name)
     val audienceFilter = getCourseById(courseId).audiences.map { it.value }.first()
     val summary = getReferralSummariesByOrganisationId(organisationId, statusFilter, audienceFilter)
 
@@ -283,12 +283,14 @@ class ReferralIntegrationTest : IntegrationTestBase() {
 
   fun getReferralSummariesByOrganisationId(
     organisationId: String,
-    statusFilter: String? = null,
+    statusFilter: List<String>? = null,
     audienceFilter: String? = null,
+    courseNameFilter: String? = null,
   ): PaginatedReferralSummary {
     val uriBuilder = UriComponentsBuilder.fromUriString("/referrals/organisation/$organisationId/dashboard")
-    statusFilter?.let { uriBuilder.queryParam("status", it) }
+    statusFilter?.let { uriBuilder.queryParam("status", it.joinToString(",")) }
     audienceFilter?.let { uriBuilder.queryParam("audience", it) }
+    courseNameFilter?.let { uriBuilder.queryParam("courseName", it) }
 
     return webTestClient
       .get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -97,14 +97,16 @@ constructor(
     @JvmStatic
     fun parametersForGetReferralsByOrganisationIdWithFiltering(): Stream<Arguments> {
       return Stream.of(
-        Arguments.of("REFERRAL_STARTED", null, "referralSummary1", listOf(referralSummary1)),
+        Arguments.of(listOf("REFERRAL_STARTED"), null, "referralSummary1", listOf(referralSummary1)),
         Arguments.of(null, "Audience 2", null, listOf(referralSummary1, referralSummary2)),
-        Arguments.of("REFERRAL_SUBMITTED", "Audience 3", null, listOf(referralSummary2, referralSummary3)),
-        Arguments.of("REFERRAL_SUBMITTED", "Audience 4", "referralSummary3", listOf(referralSummary3)),
+        Arguments.of(listOf("REFERRAL_SUBMITTED"), "Audience 3", null, listOf(referralSummary2, referralSummary3)),
+        Arguments.of(listOf("REFERRAL_SUBMITTED"), "Audience 4", "referralSummary3", listOf(referralSummary3)),
         Arguments.of(null, null, "Course", listOf(referralSummary1, referralSummary2, referralSummary3)),
-        Arguments.of("AWAITING_ASSESSMENT", null, null, emptyList<ReferralSummary>()),
+        Arguments.of(listOf("AWAITING_ASSESSMENT"), null, null, emptyList<ReferralSummary>()),
         Arguments.of(null, "Audience X", null, emptyList<ReferralSummary>()),
         Arguments.of(null, null, "Course for referralSummaryX", emptyList<ReferralSummary>()),
+        Arguments.of(listOf("REFERRAL_STARTED", "REFERRAL_SUBMITTED"), null, null, listOf(referralSummary1, referralSummary2, referralSummary3)),
+
       )
     }
   }
@@ -590,7 +592,7 @@ constructor(
   @ParameterizedTest
   @MethodSource("parametersForGetReferralsByOrganisationIdWithFiltering")
   fun `getReferralsByOrganisationId with valid organisationId and filtering will return 200 with paginated body`(
-    statusFilter: String?,
+    statusFilter: List<String>?,
     audienceFilter: String?,
     courseNameFilter: String?,
     expectedReferralSummaries: List<ReferralSummary>,
@@ -604,7 +606,7 @@ constructor(
     val result = mockMvc.get("/referrals/organisation/$organisationId/dashboard") {
       param("page", "0")
       param("size", "10")
-      statusFilter?.let { param("status", it) }
+      statusFilter?.let { param("status", it.joinToString(",")) }
       audienceFilter?.let { param("audience", it) }
       courseNameFilter?.let { param("courseName", it) }
       header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())


### PR DESCRIPTION
## Context

>[ see #1191 on the Refer & Monitor Trello Board.](https://trello.com/c/EzGOp4bf/1191-allow-list-of-status-values-for-dashboard-endpoint)

## Changes in this PR

This PR extends the functionality of our caselist GET request to allow a list of `ReferralStatus` values. Spring dynamically reads in a comma-separated string as a list, so this can be sent through easily, e.g.:

```
/referrals/organisation/$organisationId/dashboard&status=referral_started,referral_submitted
```

will return `ReferralSummary` objects filtered to include those with either status.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
