### PR TITLE
#1200 Retire referrerId from the Referral control flow

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
@@ -37,9 +37,6 @@ data class ReferralEntity(
   @JoinColumn(name = "referrer_username", referencedColumnName = "referrer_username")
   var referrer: ReferrerUserEntity,
 
-  @Deprecated("Use referrer_user.username instead.")
-  val referrerId: String? = null,
-
   var additionalInformation: String? = null,
 
   var oasysConfirmed: Boolean = false,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -31,7 +31,6 @@ constructor(
     with(referralCreate) {
       referralService.createReferral(
         prisonNumber = prisonNumber,
-        referrerId = referrerId.orEmpty(),
         offeringId = offeringId,
       )?.let {
         ResponseEntity.status(HttpStatus.CREATED).body(ReferralCreated(it))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
@@ -3,12 +3,9 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transf
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.ReferralUpdate
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Referral as ApiReferral
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus as ApiReferralStatus
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralSummary as ApiReferralSummary
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralUpdate as ApiReferralUpdate
-
 fun ReferralEntity.toApi(): ApiReferral = ApiReferral(
   id = id!!,
   offeringId = offering.id!!,
@@ -46,20 +43,3 @@ fun ReferralUpdate.toApi() = ApiReferralUpdate(
   oasysConfirmed = oasysConfirmed,
   hasReviewedProgrammeHistory = hasReviewedProgrammeHistory,
 )
-
-fun List<ReferralSummaryProjection>.toApi(): List<ApiReferralSummary> {
-  return this.groupBy { it.referralId }
-    .map { (id, projections) ->
-      val firstProjection = projections.first()
-
-      ApiReferralSummary(
-        id = id,
-        referrerUsername = firstProjection.referrerUsername,
-        courseName = firstProjection.courseName,
-        audiences = projections.map { it.audience }.distinct(),
-        status = firstProjection.status.toApi(),
-        submittedOn = firstProjection.submittedOn?.toString(),
-        prisonNumber = firstProjection.prisonNumber,
-      )
-    }
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
@@ -3,15 +3,17 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transf
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.ReferralUpdate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Referral as ApiReferral
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus as ApiReferralStatus
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralSummary as ApiReferralSummary
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralUpdate as ApiReferralUpdate
+
 fun ReferralEntity.toApi(): ApiReferral = ApiReferral(
   id = id!!,
   offeringId = offering.id!!,
   prisonNumber = prisonNumber,
   referrerUsername = referrer.username,
-  referrerId = referrerId.orEmpty(),
   oasysConfirmed = oasysConfirmed,
   hasReviewedProgrammeHistory = hasReviewedProgrammeHistory,
   additionalInformation = additionalInformation,
@@ -44,3 +46,20 @@ fun ReferralUpdate.toApi() = ApiReferralUpdate(
   oasysConfirmed = oasysConfirmed,
   hasReviewedProgrammeHistory = hasReviewedProgrammeHistory,
 )
+
+fun List<ReferralSummaryProjection>.toApi(): List<ApiReferralSummary> {
+  return this.groupBy { it.referralId }
+    .map { (id, projections) ->
+      val firstProjection = projections.first()
+
+      ApiReferralSummary(
+        id = id,
+        referrerUsername = firstProjection.referrerUsername,
+        courseName = firstProjection.courseName,
+        audiences = projections.map { it.audience }.distinct(),
+        status = firstProjection.status.toApi(),
+        submittedOn = firstProjection.submittedOn?.toString(),
+        prisonNumber = firstProjection.prisonNumber,
+      )
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -38,7 +38,6 @@ constructor(
   fun createReferral(
     prisonNumber: String,
     offeringId: UUID,
-    referrerId: String,
   ): UUID? {
     val username = SecurityContextHolder.getContext().authentication?.name
       ?: throw SecurityException("Authentication information not found")
@@ -54,7 +53,6 @@ constructor(
       ReferralEntity(
         offering = offering,
         prisonNumber = prisonNumber,
-        referrerId = referrerId,
         referrer = referrerUser,
       ),
     ).id ?: throw Exception("Referral creation failed")

--- a/src/main/resources/db/migration/V26__retire_referrerId.sql
+++ b/src/main/resources/db/migration/V26__retire_referrerId.sql
@@ -1,0 +1,19 @@
+-- Always ensure that referrals have an associated user, even if that user is a placeholder for now.
+UPDATE referral
+SET referrer_username = 'UNKNOWN_USER'
+WHERE referrer_username IS NULL OR referrer_username = '';
+
+
+-- Ensure data integrity in the referrer_user table by adding new unique users which don't already exist to it.
+INSERT INTO referrer_user (referrer_username)
+SELECT DISTINCT r.referrer_username
+FROM referral r
+WHERE r.referrer_username IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM referrer_user ru
+    WHERE ru.referrer_username = r.referrer_username
+);
+
+-- Delete the old field.
+ALTER TABLE referral DROP COLUMN referrer_id;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -320,12 +320,6 @@ paths:
           required: false
           schema:
             type: string
-        - name: referrerId
-          in: query
-          description: A permanent identifier for the person creating the referral. StaffId for prison staff. If present, only return referrals for that referrer.
-          required: false
-          schema:
-            type: string
       responses:
         200:
           description: Returns information about matching referrals
@@ -999,10 +993,6 @@ components:
           description: The prison number of the person who is being referred.
           example: "A1234AA"
           type: string
-        referrerId:
-          description: A permanent identifier for the person creating the referral. StaffId for prison staff.
-          type: string
-          deprecated: true
       required:
         - offeringId
         - prisonNumber
@@ -1043,7 +1033,6 @@ components:
             - offeringId
             - prisonNumber
             - referrerUsername
-            - referrerId
             - oasysConfirmed
             - status
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonRegisterApi/PrisonRegisterApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonRegisterApi/PrisonRegisterApiServiceTest.kt
@@ -10,14 +10,10 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonRegisterApi.model.PrisonDetails
-
-private const val PRISON_ID_1 = "1"
-
-private const val PRISON_NAME_1 = "Prison 1"
-
-private const val PRISON_ID_2 = "2"
-
-private const val PRISON_NAME_2 = "Prison 2"
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_ID_1
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_ID_2
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NAME_1
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NAME_2
 
 class PrisonRegisterApiServiceTest {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonSearchApi/PrisonerSearchApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonSearchApi/PrisonerSearchApiServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerSearchApi
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonSearchApi
 
 import io.mockk.every
 import io.mockk.mockk
@@ -9,6 +9,8 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.ClientResult
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerSearchApi.PrisonerSearchApiClient
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerSearchApi.PrisonerSearchApiService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_1
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_2
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER_1

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/RandomDataGenerators.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/RandomDataGenerators.kt
@@ -1,7 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util
 
-import kotlin.random.Random
-
 private val upperCase = ('A'..'Z').toList()
 private val lowerCase = ('a'..'z').toList()
 private val digits = ('0'..'9').toList()
@@ -12,15 +10,11 @@ fun randomUppercaseString(length: Int) = upperCase(length).asString()
 
 fun randomLowercaseString(length: Int) = lowerCase(length).asString()
 
-fun randomUppercaseAlphanumericString(length: Int) = (upperCase + digits)(length).asString()
-
 fun randomSentence(wordRange: IntRange = 1..20, wordLength: IntRange = 3..10): String =
   (sequenceOf(capitalisedWord(wordLength)) + generateSequence { word(wordLength) })
     .take(wordRange.random())
     .reduce { left, right -> left + space() + right }
     .asString()
-
-fun randomInt(min: Int, max: Int) = Random.nextInt(min, max)
 
 private fun space() = sequenceOf(' ')
 
@@ -31,7 +25,6 @@ fun capitalisedWord(length: IntRange) = upperCase(1) + lowerCase((length).random
 fun randomEmailAddress() = (lowerCase(5) + ".".asSequence() + lowerCase(8) + "@".asSequence() + lowerCase(6) + ".com".asSequence()).asString()
 
 fun randomPrisonNumber(): String = (upperCase(1) + digits(4) + upperCase(2)).asString()
-fun randomReferrerId(): String = (upperCase(3) + digits(4) + upperCase(2)).asString()
 
 fun Sequence<Char>.asString() = fold(StringBuilder(), StringBuilder::append).toString()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
@@ -3,28 +3,46 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util
 import java.time.LocalDate
 import java.util.UUID
 
-const val PRISON_NUMBER = "A1234AA"
-const val PRISON_NAME = "Moorland"
-const val REFERRER_ID = "MWX001"
-const val CLIENT_USERNAME = "TEST_REFERRER_USER_1"
 val COURSE_ID: UUID = UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367")
 val COURSE_OFFERING_ID: UUID = UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517")
+const val PRISON_NUMBER = "A1234AA"
+const val PRISON_NAME = "Moorland"
+const val CLIENT_USERNAME = "TEST_REFERRER_USER_1"
 const val PRISONER_FIRST_NAME = "John"
 const val PRISONER_LAST_NAME = "Doe"
-const val ORGANISATION_ID = "MDI"
-val BOOKING_ID = "Booking id"
+const val ORGANISATION_ID_MDI = "MDI"
+const val BOOKING_ID = "Booking id"
 const val INDETERMINATE_SENTENCE = false
-const val NONDTORELEASE_DATETYPE = "Release date type"
-val CONDITIONAL_RELEASE_DATE = LocalDate.now()
-val TARIFF_EXPIRYDATE = LocalDate.now().minusDays(5)
-
-val PAROLE_ELIGIBILITYDATE = LocalDate.now().plusYears(1)
-val REFERRER_USERNAME = "autobot"
-
-val INDIGO_COURSE = "Indigo Course"
-
-val SEXUAL_OFFENCE = "Sexual offence"
-
-val WHITE_COURSE = "White Course"
-
-val EXTREMISM_OFFENCE = "Extremism offence"
+const val NON_DTO_RELEASE_DATE_TYPE = "Release date type"
+const val REFERRER_USERNAME = "autobot"
+const val INDIGO_COURSE = "Indigo Course"
+const val WHITE_COURSE = "White Course"
+const val SEXUAL_OFFENCE = "Sexual offence"
+const val EXTREMISM_OFFENCE = "Extremism offence"
+val CONDITIONAL_RELEASE_DATE: LocalDate = LocalDate.now()
+val TARIFF_EXPIRY_DATE: LocalDate = LocalDate.now().minusDays(5)
+val PAROLE_ELIGIBILITY_DATE: LocalDate = LocalDate.now().plusYears(1)
+val PRISONS = mapOf<String?, String>(ORGANISATION_ID_MDI to PRISON_NAME)
+val PRISONERS = mapOf<String?, List<Prisoner>>(
+  PRISON_NUMBER to listOf(
+    Prisoner(
+      prisonerNumber = PRISON_NUMBER,
+      bookingId = BOOKING_ID,
+      firstName = PRISONER_FIRST_NAME,
+      lastName = PRISONER_LAST_NAME,
+      nonDtoReleaseDateType = NON_DTO_RELEASE_DATE_TYPE,
+      conditionalReleaseDate = CONDITIONAL_RELEASE_DATE,
+      tariffDate = TARIFF_EXPIRY_DATE,
+      paroleEligibilityDate = PAROLE_ELIGIBILITY_DATE,
+      indeterminateSentence = INDETERMINATE_SENTENCE,
+    ),
+  ),
+)
+const val PRISON_ID_1 = "1"
+const val PRISON_ID_2 = "2"
+const val PRISON_NUMBER_1 = "001"
+const val PRISON_NUMBER_2 = "002"
+const val PRISON_NAME_1 = "PRISON_ONE"
+const val PRISON_NAME_2 = "PRISON_TWO"
+val PRISONER_1 = Prisoner(prisonerNumber = PRISON_NUMBER_1, firstName = "John", lastName = "Doe")
+val PRISONER_2 = Prisoner(prisonerNumber = PRISON_NUMBER_2, firstName = "Ella", lastName = "Smith")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util
 
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerSearchApi.model.Prisoner
 import java.time.LocalDate
 import java.util.UUID
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -30,7 +30,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLI
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ORGANISATION_ID
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRER_ID
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toDomain
 import java.util.UUID
@@ -52,7 +51,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       id = createdReferralId,
       offeringId = offeringId,
       referrerUsername = CLIENT_USERNAME,
-      referrerId = REFERRER_ID,
       prisonNumber = PRISON_NUMBER,
       status = ReferralStatus.referralStarted,
       additionalInformation = null,
@@ -75,7 +73,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       id = createdReferralId,
       offeringId = offeringId,
       referrerUsername = "NONEXISTENT_USER",
-      referrerId = REFERRER_ID,
       prisonNumber = PRISON_NUMBER,
       status = ReferralStatus.referralStarted,
       additionalInformation = null,
@@ -103,7 +100,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       id = createdReferralId,
       offeringId = offeringId,
       referrerUsername = CLIENT_USERNAME,
-      referrerId = REFERRER_ID,
       prisonNumber = PRISON_NUMBER,
       status = ReferralStatus.referralStarted,
       additionalInformation = "Additional information",
@@ -146,7 +142,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       id = createdReferralId,
       offeringId = offeringId,
       referrerUsername = CLIENT_USERNAME,
-      referrerId = REFERRER_ID,
       prisonNumber = PRISON_NUMBER,
       status = ReferralStatus.referralSubmitted,
       oasysConfirmed = false,
@@ -346,7 +341,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
         ReferralCreate(
           offeringId = offeringId,
           prisonNumber = PRISON_NUMBER,
-          referrerId = REFERRER_ID,
         ),
       )
       .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonRe
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerSearchApi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ORGANISATION_ID
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ORGANISATION_ID_MDI
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseString
@@ -187,9 +187,8 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     val offeringId = getFirstOfferingIdForCourse(courseId)
     val referralCreated = createReferral(offeringId)
     val createdReferral = getReferralById(referralCreated.referralId)
-    val organisationId = "MDI"
-    val prisoners = listOf<Prisoner>(Prisoner(firstName = "John"))
-    val prisons = listOf<PrisonDetails>(PrisonDetails(prisonId = ORGANISATION_ID, prisonName = PRISON_NAME))
+    val prisoners = listOf(Prisoner(firstName = "John"))
+    val prisons = listOf(PrisonDetails(prisonId = ORGANISATION_ID_MDI, prisonName = PRISON_NAME))
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
     mockPrisonerSearchResponse(prisoners)
     mockPrisonRegisterResponse(prisons)
@@ -198,7 +197,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
 
     val statusFilter = listOf(createdReferral.status.toDomain().name)
     val audienceFilter = getCourseById(courseId).audiences.map { it.value }.first()
-    val summary = getReferralSummariesByOrganisationId(organisationId, statusFilter, audienceFilter)
+    val summary = getReferralSummariesByOrganisationId(ORGANISATION_ID_MDI, statusFilter, audienceFilter)
 
     summary.content?.forEach { actualSummary ->
       listOf(
@@ -252,7 +251,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
   fun `Retrieving a list of multi-status-filtered referrals for an organisation should return 200 with correct body`() {
     val courseId = getFirstCourseId()
     val offeringId = getFirstOfferingIdForCourse(courseId)
-    val organisationId = "MDI"
 
     val firstReferralCreated = createReferral(offeringId)
     val firstCreatedReferral = getReferralById(firstReferralCreated.referralId)
@@ -279,7 +277,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
 
     val statusFilter = listOf(firstReferralStatus, secondReferralStatus)
     val audienceFilter = getCourseById(courseId).audiences.map { it.value }.first()
-    val summary = getReferralSummariesByOrganisationId(organisationId, statusFilter, audienceFilter)
+    val summary = getReferralSummariesByOrganisationId(ORGANISATION_ID_MDI, statusFilter, audienceFilter)
 
     val expectedFirstSummary = ReferralSummary(
       id = firstCreatedReferral.id,
@@ -320,8 +318,8 @@ class ReferralIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Retrieving a list of referrals for an organisation with no referrals should return 200 with empty body`() {
     val randomOrganisationId = randomUppercaseString(3)
-    val prisoners = listOf<Prisoner>(Prisoner(firstName = "John"))
-    val prisons = listOf<PrisonDetails>(PrisonDetails(prisonId = ORGANISATION_ID, prisonName = PRISON_NAME))
+    val prisoners = listOf(Prisoner(firstName = "John"))
+    val prisons = listOf(PrisonDetails(prisonId = ORGANISATION_ID_MDI, prisonName = PRISON_NAME))
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
     mockPrisonerSearchResponse(prisoners)
     mockPrisonRegisterResponse(prisons)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralSummaryBuilderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralSummaryBuilderServiceTest.kt
@@ -2,8 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerSearchApi.model.Prisoner
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.BOOKING_ID
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CONDITIONAL_RELEASE_DATE
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.EXTREMISM_OFFENCE
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.INDETERMINATE_SENTENCE
@@ -14,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PAR
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONERS
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_FIRST_NAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_LAST_NAME
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONS
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRER_USERNAME
@@ -23,12 +22,11 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.WHI
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
 import java.time.LocalDateTime
+import java.util.*
 
 class ReferralSummaryBuilderServiceTest {
 
   val service = ReferralSummaryBuilderService()
-  val uuid1 = java.util.UUID.randomUUID()
-  val uuid2 = java.util.UUID.randomUUID()
 
   companion object {
     private val referralSummaryProjection1 = ReferralSummaryProjection(
@@ -41,36 +39,27 @@ class ReferralSummaryBuilderServiceTest {
       referrerUsername = REFERRER_USERNAME,
     )
 
-  private val referralSummaryProjection1 = ReferralSummaryProjection(
-    referralId = uuid1,
-    courseName = INDIGO_COURSE,
-    audience = SEXUAL_OFFENCE,
-    status = ReferralEntity.ReferralStatus.ASSESSMENT_STARTED,
-    submittedOn = LocalDateTime.now(),
-    prisonNumber = PRISON_NUMBER,
-    referrerUsername = REFERRER_USERNAME,
-  )
-
-  private val referralSummaryProjection2 = ReferralSummaryProjection(
-    referralId = uuid2,
-    courseName = WHITE_COURSE,
-    audience = EXTREMISM_OFFENCE,
-    status = ReferralEntity.ReferralStatus.ASSESSMENT_STARTED,
-    submittedOn = LocalDateTime.now(),
-    prisonNumber = PRISON_NUMBER,
-    referrerUsername = REFERRER_USERNAME,
-  )
+    private val referralSummaryProjection2 = ReferralSummaryProjection(
+      referralId = UUID.randomUUID(),
+      courseName = WHITE_COURSE,
+      audience = EXTREMISM_OFFENCE,
+      status = ReferralEntity.ReferralStatus.ASSESSMENT_STARTED,
+      submittedOn = LocalDateTime.now(),
+      prisonNumber = PRISON_NUMBER,
+      referrerUsername = REFERRER_USERNAME,
+    )
+  }
 
   @Test
   fun `build referral summary successful`() {
     val referralSummaries =
-      service.build(listOf(referralSummaryProjection1, referralSummaryProjection2), prisoners, prisons, ORGANISATION_ID)
+      service.build(listOf(referralSummaryProjection1, referralSummaryProjection2), PRISONERS, PRISONS, ORGANISATION_ID_MDI)
 
     assertEquals(2, referralSummaries.size)
 
     with(referralSummaries[0]) {
-      organisationId shouldBe ORGANISATION_ID
-      id shouldBe uuid1
+      organisationId shouldBe ORGANISATION_ID_MDI
+      id shouldBe referralSummaryProjection1.referralId
       courseName shouldBe INDIGO_COURSE
       prisonNumber shouldBe PRISON_NUMBER
       prisonName shouldBe PRISON_NAME
@@ -84,8 +73,8 @@ class ReferralSummaryBuilderServiceTest {
     }
 
     with(referralSummaries[1]) {
-      organisationId shouldBe ORGANISATION_ID
-      id shouldBe uuid2
+      organisationId shouldBe ORGANISATION_ID_MDI
+      id shouldBe referralSummaryProjection2.referralId
       courseName shouldBe WHITE_COURSE
       prisonNumber shouldBe PRISON_NUMBER
       prisonName shouldBe PRISON_NAME

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralSummaryBuilderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralSummaryBuilderServiceTest.kt
@@ -8,16 +8,17 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CON
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.EXTREMISM_OFFENCE
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.INDETERMINATE_SENTENCE
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.INDIGO_COURSE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.NONDTORELEASE_DATETYPE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ORGANISATION_ID
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PAROLE_ELIGIBILITYDATE
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.NON_DTO_RELEASE_DATE_TYPE
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ORGANISATION_ID_MDI
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PAROLE_ELIGIBILITY_DATE
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONERS
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_FIRST_NAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_LAST_NAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRER_USERNAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.SEXUAL_OFFENCE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.TARIFF_EXPIRYDATE
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.TARIFF_EXPIRY_DATE
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.WHITE_COURSE
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
@@ -29,22 +30,16 @@ class ReferralSummaryBuilderServiceTest {
   val uuid1 = java.util.UUID.randomUUID()
   val uuid2 = java.util.UUID.randomUUID()
 
-  private val prisons = mapOf<String?, String>(ORGANISATION_ID to PRISON_NAME)
-  private val prisoners = mapOf<String?, List<Prisoner>>(
-    PRISON_NUMBER to listOf(
-      Prisoner(
-        prisonerNumber = PRISON_NUMBER,
-        bookingId = BOOKING_ID,
-        firstName = PRISONER_FIRST_NAME,
-        lastName = PRISONER_LAST_NAME,
-        nonDtoReleaseDateType = NONDTORELEASE_DATETYPE,
-        conditionalReleaseDate = CONDITIONAL_RELEASE_DATE,
-        tariffDate = TARIFF_EXPIRYDATE,
-        paroleEligibilityDate = PAROLE_ELIGIBILITYDATE,
-        indeterminateSentence = INDETERMINATE_SENTENCE,
-      ),
-    ),
-  )
+  companion object {
+    private val referralSummaryProjection1 = ReferralSummaryProjection(
+      referralId = UUID.randomUUID(),
+      courseName = INDIGO_COURSE,
+      audience = SEXUAL_OFFENCE,
+      status = ReferralEntity.ReferralStatus.ASSESSMENT_STARTED,
+      submittedOn = LocalDateTime.now(),
+      prisonNumber = PRISON_NUMBER,
+      referrerUsername = REFERRER_USERNAME,
+    )
 
   private val referralSummaryProjection1 = ReferralSummaryProjection(
     referralId = uuid1,
@@ -83,9 +78,9 @@ class ReferralSummaryBuilderServiceTest {
       prisonerName?.lastName shouldBe PRISONER_LAST_NAME
       sentence?.indeterminateSentence shouldBe INDETERMINATE_SENTENCE
       sentence?.conditionalReleaseDate shouldBe CONDITIONAL_RELEASE_DATE
-      sentence?.nonDtoReleaseDateType shouldBe NONDTORELEASE_DATETYPE
-      sentence?.tariffExpiryDate shouldBe TARIFF_EXPIRYDATE
-      sentence?.paroleEligibilityDate shouldBe PAROLE_ELIGIBILITYDATE
+      sentence?.nonDtoReleaseDateType shouldBe NON_DTO_RELEASE_DATE_TYPE
+      sentence?.tariffExpiryDate shouldBe TARIFF_EXPIRY_DATE
+      sentence?.paroleEligibilityDate shouldBe PAROLE_ELIGIBILITY_DATE
     }
 
     with(referralSummaries[1]) {
@@ -98,9 +93,9 @@ class ReferralSummaryBuilderServiceTest {
       prisonerName?.lastName shouldBe PRISONER_LAST_NAME
       sentence?.indeterminateSentence shouldBe INDETERMINATE_SENTENCE
       sentence?.conditionalReleaseDate shouldBe CONDITIONAL_RELEASE_DATE
-      sentence?.nonDtoReleaseDateType shouldBe NONDTORELEASE_DATETYPE
-      sentence?.tariffExpiryDate shouldBe TARIFF_EXPIRYDATE
-      sentence?.paroleEligibilityDate shouldBe PAROLE_ELIGIBILITYDATE
+      sentence?.nonDtoReleaseDateType shouldBe NON_DTO_RELEASE_DATE_TYPE
+      sentence?.tariffExpiryDate shouldBe TARIFF_EXPIRY_DATE
+      sentence?.paroleEligibilityDate shouldBe PAROLE_ELIGIBILITY_DATE
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralEntityFactory.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.en
 import io.github.bluegroundltd.kfactory.Factory
 import io.github.bluegroundltd.kfactory.Yielded
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomPrisonNumber
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseAlphanumericString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OfferingEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferrerUserEntity
@@ -16,7 +15,6 @@ class ReferralEntityFactory : Factory<ReferralEntity> {
   private var offering: Yielded<OfferingEntity> = { OfferingEntityFactory().produce() }
   private var prisonNumber: Yielded<String> = { randomPrisonNumber() }
   private var referrer: Yielded<ReferrerUserEntity> = { ReferrerUserEntityFactory().produce() }
-  private var referrerId: Yielded<String> = { randomUppercaseAlphanumericString(6) }
   private var additionalInformation: Yielded<String?> = { null }
   private var oasysConfirmed: Yielded<Boolean> = { false }
   private var hasReviewedProgrammeHistory: Yielded<Boolean> = { false }
@@ -37,10 +35,6 @@ class ReferralEntityFactory : Factory<ReferralEntity> {
 
   fun withReferrer(referrer: ReferrerUserEntity) = apply {
     this.referrer = { referrer }
-  }
-
-  fun withReferrerId(referrerId: String) = apply {
-    this.referrerId = { referrerId }
   }
 
   fun withAdditionalInformation(additionalInformation: String?) = apply {
@@ -68,7 +62,6 @@ class ReferralEntityFactory : Factory<ReferralEntity> {
     offering = this.offering(),
     prisonNumber = this.prisonNumber(),
     referrer = this.referrer(),
-    referrerId = this.referrerId(),
     additionalInformation = this.additionalInformation(),
     oasysConfirmed = this.oasysConfirmed(),
     hasReviewedProgrammeHistory = this.hasReviewedProgrammeHistory(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRER_ID
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomEmailAddress
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomLowercaseString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomSentence
@@ -52,7 +51,6 @@ constructor(
 
     val referral = ReferralEntityFactory()
       .withReferrer(referrer)
-      .withReferrerId(REFERRER_ID)
       .withPrisonNumber(PRISON_NUMBER)
       .withOffering(offering)
       .produce()
@@ -61,7 +59,6 @@ constructor(
 
     referralRepository.findById(referral.id!!) shouldBePresent {
       referrer shouldBe referrer
-      referrerId shouldBe referrerId
       prisonNumber shouldBe prisonNumber
       offering shouldBe offering
       offering.course shouldBe course
@@ -93,7 +90,6 @@ constructor(
 
     val referral = ReferralEntityFactory()
       .withReferrer(referrer)
-      .withReferrerId(REFERRER_ID)
       .withPrisonNumber(PRISON_NUMBER)
       .withOffering(offering)
       .produce()
@@ -107,7 +103,6 @@ constructor(
 
     referralRepository.findById(referral.id!!) shouldBePresent {
       referrer shouldBe referrer
-      referrerId shouldBe referrerId
       prisonNumber shouldBe prisonNumber
       offering shouldBe offering
       offering.course shouldBe course

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -35,20 +35,10 @@ import org.springframework.test.web.servlet.put
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.PaginatedReferralSummary
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralSummary
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerSearchApi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.BOOKING_ID
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CONDITIONAL_RELEASE_DATE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.INDETERMINATE_SENTENCE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.NONDTORELEASE_DATETYPE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ORGANISATION_ID
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PAROLE_ELIGIBILITYDATE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_FIRST_NAME
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_LAST_NAME
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NAME
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ORGANISATION_ID_MDI
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.TARIFF_EXPIRYDATE
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomPrisonNumber
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.AWAITING_ASSESSMENT
@@ -422,7 +412,6 @@ constructor(
 
   @Test
   fun `getReferralsByOrganisationId with valid organisationId returns 200 with paginated body`() {
-    val organisationId = "MDI"
     val pageable = PageRequest.of(0, 10, Sort.by("referralId"))
 
     val firstReferralId = UUID.randomUUID()
@@ -449,10 +438,10 @@ constructor(
       referrerUsername = CLIENT_USERNAME,
     )
 
-    every { referralService.getReferralsByOrganisationId(organisationId, pageable, null, null, null) } returns
+    every { referralService.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageable, null, null, null) } returns
       PageImpl(listOf(referralSummary1, referralSummary2), pageable, 2L)
 
-    val mvcResult = mockMvc.get("/referrals/organisation/$organisationId/dashboard") {
+    val mvcResult = mockMvc.get("/referrals/organisation/$ORGANISATION_ID_MDI/dashboard") {
       param("page", "0")
       param("size", "10")
       header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
@@ -492,12 +481,11 @@ constructor(
       referral.referrerUsername shouldBe CLIENT_USERNAME
     }
 
-    verify { referralService.getReferralsByOrganisationId(organisationId, pageable, null, null, null) }
+    verify { referralService.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageable, null, null, null) }
   }
 
   @Test
   fun `getReferralsByOrganisationId with valid organisationId and custom pagination count will return 200 with paginated body for each page`() {
-    val organisationId = "MDI"
     val pageSize = 1
     val pageableFirstPage = PageRequest.of(0, pageSize, Sort.by("referralId"))
     val pageableSecondPage = PageRequest.of(1, pageSize, Sort.by("referralId"))
@@ -529,13 +517,13 @@ constructor(
         .produce()
     }
 
-    every { referralService.getReferralsByOrganisationId(organisationId, pageableFirstPage, null, null, null) } returns
+    every { referralService.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageableFirstPage, null, null, null) } returns
       PageImpl(listOf(referralSummary1), pageableFirstPage, 2)
 
-    every { referralService.getReferralsByOrganisationId(organisationId, pageableSecondPage, null, null, null) } returns
+    every { referralService.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageableSecondPage, null, null, null) } returns
       PageImpl(listOf(referralSummary2), pageableSecondPage, 2)
 
-    val firstPageResult = mockMvc.get("/referrals/organisation/$organisationId/dashboard") {
+    val firstPageResult = mockMvc.get("/referrals/organisation/$ORGANISATION_ID_MDI/dashboard") {
       param("page", "0")
       param("size", pageSize.toString())
       header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
@@ -561,7 +549,7 @@ constructor(
       referral.referrerUsername shouldBe CLIENT_USERNAME
     }
 
-    val secondPageResult = mockMvc.get("/referrals/organisation/$organisationId/dashboard") {
+    val secondPageResult = mockMvc.get("/referrals/organisation/$ORGANISATION_ID_MDI/dashboard") {
       param("page", "1")
       param("size", pageSize.toString())
       header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
@@ -588,8 +576,8 @@ constructor(
       referral.referrerUsername shouldBe CLIENT_USERNAME
     }
 
-    verify(exactly = 1) { referralService.getReferralsByOrganisationId(organisationId, pageableFirstPage, null, null, null) }
-    verify(exactly = 1) { referralService.getReferralsByOrganisationId(organisationId, pageableSecondPage, null, null, null) }
+    verify(exactly = 1) { referralService.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageableFirstPage, null, null, null) }
+    verify(exactly = 1) { referralService.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageableSecondPage, null, null, null) }
   }
 
   @ParameterizedTest
@@ -600,13 +588,12 @@ constructor(
     courseNameFilter: String?,
     expectedReferralSummaries: List<ReferralSummary>,
   ) {
-    val organisationId = "MDI"
     val pageable = PageRequest.of(0, 10, Sort.by("referralId"))
 
-    every { referralService.getReferralsByOrganisationId(organisationId, pageable, statusFilter, audienceFilter, courseNameFilter) } returns
+    every { referralService.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageable, statusFilter, audienceFilter, courseNameFilter) } returns
       PageImpl(expectedReferralSummaries, pageable, 1)
 
-    val result = mockMvc.get("/referrals/organisation/$organisationId/dashboard") {
+    val result = mockMvc.get("/referrals/organisation/$ORGANISATION_ID_MDI/dashboard") {
       param("page", "0")
       param("size", "10")
       statusFilter?.let { param("status", it.joinToString(",")) }
@@ -625,7 +612,7 @@ constructor(
     response.content?.shouldContainExactlyInAnyOrder(expectedReferralSummaries)
 
     verify(exactly = 1) {
-      referralService.getReferralsByOrganisationId(organisationId, pageable, statusFilter, audienceFilter, courseNameFilter)
+      referralService.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageable, statusFilter, audienceFilter, courseNameFilter)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/transformer/ReferralTransformersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/transformer/ReferralTransformersTest.kt
@@ -8,17 +8,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Refer
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.awaitingAssessment
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.referralStarted
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatus.referralSubmitted
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerSearchApi.model.Prisoner
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.BOOKING_ID
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CONDITIONAL_RELEASE_DATE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.INDETERMINATE_SENTENCE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.NONDTORELEASE_DATETYPE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ORGANISATION_ID
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PAROLE_ELIGIBILITYDATE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_FIRST_NAME
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_LAST_NAME
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NAME
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.TARIFF_EXPIRYDATE
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.ASSESSMENT_STARTED
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.AWAITING_ASSESSMENT
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity.ReferralStatus.REFERRAL_STARTED
@@ -31,23 +20,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.c
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.ReferralUpdate as DomainReferralUpdate
 
 class ReferralTransformersTest {
-
-  private val prisons = mapOf<String?, String>(ORGANISATION_ID to PRISON_NAME)
-  private val prisoners = mapOf<String?, List<Prisoner>>(
-    uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER to listOf(
-      Prisoner(
-        prisonerNumber = uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER,
-        bookingId = BOOKING_ID,
-        firstName = PRISONER_FIRST_NAME,
-        lastName = PRISONER_LAST_NAME,
-        nonDtoReleaseDateType = NONDTORELEASE_DATETYPE,
-        conditionalReleaseDate = CONDITIONAL_RELEASE_DATE,
-        tariffDate = TARIFF_EXPIRYDATE,
-        paroleEligibilityDate = PAROLE_ELIGIBILITYDATE,
-        indeterminateSentence = INDETERMINATE_SENTENCE,
-      ),
-    ),
-  )
 
   @ParameterizedTest
   @EnumSource

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -32,8 +32,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRI
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_LAST_NAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRER_ID
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.TARIFF_EXPIRYDATE
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferrerUserEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
@@ -52,7 +50,6 @@ import java.util.stream.Stream
 class ReferralServiceTest {
 
   companion object {
-
     @JvmStatic
     fun parametersForGetReferralsByOrganisationId(): Stream<Arguments> {
       val projections1 = listOf("Audience 1", "Audience 2").map { audience ->
@@ -120,24 +117,6 @@ class ReferralServiceTest {
   @InjectMockKs
   private lateinit var referralService: ReferralService
 
-  private val prisons = mapOf<String?, String>(ORGANISATION_ID to PRISON_NAME)
-  private val prisoners = mapOf<String?, List<Prisoner>>(
-    PRISON_NUMBER to listOf(
-      Prisoner(
-        prisonerNumber = PRISON_NUMBER,
-        bookingId = BOOKING_ID,
-        firstName = PRISONER_FIRST_NAME,
-        lastName = PRISONER_LAST_NAME,
-        nonDtoReleaseDateType = NONDTORELEASE_DATETYPE,
-        conditionalReleaseDate = CONDITIONAL_RELEASE_DATE,
-        tariffDate = TARIFF_EXPIRYDATE,
-        paroleEligibilityDate = PAROLE_ELIGIBILITYDATE,
-        indeterminateSentence = INDETERMINATE_SENTENCE,
-      ),
-    ),
-  )
-  val organisationId = "MDI"
-
   @BeforeEach
   fun setup() {
     MockKAnnotations.init(this)
@@ -175,7 +154,7 @@ class ReferralServiceTest {
       firstArg<ReferralEntity>().apply { id = referralId }
     }
 
-    val createdReferralId = referralService.createReferral(PRISON_NUMBER, offering.id!!, REFERRER_ID)
+    val createdReferralId = referralService.createReferral(PRISON_NUMBER, offering.id!!)
 
     createdReferralId shouldBe referralId
 
@@ -185,7 +164,6 @@ class ReferralServiceTest {
       referralRepository.save(
         match {
           it.prisonNumber == PRISON_NUMBER &&
-            it.referrerId == REFERRER_ID &&
             it.referrer.username == CLIENT_USERNAME &&
             it.offering.id == offering.id
         },
@@ -213,7 +191,7 @@ class ReferralServiceTest {
       firstArg<ReferralEntity>().apply { id = referralId }
     }
 
-    val createdReferralId = referralService.createReferral(PRISON_NUMBER, offering.id!!, REFERRER_ID)
+    val createdReferralId = referralService.createReferral(PRISON_NUMBER, offering.id!!)
 
     createdReferralId shouldBe referralId
 
@@ -230,7 +208,6 @@ class ReferralServiceTest {
       referralRepository.save(
         match {
           it.prisonNumber == PRISON_NUMBER &&
-            it.referrerId == REFERRER_ID &&
             it.referrer.username == "NONEXISTENT_USER" &&
             it.offering.id == offering.id
         },

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -20,17 +20,10 @@ import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonRegisterApi.PrisonRegisterApiService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerSearchApi.PrisonerSearchApiService
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerSearchApi.model.Prisoner
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.BOOKING_ID
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CONDITIONAL_RELEASE_DATE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.INDETERMINATE_SENTENCE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.NONDTORELEASE_DATETYPE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ORGANISATION_ID
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PAROLE_ELIGIBILITYDATE
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_FIRST_NAME
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_LAST_NAME
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NAME
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ORGANISATION_ID_MDI
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONERS
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONS
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferrerUserEntity
@@ -120,8 +113,8 @@ class ReferralServiceTest {
   @BeforeEach
   fun setup() {
     MockKAnnotations.init(this)
-    every { prisonRegisterApiService.getAllPrisons() } returns prisons
-    every { prisonerSearchApiService.getPrisoners(any()) } returns prisoners
+    every { prisonRegisterApiService.getAllPrisons() } returns PRISONS
+    every { prisonerSearchApiService.getPrisoners(any()) } returns PRISONERS
   }
 
   private fun mockSecurityContext(username: String) {
@@ -223,25 +216,24 @@ class ReferralServiceTest {
     courseFilter: String?,
     expectedReferralSummaryProjections: List<ReferralSummaryProjection>,
   ) {
-    val orgId = "MDI"
     val pageable = PageRequest.of(0, 10)
     val statusEnums = statusFilter?.map { ReferralEntity.ReferralStatus.valueOf(it) }
 
-    every { referralRepository.getReferralsByOrganisationId(orgId, pageable, statusEnums, audienceFilter, courseFilter) } returns
+    every { referralRepository.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageable, statusEnums, audienceFilter, courseFilter) } returns
       PageImpl(expectedReferralSummaryProjections, pageable, expectedReferralSummaryProjections.size.toLong())
 
-    val resultPage = referralService.getReferralsByOrganisationId(orgId, pageable, statusFilter, audienceFilter, courseFilter)
+    val resultPage = referralService.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageable, statusFilter, audienceFilter, courseFilter)
 
     resultPage.totalElements shouldBe expectedReferralSummaryProjections.size.toLong()
 
     val expectedTotalPages = (expectedReferralSummaryProjections.size + pageable.pageSize - 1) / pageable.pageSize
     resultPage.totalPages shouldBe expectedTotalPages
 
-    verify { referralRepository.getReferralsByOrganisationId(orgId, pageable, statusEnums, audienceFilter, courseFilter) }
+    verify { referralRepository.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageable, statusEnums, audienceFilter, courseFilter) }
     verify { prisonRegisterApiService.getAllPrisons() }
     verify { prisonerSearchApiService.getPrisoners(any()) }
     verify { referralSummaryBuilderService.build(any(), any(), any(), any()) }
-    verify { referralRepository.getReferralsByOrganisationId(orgId, pageable, statusEnums, audienceFilter, courseFilter) }
+    verify { referralRepository.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageable, statusEnums, audienceFilter, courseFilter) }
     verify { referralSummaryBuilderService.build(any(), any(), any(), any()) }
   }
 

--- a/src/test/resources/db/migration/R__test_data.sql
+++ b/src/test/resources/db/migration/R__test_data.sql
@@ -24,7 +24,7 @@ VALUES ('TEST_REFERRER_USER_1'),
        ('TEST_REFERRER_USER_2'),
        ('TEST_REFERRER_USER_3');
 
-INSERT INTO referral (referral_id, offering_id, prison_number, referrer_username, referrer_id, additional_information, oasys_confirmed, has_reviewed_programme_history, status, submitted_on)
-VALUES ('0c46ed09-170b-4c0f-aee8-a24eeaeeddaa', '7fffcc6a-11f8-4713-be35-cf5ff1aee517', 'B2345BB', 'TEST_REFERRER_USER_1', '123456', 'This referral will be updated', false, false, 'REFERRAL_STARTED', NULL),
-       ('fae2ed00-057e-4179-9e55-f6a4f4874cf0', '790a2dfe-7de5-4504-bb9c-83e6e53a6537', 'C3456CC', 'TEST_REFERRER_USER_2', '234567', 'more information', true, true, 'REFERRAL_SUBMITTED', '2023-11-12T19:11:00'),
-       ('153383a4-b250-46a8-9950-43eb358c2805', '790a2dfe-7de5-4504-bb9c-83e6e53a6537', 'D3456DD', 'TEST_REFERRER_USER_2', '234567', 'more information', true, true, 'REFERRAL_SUBMITTED', '2023-11-13T19:11:00');
+INSERT INTO referral (referral_id, offering_id, prison_number, referrer_username, additional_information, oasys_confirmed, has_reviewed_programme_history, status, submitted_on)
+VALUES ('0c46ed09-170b-4c0f-aee8-a24eeaeeddaa', '7fffcc6a-11f8-4713-be35-cf5ff1aee517', 'B2345BB', 'TEST_REFERRER_USER_1', 'This referral will be updated', false, false, 'REFERRAL_STARTED', NULL),
+       ('fae2ed00-057e-4179-9e55-f6a4f4874cf0', '790a2dfe-7de5-4504-bb9c-83e6e53a6537', 'C3456CC', 'TEST_REFERRER_USER_2', 'more information', true, true, 'REFERRAL_SUBMITTED', '2023-11-12T19:11:00'),
+       ('153383a4-b250-46a8-9950-43eb358c2805', '790a2dfe-7de5-4504-bb9c-83e6e53a6537', 'D3456DD', 'TEST_REFERRER_USER_2', 'more information', true, true, 'REFERRAL_SUBMITTED', '2023-11-13T19:11:00');


### PR DESCRIPTION
## Context

> [see #1200 on the Refer & Monitor Trello board.](https://trello.com/c/WMr6ClIF/1200-gracefully-retire-referrerid-in-favour-of-novel-referreruser-and-username-retrieval-from-the-fe-token)

## Changes in this PR

Following from #185 which added a new `ReferrerUser` which sources its information from the current logged-in user in place of the original `referrerId` implementation, this PR gracefully retires it.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
