### PR TITLE
#1205 Implement getEarliestReleaseDate for caselist ReferralSummary objects

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -122,11 +122,9 @@ constructor(
     val statusEnums = status?.map { ReferralEntity.ReferralStatus.valueOf(it) }
     val referralProjectionPage = referralRepository.getReferralsByOrganisationId(organisationId, pageable, statusEnums, audience, courseName)
     val content = referralProjectionPage.content
-    val prisonersDetails =
-      prisonerSearchApiService.getPrisoners(content.map { it.prisonNumber }.distinct())
+    val prisonersDetails = prisonerSearchApiService.getPrisoners(content.map { it.prisonNumber }.distinct())
     val allPrisons = prisonRegisterApiService.getAllPrisons()
-
-    val apiContent = referralSummaryBuilderService.build(content, prisonersDetails, allPrisons, organisationId)
+    val apiContent = referralSummaryBuilderService.build(content, prisonersDetails, allPrisons, organisationId, false)
 
     return PageImpl(apiContent, pageable, referralProjectionPage.totalElements)
   }

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1092,6 +1092,10 @@ components:
           description: ID of the organisation
         sentence:
           $ref: '#/components/schemas/Sentence'
+        earliestReleaseDate:
+          type: string
+          format: date
+          description: Earliest release date, if applicable, to this individual. Derived from Sentence information.
         prisonerName:
           $ref: '#/components/schemas/Name'
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonSearchApi/PrisonSearchApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonSearchApi/PrisonSearchApiServiceTest.kt
@@ -16,7 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRI
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER_1
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER_2
 
-class PrisonerSearchApiServiceTest {
+class PrisonSearchApiServiceTest {
 
   private val prisonerSearchApiClient = mockk<PrisonerSearchApiClient>()
   val service = PrisonerSearchApiService(prisonerSearchApiClient)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -232,9 +232,9 @@ class ReferralServiceTest {
     verify { referralRepository.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageable, statusEnums, audienceFilter, courseFilter) }
     verify { prisonRegisterApiService.getAllPrisons() }
     verify { prisonerSearchApiService.getPrisoners(any()) }
-    verify { referralSummaryBuilderService.build(any(), any(), any(), any()) }
+    verify { referralSummaryBuilderService.build(any(), any(), any(), any(), false) }
     verify { referralRepository.getReferralsByOrganisationId(ORGANISATION_ID_MDI, pageable, statusEnums, audienceFilter, courseFilter) }
-    verify { referralSummaryBuilderService.build(any(), any(), any(), any()) }
+    verify { referralSummaryBuilderService.build(any(), any(), any(), any(), false) }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralSummaryBuilderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralSummaryBuilderServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.service
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -21,12 +21,13 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.TAR
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.WHITE_COURSE
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralSummaryBuilderService
 import java.time.LocalDateTime
 import java.util.*
 
 class ReferralSummaryBuilderServiceTest {
 
-  val service = ReferralSummaryBuilderService()
+  private val referralSummaryBuilderService = ReferralSummaryBuilderService()
 
   companion object {
     private val referralSummaryProjection1 = ReferralSummaryProjection(
@@ -51,9 +52,9 @@ class ReferralSummaryBuilderServiceTest {
   }
 
   @Test
-  fun `build referral summary successful`() {
+  fun `Building a referral summary requiring all sentence information should succeed`() {
     val referralSummaries =
-      service.build(listOf(referralSummaryProjection1, referralSummaryProjection2), PRISONERS, PRISONS, ORGANISATION_ID_MDI)
+      referralSummaryBuilderService.build(listOf(referralSummaryProjection1, referralSummaryProjection2), PRISONERS, PRISONS, ORGANISATION_ID_MDI, false)
 
     assertEquals(2, referralSummaries.size)
 
@@ -70,6 +71,7 @@ class ReferralSummaryBuilderServiceTest {
       sentence?.nonDtoReleaseDateType shouldBe NON_DTO_RELEASE_DATE_TYPE
       sentence?.tariffExpiryDate shouldBe TARIFF_EXPIRY_DATE
       sentence?.paroleEligibilityDate shouldBe PAROLE_ELIGIBILITY_DATE
+      earliestReleaseDate shouldBe null
     }
 
     with(referralSummaries[1]) {
@@ -85,6 +87,47 @@ class ReferralSummaryBuilderServiceTest {
       sentence?.nonDtoReleaseDateType shouldBe NON_DTO_RELEASE_DATE_TYPE
       sentence?.tariffExpiryDate shouldBe TARIFF_EXPIRY_DATE
       sentence?.paroleEligibilityDate shouldBe PAROLE_ELIGIBILITY_DATE
+      earliestReleaseDate shouldBe null
+    }
+  }
+
+  @Test
+  fun `Building a referral summary requiring only earliest release date should succeed`() {
+    val referralSummaries =
+      referralSummaryBuilderService.build(listOf(referralSummaryProjection1, referralSummaryProjection2), PRISONERS, PRISONS, ORGANISATION_ID_MDI, true)
+
+    assertEquals(2, referralSummaries.size)
+
+    with(referralSummaries[0]) {
+      organisationId shouldBe ORGANISATION_ID_MDI
+      id shouldBe referralSummaryProjection1.referralId
+      courseName shouldBe INDIGO_COURSE
+      prisonNumber shouldBe PRISON_NUMBER
+      prisonName shouldBe PRISON_NAME
+      prisonerName?.firstName shouldBe PRISONER_FIRST_NAME
+      prisonerName?.lastName shouldBe PRISONER_LAST_NAME
+      sentence?.indeterminateSentence shouldBe INDETERMINATE_SENTENCE
+      sentence?.conditionalReleaseDate shouldBe CONDITIONAL_RELEASE_DATE
+      sentence?.nonDtoReleaseDateType shouldBe NON_DTO_RELEASE_DATE_TYPE
+      sentence?.tariffExpiryDate shouldBe TARIFF_EXPIRY_DATE
+      sentence?.paroleEligibilityDate shouldBe PAROLE_ELIGIBILITY_DATE
+      earliestReleaseDate shouldBe PAROLE_ELIGIBILITY_DATE
+    }
+
+    with(referralSummaries[1]) {
+      organisationId shouldBe ORGANISATION_ID_MDI
+      id shouldBe referralSummaryProjection2.referralId
+      courseName shouldBe WHITE_COURSE
+      prisonNumber shouldBe PRISON_NUMBER
+      prisonName shouldBe PRISON_NAME
+      prisonerName?.firstName shouldBe PRISONER_FIRST_NAME
+      prisonerName?.lastName shouldBe PRISONER_LAST_NAME
+      sentence?.indeterminateSentence shouldBe INDETERMINATE_SENTENCE
+      sentence?.conditionalReleaseDate shouldBe CONDITIONAL_RELEASE_DATE
+      sentence?.nonDtoReleaseDateType shouldBe NON_DTO_RELEASE_DATE_TYPE
+      sentence?.tariffExpiryDate shouldBe TARIFF_EXPIRY_DATE
+      sentence?.paroleEligibilityDate shouldBe PAROLE_ELIGIBILITY_DATE
+      earliestReleaseDate shouldBe PAROLE_ELIGIBILITY_DATE
     }
   }
 }


### PR DESCRIPTION
## Context

> [see #1205 on the Accredited Programmes Trello board.](https://trello.com/c/r6Hy20fA/1205-return-earliest-release-date-from-api-m)

## Changes in this PR

We currently fetch the following fields from the Prisoner Search:
- Tariff date
- Parole eligibility date
- Conditional release date
- Indeterminate sentence

This PR implements `getEarliestReleaseDate` which determines the earliest possible release date for a particular individual. This is required for the user-caselist view in the UI.

This has been handled by introducing a boolean in `ReferralSummaryBuilderService` which will optionally produce the `ReferralSummary` object with the additional field `earliestReleaseDate`. This is open for extension and modification, in the case that different information is required for building a `ReferralSummary` object.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
