### PR TITLE
Use `ACP_TEST` instead of `UNKNOWN_USER`

### DIFF
--- a/src/main/resources/db/migration/V26__retire_referrerId.sql
+++ b/src/main/resources/db/migration/V26__retire_referrerId.sql
@@ -10,12 +10,12 @@ WHERE r.referrer_username IS NOT NULL
     WHERE ru.referrer_username = r.referrer_username
 );
 
-INSERT INTO referrer_user(referrer_username) VALUES ('UNKNOWN_USER');
+INSERT INTO referrer_user(referrer_username) VALUES ('ACP_TEST');
 
 -- Always ensure that referrals have an associated user, even if that user is a placeholder for now.
 UPDATE referral
-SET referrer_username = 'UNKNOWN_USER'
-WHERE referrer_username IS NULL OR referrer_username = '';
+SET referrer_username = 'ACP_TEST'
+WHERE referrer_username IS NULL OR referrer_username = '' OR referrer_username = 'UNKNOWN_USER';
 
 
 -- Delete the old field.


### PR DESCRIPTION

## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

`UNKNOWN_USER` is currently 404ing when fetching from the Manage Users API and breaking a few pages in dev as we don't currently handle 404ing users properly in the UI. `ACP_TEST` is a real user in dev, so should hopefully fetch that user's details.

## Changes in this PR

Migrates `UNKNOWN_USER`'s referrals to the `ACP_TEST` user.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
