### PR TITLE
Add dependency update documentation to repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,17 @@ This is available in development at
 
 There's currently a slight issue with one of the environments, so you may need
 to refresh a couple of times before the OpenAPI documentation loads.
+
+## Dependency updates
+
+As with other MOJ projects, we use [Renovate](https://github.com/renovatebot/renovate) to automate dependency updates.
+
+This will open PRs for us to update any outdated packages. We'll want to ensure the build is passing on these and
+ideally smoke test after merging to dev to ensure all is still working as expected. There may be some that require
+manual intervention to get working with our build.
+
+### HMPPS Gradle Spring Boot package
+
+We may get reports of vulnerabilities in our dependencies through Trivy. Most of these can be resolved by updating
+the `uk.gov.justice.hmpps.gradle-spring-boot` package in `build.gradle.kts`, as the team managing that package have
+fixed them for us.


### PR DESCRIPTION
## Changes in this PR

Add dependency update documentation to repo to inform new devs that vulnerabilities are often taken care of for us by other teams, and of the Renovate process.


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
