### PR TITLE
Simplify `application.yml` and different environments

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-api/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-api/values.yaml
@@ -43,8 +43,8 @@ generic-service:
     rds-postgresql-instance-output:
       DB_HOST: "rds_instance_endpoint"
       DB_NAME: "database_name"
-      DATABASE_USERNAME: "database_username"
-      DATABASE_PASSWORD: "database_password"
+      SPRING_DATASOURCE_USERNAME: "database_username"
+      SPRING_DATASOURCE_PASSWORD: "database_password"
 
 generic-prometheus-alerts:
   targetApplication: hmpps-accredited-programmes-api

--- a/helm_deploy/hmpps-accredited-programmes-api/values.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-api/values.yaml
@@ -23,6 +23,7 @@ generic-service:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
     SENTRY_SAMPLE-RATE: 1
     SENTRY_TRACES-SAMPLE-RATE: 0.2
+    SPRING_DATASOURCE_URL: "jdbc:postgresql://${DB_HOST}/${DB_NAME}"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:
@@ -40,8 +41,8 @@ generic-service:
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_PRISON-REGISTER-API_CLIENT-ID: "SYSTEM_CLIENT_ID"
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_PRISON-REGISTER-API_CLIENT-SECRET: "SYSTEM_CLIENT_SECRET"
     rds-postgresql-instance-output:
-      DATABASE_ENDPOINT: "rds_instance_endpoint"
-      DATABASE_NAME: "database_name"
+      DB_HOST: "rds_instance_endpoint"
+      DB_NAME: "database_name"
       DATABASE_USERNAME: "database_username"
       DATABASE_PASSWORD: "database_password"
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,8 +1,3 @@
-oauth:
-  client:
-    id: hmpps-accredited-programmes-client-1
-    secret: clientsecret
-
 hmpps:
   auth:
     url: http://localhost:9090/auth

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,17 +1,5 @@
-hmpps:
-  auth:
-    url: http://localhost:9090/auth
-
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/postgres
     username: admin
     password: admin_password
-
-services:
-  prison-api:
-    base-url: http://localhost:9094
-  prisoner-search-api:
-    base-url: http://localhost:9095
-  prison-register-api:
-    base-url: http://localhost:9096

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,8 +56,6 @@ spring:
       ddl-auto: none
 
   datasource:
-    username: ${DATABASE_USERNAME}
-    password: ${DATABASE_PASSWORD}
     hikari:
       connectionTimeout: 1000
       validationTimeout: 500

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,7 +56,6 @@ spring:
       ddl-auto: none
 
   datasource:
-    url: jdbc:postgresql://${DATABASE_ENDPOINT}/${DATABASE_NAME}?sslmode=verify-full
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
     hikari:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,11 +101,15 @@ management:
 
 services:
   prison-api:
-    base-url: ${PRISON-API_BASE-URL}
+    base-url: http://localhost:9094
   prisoner-search-api:
-    base-url: ${PRISONER-SEARCH-API_BASE-URL}
+    base-url: http://localhost:9095
   prison-register-api:
-    base-url: ${PRISON-REGISTER-API_BASE-URL}
+    base-url: http://localhost:9096
+
+hmpps:
+  auth:
+    url: http://localhost:9090/auth
 
 log-client-credentials-jwt-info: false
 


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We had some issues setting up wiremock on the API side, which led to some confusion about how the different environments are configured, and led us to believe our setup wasn't as clear as it could be.

## Changes in this PR

- Moves local application config into base `application.yml` where possible.
- Removes duplicate setting of env vars where not needed, instead leveraging Spring's environment variable naming convention
- Renames some environment variables to be a bit clearer, in line with the Approved Premises API team's naming convention.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
