### PR TITLE
Add missing `SERVICES` prefix to env vars

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,9 +11,9 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth
-    PRISON-API_BASE-URL: https://prison-api-dev.prison.service.justice.gov.uk
-    PRISONER-SEARCH-API_BASE-URL: https://prisoner-search-dev.prison.service.justice.gov.uk
-    PRISON-REGISTER-API_BASE-URL: https://prison-register-dev.hmpps.service.justice.gov.uk
+    SERVICES_PRISON-API_BASE-URL: https://prison-api-dev.prison.service.justice.gov.uk
+    SERVICES_PRISONER-SEARCH-API_BASE-URL: https://prisoner-search-dev.prison.service.justice.gov.uk
+    SERVICES_PRISON-REGISTER-API_BASE-URL: https://prison-register-dev.hmpps.service.justice.gov.uk
     SENTRY_ENVIRONMENT: dev
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -9,9 +9,9 @@ generic-service:
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     HMPPS_AUTH_URL: https://sign-in-preprod.hmpps.service.justice.gov.uk/auth
-    PRISON-API_BASE-URL: https://api-preprod.prison.service.justice.gov.uk
-    PRISONER-SEARCH-API_BASE-URL: https://prisoner-search-preprod.prison.service.justice.gov.uk
-    PRISON-REGISTER-API_BASE-URL: https://prison-register-preprod.hmpps.service.justice.gov.uk
+    SERVICES_PRISON-API_BASE-URL: https://api-preprod.prison.service.justice.gov.uk
+    SERVICES_PRISONER-SEARCH-API_BASE-URL: https://prisoner-search-preprod.prison.service.justice.gov.uk
+    SERVICES_PRISON-REGISTER-API_BASE-URL: https://prison-register-preprod.hmpps.service.justice.gov.uk
     SENTRY_ENVIRONMENT: preprod
 
   allowlist:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -8,9 +8,9 @@ generic-service:
 
   env:
     HMPPS_AUTH_URL: https://sign-in.hmpps.service.justice.gov.uk/auth
-    PRISON-API_BASE-URL: https://api.prison.service.justice.gov.uk
-    PRISONER-SEARCH-API_BASE-URL: https://prisoner-search.prison.service.justice.gov.uk
-    PRISON-REGISTER-API_BASE-URL: https://prison-register.hmpps.service.justice.gov.uk
+    SERVICES_PRISON-API_BASE-URL: https://api.prison.service.justice.gov.uk
+    SERVICES_PRISONER-SEARCH-API_BASE-URL: https://prisoner-search.prison.service.justice.gov.uk
+    SERVICES_PRISON-REGISTER-API_BASE-URL: https://prison-register.hmpps.service.justice.gov.uk
     SENTRY_ENVIRONMENT: prod
 
   allowlist:


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

In https://github.com/ministryofjustice/hmpps-accredited-programmes-api/pull/220/commits/0a71b522742720a8fcae3b757ec0e753f88b2093, we simplified the environment variables, but forgot to update the variable names in the Helm deployment files. These need to match the values set in `application.yml` to successfully override them.

## Changes in this PR

Adds missing prefix to set values correctly for integrations.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
