### PR TITLE
Add Prisoner Search mocks & local Prison Register response when running via Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,16 +31,6 @@ services:
     ports:
       - '9094:8080'
 
-  prisoner-search:
-    image: wiremock/wiremock:2.35.0
-    networks:
-      - hmpps
-    container_name: prisoner-search
-    ports:
-      - "9095:8080"
-    volumes:
-      - ./prisoner-search-data:/home/wiremock
-
   prison-register-api:
     container_name: prison-register-api
     depends_on:
@@ -90,6 +80,16 @@ services:
       - POSTGRES_USER=admin
       - POSTGRES_PASSWORD=admin_password
 
+  wiremock:
+    image: wiremock/wiremock:2.35.0
+    networks:
+      - hmpps
+    container_name: wiremock
+    ports:
+      - "9095:8080"
+    volumes:
+      - ./wiremock:/home/wiremock
+
   hmpps-accredited-programmes-api:
     image: quay.io/hmpps/hmpps-accredited-programmes-api:latest
     container_name: hmpps-accredited-programmes-api
@@ -109,6 +109,7 @@ services:
     environment:
       - SPRING_PROFILES_ACTIVE=dev,local,seed
       - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
+      - SERVICES_PRISONER-SEARCH-API_BASE-URL=http://wiremock:8080
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgresql:5432/postgres
       - SPRING_DATASOURCE_USERNAME=admin
       - SPRING_DATASOURCE_PASSWORD=admin_password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,7 @@ services:
       - SPRING_PROFILES_ACTIVE=dev,local,seed
       - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth
       - SERVICES_PRISONER-SEARCH-API_BASE-URL=http://wiremock:8080
+      - SERVICES_PRISON-REGISTER-API_BASE-URL=http://prison-register-api:8080
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgresql:5432/postgres
       - SPRING_DATASOURCE_USERNAME=admin
       - SPRING_DATASOURCE_PASSWORD=admin_password

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/BaseHMPPSClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/BaseHMPPSClient.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client
 
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
@@ -49,6 +50,7 @@ abstract class BaseHMPPSClient(
 
       val result = request.retrieve().toEntity(String::class.java).block()!!
 
+      objectMapper.apply { registerModule((JavaTimeModule())) }
       val deserialized = objectMapper.readValue(result.body, typeReference)
 
       return ClientResult.Success(result.statusCode, deserialized)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -103,7 +103,7 @@ services:
   prison-api:
     base-url: http://localhost:9094
   prisoner-search-api:
-    base-url: http://localhost:9095
+    base-url: http://localhost:9095 # wiremock port
   prison-register-api:
     base-url: http://localhost:9096
 

--- a/wiremock/mappings/prisoner-search.json
+++ b/wiremock/mappings/prisoner-search.json
@@ -1,0 +1,431 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "urlPattern": "/prisoner-search/prisoner-numbers",
+        "method": "POST"
+      },
+      "response": {
+        "status": 200,
+        "jsonBody": [
+          {
+            "bookingId": "9332656800",
+            "firstName": "Savannah",
+            "indeterminateSentence": true,
+            "lastName": "Fritsch",
+            "prisonerNumber": "Y7RLN5A"
+          },
+          {
+            "bookingId": "7345105758",
+            "firstName": "Kallie",
+            "lastName": "Lakin",
+            "paroleEligibilityDate": "2038-03-08",
+            "prisonerNumber": "175AQ4D",
+            "tariffDate": "2025-03-04"
+          },
+          {
+            "bookingId": "8592169147",
+            "conditionalReleaseDate": "2026-11-06",
+            "firstName": "Jesus",
+            "indeterminateSentence": true,
+            "lastName": "Tromp",
+            "prisonerNumber": "TXWAMYX",
+            "tariffDate": "2026-09-06"
+          },
+          {
+            "bookingId": "1852862949",
+            "conditionalReleaseDate": "2032-02-05",
+            "firstName": "Hunter",
+            "lastName": "Schultz",
+            "prisonerNumber": "D7C2BPQ"
+          },
+          {
+            "bookingId": "6783951444",
+            "conditionalReleaseDate": "2032-04-04",
+            "firstName": "Marina",
+            "lastName": "Hermiston",
+            "prisonerNumber": "439P14J",
+            "tariffDate": "2034-06-14"
+          },
+          {
+            "bookingId": "7156408729",
+            "conditionalReleaseDate": "2033-06-16",
+            "firstName": "Sallie",
+            "lastName": "Frami",
+            "paroleEligibilityDate": "2034-10-15",
+            "prisonerNumber": "S8M1LGC",
+            "tariffDate": "2040-11-16"
+          },
+          {
+            "bookingId": "1918337781",
+            "firstName": "Reyna",
+            "lastName": "Zboncak",
+            "paroleEligibilityDate": "2025-08-30",
+            "prisonerNumber": "B9C83GE"
+          },
+          {
+            "bookingId": "4072445675",
+            "firstName": "Kallie",
+            "lastName": "Braun",
+            "paroleEligibilityDate": "2043-06-04",
+            "prisonerNumber": "VXKGG1D",
+            "tariffDate": "2033-02-16"
+          },
+          {
+            "bookingId": "8039579339",
+            "firstName": "Julia",
+            "indeterminateSentence": false,
+            "lastName": "Schinner",
+            "prisonerNumber": "1DULMVV",
+            "tariffDate": "2043-10-15"
+          },
+          {
+            "bookingId": "1878518002",
+            "conditionalReleaseDate": "2035-12-24",
+            "firstName": "Yvette",
+            "lastName": "Stark",
+            "paroleEligibilityDate": "2024-01-21",
+            "prisonerNumber": "135A22I",
+            "tariffDate": "2038-08-08"
+          },
+          {
+            "bookingId": "9981350711",
+            "conditionalReleaseDate": "2034-12-23",
+            "firstName": "Kavon",
+            "indeterminateSentence": true,
+            "lastName": "Labadie",
+            "prisonerNumber": "JVWN4Y8",
+            "tariffDate": "2024-01-10"
+          },
+          {
+            "bookingId": "5001303334",
+            "conditionalReleaseDate": "2042-10-25",
+            "firstName": "Ronaldo",
+            "indeterminateSentence": false,
+            "lastName": "Turner",
+            "prisonerNumber": "3CL85UT",
+            "tariffDate": "2036-08-10"
+          },
+          {
+            "bookingId": "9715401303",
+            "firstName": "Diego",
+            "lastName": "Wisozk",
+            "paroleEligibilityDate": "2029-02-10",
+            "prisonerNumber": "UZB7W3A",
+            "tariffDate": "2031-02-27"
+          },
+          {
+            "bookingId": "9296270712",
+            "conditionalReleaseDate": "2032-03-03",
+            "firstName": "Collin",
+            "lastName": "Ernser",
+            "paroleEligibilityDate": "2024-06-16",
+            "prisonerNumber": "ZM5KTFH"
+          },
+          {
+            "bookingId": "5855247541",
+            "conditionalReleaseDate": "2025-09-04",
+            "firstName": "Newton",
+            "lastName": "Howe",
+            "prisonerNumber": "P0N4050",
+            "tariffDate": "2028-11-01"
+          },
+          {
+            "bookingId": "6460732428",
+            "conditionalReleaseDate": "2030-11-09",
+            "firstName": "Corine",
+            "indeterminateSentence": true,
+            "lastName": "Cole",
+            "paroleEligibilityDate": "2037-07-03",
+            "prisonerNumber": "WMRXAKU",
+            "tariffDate": "2027-11-24"
+          },
+          {
+            "bookingId": "1710334594",
+            "conditionalReleaseDate": "2032-10-31",
+            "firstName": "Rodolfo",
+            "lastName": "Glover",
+            "paroleEligibilityDate": "2041-05-26",
+            "prisonerNumber": "XC1JMGC"
+          },
+          {
+            "bookingId": "0352068923",
+            "firstName": "Ethelyn",
+            "indeterminateSentence": false,
+            "lastName": "Rolfson",
+            "paroleEligibilityDate": "2040-01-01",
+            "prisonerNumber": "C5OR3SQ"
+          },
+          {
+            "bookingId": "0314789716",
+            "firstName": "Skylar",
+            "indeterminateSentence": false,
+            "lastName": "Miller",
+            "prisonerNumber": "XMHCORV"
+          },
+          {
+            "bookingId": "9848953220",
+            "conditionalReleaseDate": "2041-03-12",
+            "firstName": "Elza",
+            "lastName": "Blanda",
+            "prisonerNumber": "AQ6V7KH",
+            "tariffDate": "2036-07-22"
+          },
+          {
+            "bookingId": "7742578281",
+            "firstName": "Alvah",
+            "indeterminateSentence": false,
+            "lastName": "Langosh",
+            "paroleEligibilityDate": "2037-12-07",
+            "prisonerNumber": "27LD9LP",
+            "tariffDate": "2038-01-30"
+          },
+          {
+            "bookingId": "7179581646",
+            "conditionalReleaseDate": "2035-03-22",
+            "firstName": "Augustine",
+            "lastName": "Hauck",
+            "paroleEligibilityDate": "2025-11-30",
+            "prisonerNumber": "UJWXNSR",
+            "tariffDate": "2038-01-12"
+          },
+          {
+            "bookingId": "5818749286",
+            "firstName": "Evangeline",
+            "indeterminateSentence": false,
+            "lastName": "Crooks",
+            "prisonerNumber": "I2T0T14"
+          },
+          {
+            "bookingId": "7217090509",
+            "conditionalReleaseDate": "2037-10-14",
+            "firstName": "Oswald",
+            "indeterminateSentence": false,
+            "lastName": "Wolff",
+            "prisonerNumber": "CAECMFS",
+            "tariffDate": "2040-11-04"
+          },
+          {
+            "bookingId": "4382489101",
+            "conditionalReleaseDate": "2031-07-14",
+            "firstName": "Kyra",
+            "indeterminateSentence": true,
+            "lastName": "Kshlerin",
+            "paroleEligibilityDate": "2032-11-29",
+            "prisonerNumber": "N24RBH2",
+            "tariffDate": "2033-01-10"
+          },
+          {
+            "bookingId": "7577307753",
+            "conditionalReleaseDate": "2032-08-26",
+            "firstName": "Rosalia",
+            "indeterminateSentence": false,
+            "lastName": "Lehner",
+            "paroleEligibilityDate": "2042-06-15",
+            "prisonerNumber": "W8CHFHM",
+            "tariffDate": "2029-07-10"
+          },
+          {
+            "bookingId": "8768910577",
+            "conditionalReleaseDate": "2030-06-24",
+            "firstName": "Dusty",
+            "indeterminateSentence": true,
+            "lastName": "Von-Emard",
+            "prisonerNumber": "FFVPDZL",
+            "tariffDate": "2035-09-22"
+          },
+          {
+            "bookingId": "8777318021",
+            "conditionalReleaseDate": "2041-07-25",
+            "firstName": "Pansy",
+            "indeterminateSentence": true,
+            "lastName": "Rath",
+            "prisonerNumber": "7GZYCT7",
+            "tariffDate": "2028-02-01"
+          },
+          {
+            "bookingId": "5979359583",
+            "conditionalReleaseDate": "2034-06-22",
+            "firstName": "Donny",
+            "lastName": "Koch",
+            "prisonerNumber": "04P9F9E"
+          },
+          {
+            "bookingId": "8920427213",
+            "firstName": "Clementina",
+            "indeterminateSentence": false,
+            "lastName": "Bergstrom",
+            "prisonerNumber": "0T50F12"
+          },
+          {
+            "bookingId": "5320302280",
+            "firstName": "Ken",
+            "lastName": "Veum-Krajcik",
+            "prisonerNumber": "F0SRSJ8",
+            "tariffDate": "2025-07-24"
+          },
+          {
+            "bookingId": "9844726283",
+            "conditionalReleaseDate": "2036-04-02",
+            "firstName": "Odessa",
+            "lastName": "Kulas",
+            "prisonerNumber": "HF1WH1L"
+          },
+          {
+            "bookingId": "8400551035",
+            "firstName": "Ewald",
+            "indeterminateSentence": true,
+            "lastName": "Jakubowski-Strosin",
+            "paroleEligibilityDate": "2042-06-03",
+            "prisonerNumber": "T5BR1XV"
+          },
+          {
+            "bookingId": "4300812300",
+            "conditionalReleaseDate": "2033-03-04",
+            "firstName": "Carlee",
+            "indeterminateSentence": false,
+            "lastName": "Franey",
+            "prisonerNumber": "UY1N011"
+          },
+          {
+            "bookingId": "9304192554",
+            "conditionalReleaseDate": "2025-04-08",
+            "firstName": "Zetta",
+            "indeterminateSentence": true,
+            "lastName": "Champlin",
+            "paroleEligibilityDate": "2031-10-19",
+            "prisonerNumber": "AFZXD70",
+            "tariffDate": "2032-04-12"
+          },
+          {
+            "bookingId": "8313939694",
+            "conditionalReleaseDate": "2033-02-16",
+            "firstName": "Lesley",
+            "indeterminateSentence": true,
+            "lastName": "Kohler",
+            "prisonerNumber": "JTWZW2E"
+          },
+          {
+            "bookingId": "6260286581",
+            "conditionalReleaseDate": "2025-07-12",
+            "firstName": "Tyshawn",
+            "indeterminateSentence": false,
+            "lastName": "Kassulke",
+            "prisonerNumber": "ZRRCHJO",
+            "tariffDate": "2037-08-27"
+          },
+          {
+            "bookingId": "9260795548",
+            "firstName": "Syble",
+            "lastName": "Weber-Hackett",
+            "prisonerNumber": "USULN51"
+          },
+          {
+            "bookingId": "1545960492",
+            "firstName": "Lyric",
+            "indeterminateSentence": false,
+            "lastName": "Dach",
+            "prisonerNumber": "D124Z3L",
+            "tariffDate": "2024-11-03"
+          },
+          {
+            "bookingId": "9623195418",
+            "conditionalReleaseDate": "2043-09-09",
+            "firstName": "Ford",
+            "indeterminateSentence": true,
+            "lastName": "Johnston",
+            "paroleEligibilityDate": "2027-05-22",
+            "prisonerNumber": "4C59RIL"
+          },
+          {
+            "bookingId": "9793546830",
+            "firstName": "Garland",
+            "indeterminateSentence": true,
+            "lastName": "Glover",
+            "prisonerNumber": "GJNYGD6"
+          },
+          {
+            "bookingId": "5665464482",
+            "firstName": "Aylin",
+            "indeterminateSentence": false,
+            "lastName": "Roberts",
+            "paroleEligibilityDate": "2029-12-08",
+            "prisonerNumber": "ENMP9SL"
+          },
+          {
+            "bookingId": "7164710187",
+            "conditionalReleaseDate": "2030-08-06",
+            "firstName": "Burnice",
+            "indeterminateSentence": false,
+            "lastName": "Dickens",
+            "prisonerNumber": "PELXHKC"
+          },
+          {
+            "bookingId": "1492245123",
+            "conditionalReleaseDate": "2034-10-19",
+            "firstName": "Jacquelyn",
+            "indeterminateSentence": false,
+            "lastName": "Blanda",
+            "paroleEligibilityDate": "2026-04-21",
+            "prisonerNumber": "HR1EQI2",
+            "tariffDate": "2033-03-29"
+          },
+          {
+            "bookingId": "8858918087",
+            "conditionalReleaseDate": "2036-09-02",
+            "firstName": "Breanne",
+            "indeterminateSentence": true,
+            "lastName": "Murphy-O'Keefe",
+            "prisonerNumber": "YZ6RBNN",
+            "tariffDate": "2033-04-06"
+          },
+          {
+            "bookingId": "1647859489",
+            "conditionalReleaseDate": "2038-08-22",
+            "firstName": "Leland",
+            "lastName": "Romaguera",
+            "prisonerNumber": "A0O6ENK",
+            "tariffDate": "2041-12-04"
+          },
+          {
+            "bookingId": "1448608882",
+            "conditionalReleaseDate": "2041-07-11",
+            "firstName": "Nelda",
+            "indeterminateSentence": true,
+            "lastName": "Walker",
+            "prisonerNumber": "4CUT1G4",
+            "tariffDate": "2037-06-09"
+          },
+          {
+            "bookingId": "6551340716",
+            "firstName": "Ruby",
+            "lastName": "Bruen",
+            "paroleEligibilityDate": "2032-02-10",
+            "prisonerNumber": "ZHL6G3M"
+          },
+          {
+            "bookingId": "1630148371",
+            "firstName": "Wilhelmine",
+            "indeterminateSentence": false,
+            "lastName": "Wyman",
+            "paroleEligibilityDate": "2033-04-05",
+            "prisonerNumber": "64CR2JR",
+            "tariffDate": "2039-08-16"
+          },
+          {
+            "bookingId": "6213169552",
+            "conditionalReleaseDate": "2032-05-19",
+            "firstName": "Leon",
+            "indeterminateSentence": false,
+            "lastName": "Spencer",
+            "prisonerNumber": "YG0X5TO",
+            "tariffDate": "2031-05-30"
+          }
+        ],
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

When running the API via a Docker image, e.g. in the UI codebase, we weren't providing any responses for the values obtained from the Prisoner Search or Prison Register.

## Changes in this PR

- Sets up mocks for the Prisoner Search API when running locally, matching the people in prison expected in the UI.
- Configures Docker container to use these mocks and the locally-running Prison Register when running the service with docker compose.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
