### PR TITLE
Add missing pact states

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
@@ -80,6 +80,15 @@ class PactContractTest {
   @State("Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists")
   fun `ensure referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists`() {}
 
+  @State("Referral(s) exist for the logged in user")
+  fun `ensure referrals exist for the logged in user`() {
+    // TODO: implement this once we've moved away from re-using test setup in `R__test_data.sql`
+    // TODO: as this can't cope with the previously-created referral having a `null` `submittedOn` instead of a string.
+  }
+
+  @State("Referral(s) exist for logged in user with status REFERRAL_SUBMITTED")
+  fun `ensure referrals exist for logged in user with status REFERRAL_SUBMITTED`() {}
+
   @State("Referral(s) exist for organisation BWN")
   fun `ensure referrals exist for organisation BWN`() {}
 


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

The `Referral(s) exist for the logged in user` test is currently failing due to our re-use of data between tests, which we urgently need to fix:

In `R__test_data.sql`, we create one Referral for `TEST_REFERRER_USER_1`. This is updated in tests to have a non-null `submittedOn` value. In another test, we create a new referral, which then has a null `submittedOn` value.

Pact [can't handle](https://github.com/pact-foundation/pact-js/issues/393) these two referrals having different types of their `submittedOn` values (specifically one being `null` and one a `string`), so the expectation fails.

## Changes in this PR

Adds missing Pact states, even if this won't fix Pact completely at this moment in time.

Once we refactor our Pact tests to set up and tear down data in between tests, we'll be able to get the failing test passing, and as we can't override the username here due to the `@TestTemplate` config being shared across tests with the same referrer username. For this reason, we're going to disable that individual assertion on the UI side for now, but I've left this marked as `TODO` to remind us to add this assertion and re-enable it on the UI side.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
