### PR TITLE
Stub Prisoner Search with Wiremock in Pact tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
@@ -41,9 +41,30 @@ val PRISONERS = mapOf<String?, List<Prisoner>>(
 )
 const val PRISON_ID_1 = "1"
 const val PRISON_ID_2 = "2"
-const val PRISON_NUMBER_1 = "001"
-const val PRISON_NUMBER_2 = "002"
+const val PRISON_NUMBER_1 = "C3456CC"
+const val PRISON_NUMBER_2 = "D3456DD"
 const val PRISON_NAME_1 = "PRISON_ONE"
 const val PRISON_NAME_2 = "PRISON_TWO"
-val PRISONER_1 = Prisoner(prisonerNumber = PRISON_NUMBER_1, firstName = "John", lastName = "Doe")
-val PRISONER_2 = Prisoner(prisonerNumber = PRISON_NUMBER_2, firstName = "Ella", lastName = "Smith")
+
+val PRISONER_1 = Prisoner(
+  prisonerNumber = PRISON_NUMBER_1,
+  bookingId = BOOKING_ID,
+  firstName = PRISONER_FIRST_NAME,
+  lastName = PRISONER_LAST_NAME,
+  nonDtoReleaseDateType = NON_DTO_RELEASE_DATE_TYPE,
+  conditionalReleaseDate = CONDITIONAL_RELEASE_DATE,
+  tariffDate = TARIFF_EXPIRY_DATE,
+  paroleEligibilityDate = PAROLE_ELIGIBILITY_DATE,
+  indeterminateSentence = INDETERMINATE_SENTENCE,
+)
+val PRISONER_2 = Prisoner(
+  prisonerNumber = PRISON_NUMBER_2,
+  bookingId = BOOKING_ID,
+  firstName = "Ella",
+  lastName = "Smith",
+  nonDtoReleaseDateType = NON_DTO_RELEASE_DATE_TYPE,
+  conditionalReleaseDate = CONDITIONAL_RELEASE_DATE,
+  tariffDate = TARIFF_EXPIRY_DATE,
+  paroleEligibilityDate = PAROLE_ELIGIBILITY_DATE,
+  indeterminateSentence = INDETERMINATE_SENTENCE,
+)


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Because we weren't stubbing the Prisoner Search here, we were getting back `null` values for all Prisoners returned. Pact was failing due to the consumer tests expecting these to be strings.

## Changes in this PR

Provides a mocked response for the Prisoner Search endpoint in Pact tests to ensure we're always fetching realistic people in prison.

This also fixes some test constants, using Prison Numbers that match those found in the `test_data.sql` file. These are a bit messy at the moment and need tidying up, but that can come in a separate PR.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
