### PR TITLE
Make `prisonNumber`, `firstName` and `lastName` fields required

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonerSearchApi/model/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonerSearchApi/model/Prisoner.kt
@@ -5,10 +5,10 @@ import java.time.LocalDate
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class Prisoner(
-  var prisonerNumber: String? = null,
+  var prisonerNumber: String,
   var bookingId: String? = null,
-  var firstName: String? = null,
-  var lastName: String? = null,
+  var firstName: String,
+  var lastName: String,
   var indeterminateSentence: Boolean? = null,
   var nonDtoReleaseDateType: String? = null,
   var conditionalReleaseDate: LocalDate? = null,

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1233,6 +1233,9 @@ components:
         lastName:
           type: string
           description: Last name of the person
+      required:
+        - firstName
+        - lastName
 
     Sentence:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisoner
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ORGANISATION_ID_MDI
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_1
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISON_NUMBER_1
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseString
@@ -187,7 +188,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     val offeringId = getFirstOfferingIdForCourse(courseId)
     val referralCreated = createReferral(offeringId)
     val createdReferral = getReferralById(referralCreated.referralId)
-    val prisoners = listOf(Prisoner(firstName = "John"))
+    val prisoners = listOf(PRISONER_1)
     val prisons = listOf(PrisonDetails(prisonId = ORGANISATION_ID_MDI, prisonName = PRISON_NAME))
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
     mockPrisonerSearchResponse(prisoners)
@@ -318,7 +319,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Retrieving a list of referrals for an organisation with no referrals should return 200 with empty body`() {
     val randomOrganisationId = randomUppercaseString(3)
-    val prisoners = listOf(Prisoner(firstName = "John"))
+    val prisoners = listOf(PRISONER_1)
     val prisons = listOf(PrisonDetails(prisonId = ORGANISATION_ID_MDI, prisonName = PRISON_NAME))
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
     mockPrisonerSearchResponse(prisoners)


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

We fetch names of people in prison from the Prisoner Search, which, according to the [Open API schema](https://prisoner-search-dev.prison.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/Prisoner) are required, so wouldn't be `null`.

## Changes in this PR

Make `prisonNumber`, `firstName` and `lastName` fields required on a `ReferralSummary`.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
