### PR TITLE
Update Java version for Intellij usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ courses.
 To run from IntelliJ, first start `hmpps-auth` and the `postgresql` database in
 Docker as above.
 
-You may need to manually install the Java 19 SDK to run the application. We've
-used `temurin-19` for this in most developer environments.
+You may need to manually install the Java 21 SDK to run the application. We've
+used `temurin-21` for this in most developer environments.
 
 To set this, in the "Project Structure" window (`File -> Project Structure`),
-expand the SDK select, and if the version you need (e.g. `temurin-19`) isn't
+expand the SDK select, and if the version you need (e.g. `temurin-21`) isn't
 available, click `Add SDK -> Download JDK...`, then search for it and download
 it.
 


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

134be24 updated the project to use Java 21, but the README section that describes how to install and select the Java version via IntelliJ IDEA still refers to Java 19

## Changes in this PR

- Update README to reflect Java update re: IntelliJ usage (#219)

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
