### PR TITLE
Add instructions for testing against local Pact contracts

### DIFF
--- a/doc/how-to/test-pact-locally.md
+++ b/doc/how-to/test-pact-locally.md
@@ -1,0 +1,33 @@
+# Running Pact tests locally
+
+## Why would I need to do this?
+
+We use Pact for testing the interactions between our UI and API codebases.
+
+When running the Pact tests locally, the `@PactBroker` annotation in `/test/.../pact/PactContractTest.kt` fetches the
+most recently-published Pact contract from
+the [Pact Broker](https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk/), essentially running the
+API's tests against the version of the UI running on Dev.
+
+There are times when you may want to run the tests against a local development version of the UI, e.g. when debugging or
+checking the stability of our Pact tests which, until recently, have provided string or null values for optional API
+fields,
+which [Pact struggles to deal with](https://docs.pact.io/faq#why-is-there-no-support-for-specifying-optional-attributes).
+
+## How to run Pact tests against a local JSON file
+
+When the UI runs its client tests, it generates a JSON file in the UI
+codebase: `pact/pacts/Accredited Programmes UI-Accredited Programmes API.json`, containing a specification of all the
+endpoints the UI expects to consume, and the shape of the data that comes back from those endpoints.
+
+To run your local API tests against a version of this JSON file:
+
+1. In the UI codebase, generate the JSON file by running npm run test:unit (you may need to manually delete your local
+   pact/pacts/Accredited Programmes UI-Accredited Programmes API.json.
+2. Copy the newly-generated JSON file from UI
+   codebase (`pact/pacts/Accredited Programmes UI-Accredited Programmes API.json` into API codebase, under a `pact/`
+   folder in root directory.
+3. In `test/.../pact/PactContractTest.kt` , change the `@PactBroker` annotation (which instructs tests to read from
+   remote pact broker) to `@PactFolder("pact")` (you'll need to update import
+   to `import au.com.dius.pact.provider.junitsupport.loader.PactFolder` for this)
+4. Run the `PactContractTest.kt` tests and see output.


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

Pact contracts are published to the [Pact Broker](https://pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk/) on successful dev deployments. It's sometimes useful to be able to test against a local version of the contract, rather than having to push code to the dev environment and wait for the build to run every time.

## Changes in this PR

Adds a `how-to` doc for running API Pact tests against a local copy of the UI's JSON specification, rather than the version published to the Pact Broker.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
