### PR TITLE
[1085] secure all endpoints with role ACCREDITED_PROGRAMMES_API

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/config/SecurityConfiguration.kt
@@ -40,7 +40,8 @@ class SecurityConfiguration(
           "/api.yml",
           "/info",
         ).permitAll()
-        .anyRequest().authenticated()
+        .anyRequest()
+        .hasRole("ACCREDITED_PROGRAMMES_API")
     }
     .anonymous { it.disable() }
     .oauth2ResourceServer { resourceServer ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/JwtAuthHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/JwtAuthHelper.kt
@@ -61,10 +61,13 @@ class JwtAuthHelper {
 
   fun bearerToken(): String {
     val auth = SecurityContextHolder.getContext().authentication
+    val authorities = auth?.authorities?.map { it.authority }?.let {
+      listOf("ROLE_ACCREDITED_PROGRAMMES_API") + it
+    } ?: listOf("ROLE_ACCREDITED_PROGRAMMES_API")
 
     val claims = mutableMapOf<String, Any>().apply {
       put("user_name", auth?.name ?: CLIENT_USERNAME)
-      put("authorities", auth?.authorities?.map { it.authority } ?: listOf<String>())
+      put("authorities", authorities)
       put("scope", listOf<String>())
       put("client_id", "hmpps-accredited-programmes-ui")
     }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->

https://trello.com/c/AGDYXPvN/1085-add-role-guard-to-all-endpoints-on-api-m

<!-- Do you need to add any environment variables? -->

<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR
Adding role ROLE_ACCREDITED_PROGRAMMES_API to secure all our endpoints

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
