### PR TITLE
Adding audience to course entity and setting audience value from audi…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
@@ -51,6 +51,7 @@ data class CourseEntity(
     inverseJoinColumns = [JoinColumn(name = "audience_id")],
   )
   var audiences: MutableSet<AudienceEntity> = mutableSetOf(),
+  var audience: String,
   var withdrawn: Boolean = false,
 ) {
   fun addOffering(offering: OfferingEntity) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/RecordTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/RecordTransformers.kt
@@ -22,6 +22,7 @@ fun CourseEntity.toApi(): Course = Course(
   alternateName = alternateName,
   coursePrerequisites = prerequisites.map(PrerequisiteEntity::toApi),
   audiences = audiences.map(AudienceEntity::toApi),
+  audience = audience,
   referable = referable,
 )
 
@@ -31,7 +32,7 @@ fun CourseEntity.toCourseRecord(): CourseRecord = CourseRecord(
   alternateName = alternateName,
   referable = referable,
   identifier = identifier,
-  audience = audiences.joinToString { it.value },
+  audience = audience,
 )
 
 fun PrerequisiteEntity.toApi(): CoursePrerequisite = CoursePrerequisite(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
@@ -63,6 +63,7 @@ constructor(
           alternateName = update.alternateName,
           audiences = audienceStrings(update.audience).mapNotNull { audienceName -> allAudiences[audienceName] }
             .toMutableSet(),
+          audience = update.audience,
           referable = update.referable,
         )
       }

--- a/src/main/resources/db/migration/V27__add_audience_to_course_table.sql
+++ b/src/main/resources/db/migration/V27__add_audience_to_course_table.sql
@@ -1,0 +1,12 @@
+ALTER TABLE course
+    ADD COLUMN audience TEXT;
+
+
+UPDATE course c
+SET audience = (
+    SELECT a.audience_value
+    FROM audience a
+             JOIN course_audience ca ON a.audience_id = ca.audience_id
+    WHERE ca.course_id = c.course_id
+    LIMIT 1
+);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1055,9 +1055,13 @@ components:
           items:
             $ref: '#/components/schemas/CoursePrerequisite'
         audiences:
+          deprecated: true
           type: array
           items:
             $ref: '#/components/schemas/CourseAudience'
+        audience:
+          type: string
+          example: 'Gang offence'
         referable:
           type: boolean
           default: true
@@ -1066,6 +1070,7 @@ components:
         - name
         - coursePrerequisites
         - audiences
+        - audience
         - referable
 
     CourseRecord:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/PersistenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/PersistenceHelper.kt
@@ -31,14 +31,15 @@ class PersistenceHelper {
       .executeUpdate()
   }
 
-  fun createCourse(courseId: UUID, identifier: String, name: String, description: String, altName: String, referable: Boolean) {
-    entityManager.createNativeQuery("INSERT INTO course (course_id, identifier, name, description, alternate_name, referable) VALUES (:id, :identifier, :name, :description, :altName, :referable)")
+  fun createCourse(courseId: UUID, identifier: String, name: String, description: String, altName: String, referable: Boolean, audience: String = "Gang offence") {
+    entityManager.createNativeQuery("INSERT INTO course (course_id, identifier, name, description, alternate_name, referable, audience) VALUES (:id, :identifier, :name, :description, :altName, :referable, :audience)")
       .setParameter("id", courseId)
       .setParameter("identifier", identifier)
       .setParameter("name", name)
       .setParameter("description", description)
       .setParameter("altName", altName)
       .setParameter("referable", referable)
+      .setParameter("audience", audience)
       .executeUpdate()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -46,13 +46,13 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     persistenceHelper.clearAllTableContent()
 
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true, "General offence")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
 
-    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC", true)
-    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC", false)
+    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC", true, "General offence")
+    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC", false, "General offence")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseEntityFactory.kt
@@ -23,6 +23,7 @@ class CourseEntityFactory : Factory<CourseEntity> {
   private var prerequisites: Yielded<MutableSet<PrerequisiteEntity>> = { mutableSetOf() }
   private var offerings: Yielded<MutableSet<OfferingEntity>> = { mutableSetOf() }
   private var audiences: Yielded<MutableSet<AudienceEntity>> = { mutableSetOf() }
+  private var audience: Yielded<String> = { randomUppercaseString() }
   private var withdrawn: Yielded<Boolean> = { false }
 
   fun withId(id: UUID?) = apply {
@@ -71,6 +72,7 @@ class CourseEntityFactory : Factory<CourseEntity> {
     prerequisites = this.prerequisites(),
     offerings = this.offerings(),
     audiences = this.audiences(),
+    audience = this.audience(),
     withdrawn = this.withdrawn(),
   )
 }


### PR DESCRIPTION
…ence entity

## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/omP71TsY/799-add-a-new-audience-field-to-a-course-m
<!-- Do you need to add any environment variables? -->

<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

* Add audience field to course
* Update audience field in course with value from audience
* Its always been a one to one mapping between course and audience. So rather than have them as separate tables and link them, we have gone with this approach

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
