### PR TITLE
#1163-1 Add referable field to Offering

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
@@ -31,6 +31,7 @@ data class CourseEntity(
   var identifier: String,
   var description: String? = null,
   var alternateName: String? = null,
+  @Deprecated("Referrals are now made to specific offerings of a course, not the course itself")
   var referable: Boolean = true,
 
   @ElementCollection(fetch = FetchType.EAGER)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OfferingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OfferingEntity.kt
@@ -22,6 +22,7 @@ data class OfferingEntity(
   var contactEmail: String,
   var secondaryContactEmail: String? = null,
   var withdrawn: Boolean = false,
+  var referable: Boolean = true,
 ) {
   @ManyToOne(fetch = FetchType.EAGER, optional = false)
   @JoinColumn(name = "course_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/CourseUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/CourseUpdate.kt
@@ -6,5 +6,6 @@ data class CourseUpdate(
   val identifier: String,
   val audience: String,
   val alternateName: String? = null,
+  @Deprecated("Referrals are now made to specific offerings of a course, not the course itself")
   val referable: Boolean = true,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/OfferingUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/OfferingUpdate.kt
@@ -5,4 +5,5 @@ data class OfferingUpdate(
   val identifier: String,
   val contactEmail: String? = null,
   val secondaryContactEmail: String? = null,
+  val referable: Boolean = true,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/RecordTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/RecordTransformers.kt
@@ -45,6 +45,7 @@ fun OfferingEntity.toApi(): CourseOffering = CourseOffering(
   organisationId = organisationId,
   contactEmail = contactEmail,
   secondaryContactEmail = secondaryContactEmail,
+  referable = referable,
 )
 
 fun OfferingEntity.toOfferingRecord() = OfferingRecord(
@@ -53,6 +54,7 @@ fun OfferingEntity.toOfferingRecord() = OfferingRecord(
   prisonId = organisationId,
   contactEmail = contactEmail,
   secondaryContactEmail = secondaryContactEmail,
+  referable = referable,
 )
 
 fun AudienceEntity.toApi(): CourseAudience = CourseAudience(
@@ -75,6 +77,7 @@ fun OfferingRecord.toDomain(): OfferingUpdate = OfferingUpdate(
   contactEmail = contactEmail?.trim(),
   // The controller treats an absent value as an empty string. The Domain expects an absent value to be null.
   secondaryContactEmail = secondaryContactEmail?.let { it.trim().ifEmpty { null } },
+  referable = referable,
 )
 
 fun PrerequisiteRecord.toDomain(): NewPrerequisite = NewPrerequisite(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
@@ -171,6 +171,7 @@ constructor(
         organisationId = it,
         contactEmail = update?.contactEmail ?: "",
         secondaryContactEmail = update?.secondaryContactEmail,
+        referable = update?.referable ?: true,
       )
 
       course.addOffering(offeringToAdd)
@@ -183,6 +184,7 @@ constructor(
         withdrawn = false
         contactEmail = update?.contactEmail ?: ""
         secondaryContactEmail = update?.secondaryContactEmail
+        referable = update?.referable ?: true
       }
     }
 

--- a/src/main/resources/db/migration/V28__add-referable-to-offering.sql
+++ b/src/main/resources/db/migration/V28__add-referable-to-offering.sql
@@ -1,0 +1,9 @@
+ALTER TABLE offering
+    ADD COLUMN referable BOOLEAN NOT NULL DEFAULT true;
+
+UPDATE offering
+SET referable = (
+    SELECT c.referable
+    FROM course c
+    WHERE c.course_id = offering.course_id
+);

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1065,6 +1065,7 @@ components:
         referable:
           type: boolean
           default: true
+          deprecated: true
       required:
         - id
         - name
@@ -1092,6 +1093,7 @@ components:
         referable:
           type: boolean
           default: true
+          deprecated: true
       required:
         - name
         - identifier
@@ -1163,10 +1165,14 @@ components:
           format: email
           example: "ap-admin-2@digital.justice.gov.uk"
           description: "An optional secondary email address of a contact for this offering."
+        referable:
+          type: boolean
+          default: true
       required:
         - id
         - organisationId
         - contactEmail
+        - referable
 
     OfferingRecord:
       type: object
@@ -1196,10 +1202,14 @@ components:
           type: string
           example: "MDI"
           description: "The prison id for the prison associated with this Offering. This is usually three capital letters."
+        referable:
+          type: boolean
+          default: true
       required:
         - course
         - prisonId
         - identifier
+        - referable
 
     CourseAudience:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/CsvGenerators.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/CsvGenerators.kt
@@ -7,7 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Prere
 
 const val COURSES_PREFIX = "name,identifier,description,audience,referable,alternateName,comments\n"
 const val PREREQUISITES_PREFIX = "name,description,course,identifier,comments,,,,\n"
-const val OFFERINGS_PREFIX = "course,identifier,organisation,contact email,secondary contact email,prisonId\n"
+const val OFFERINGS_PREFIX = "course,identifier,organisation,contact email,secondary contact email,prisonId,referable\n"
 
 fun generateCourseRecords(count: Int): List<CourseRecord> {
   return (1..count).map {
@@ -44,6 +44,7 @@ fun generateOfferingRecords(count: Int): List<OfferingRecord> {
       contactEmail = "email-$it@example.com",
       secondaryContactEmail = "secondaryEmail-$it@example.com",
       prisonId = "PrisonID-$it",
+      referable = true,
     )
   }
 }
@@ -76,7 +77,7 @@ fun List<OfferingRecord>.toOfferingCsv(): String = if (isEmpty()) {
   joinToString(
     prefix = OFFERINGS_PREFIX,
     separator = "\n",
-    transform = { """"${it.course}","${it.identifier}","${it.organisation}","${it.contactEmail}",${it.secondaryContactEmail?.let { secondaryContactEmail -> "\"$secondaryContactEmail\"" } ?: ""},${it.prisonId}""" },
+    transform = { """"${it.course}","${it.identifier}","${it.organisation}","${it.contactEmail}",${it.secondaryContactEmail?.let { secondaryContactEmail -> "\"$secondaryContactEmail\"" } ?: ""},${it.prisonId},${it.referable}""" },
     postfix = "\n",
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/OfferingEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/OfferingEntityFactory.kt
@@ -16,6 +16,7 @@ class OfferingEntityFactory : Factory<OfferingEntity> {
   private var contactEmail: Yielded<String> = { randomEmailAddress() }
   private var secondaryContactEmail: Yielded<String?> = { null }
   private var withdrawn: Yielded<Boolean> = { false }
+  private var referable: Yielded<Boolean> = { true }
 
   fun withId(id: UUID?) = apply {
     this.id = { id }
@@ -43,6 +44,7 @@ class OfferingEntityFactory : Factory<OfferingEntity> {
     contactEmail = this.contactEmail(),
     secondaryContactEmail = this.secondaryContactEmail(),
     withdrawn = this.withdrawn(),
+    referable = this.referable(),
   )
 }
 
@@ -51,6 +53,7 @@ class OfferingUpdateFactory : Factory<OfferingUpdate> {
   private var identifier: Yielded<String> = { randomUppercaseString() }
   private var contactEmail: Yielded<String?> = { null }
   private var secondaryContactEmail: Yielded<String?> = { null }
+  private var referable: Yielded<Boolean> = { true }
 
   fun withPrisonId(prisonId: String) = apply {
     this.prisonId = { prisonId }
@@ -69,5 +72,6 @@ class OfferingUpdateFactory : Factory<OfferingUpdate> {
     identifier = this.identifier(),
     contactEmail = this.contactEmail(),
     secondaryContactEmail = this.secondaryContactEmail(),
+    referable = this.referable(),
   )
 }


### PR DESCRIPTION
## Context

> [see #1163 on the Accredited Programmes Trello board.](https://trello.com/c/86tT1mSV/1163-move-referable-property-from-course-to-offering-m)

This is the first of three PRs regarding the migration of the `referable` field from Course to Offering:
1. (this PR) add the new field to Offering and migrate any information from the old Course field to the new Offering field
2. (UI) read all referable information from the new Offering field
3. (API) retire Course.referable

## Changes in this PR

Added referable field to Offering entity, updating all CSV, model and domain classes and functionality surrounding it.
Tests remain untouched, showing their integrity has been much improved after doing all those previous refactoring PRs!

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
