### PR TITLE
Deprecate audiences and add audience in referral summary

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralSummaryBuilderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralSummaryBuilderService.kt
@@ -27,6 +27,7 @@ class ReferralSummaryBuilderService {
           id = id,
           referrerUsername = firstProjection.referrerUsername,
           courseName = firstProjection.courseName,
+          audience = firstProjection.audience,
           audiences = projections.map { it.audience }.distinct(),
           status = firstProjection.status.toApi(),
           submittedOn = firstProjection.submittedOn?.toString(),

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1468,9 +1468,13 @@ components:
         courseName:
           type: string
         audiences:
+          deprecated: true
           type: array
           items:
             type: string
+        audience:
+          type: string
+          example: 'Gang offence'
         status:
           $ref: "#/components/schemas/ReferralStatus"
         submittedOn:
@@ -1497,6 +1501,7 @@ components:
         - referrerUsername
         - courseName
         - audiences
+        - audience
         - status
         - prisonNumber
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -220,6 +220,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
         ReferralSummary(
           id = createdReferral.id,
           courseName = getCourseById(courseId).name,
+          audience = getCourseById(courseId).audience,
           audiences = getCourseById(courseId).audiences.map { it.value }.sorted(),
           status = createdReferral.status,
           submittedOn = createdReferral.submittedOn,
@@ -230,6 +231,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
         actualSummary.id shouldBe expectedSummary.id
         actualSummary.courseName shouldBe expectedSummary.courseName
         actualSummary.audiences shouldContainExactlyInAnyOrder expectedSummary.audiences
+        actualSummary.audience shouldBe expectedSummary.audience
         actualSummary.status shouldBe expectedSummary.status
         actualSummary.submittedOn shouldBe expectedSummary.submittedOn
         actualSummary.prisonNumber shouldBe expectedSummary.prisonNumber
@@ -299,6 +301,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       id = firstCreatedReferral.id,
       courseName = getCourseById(courseId).name,
       audiences = getCourseById(courseId).audiences.map { it.value }.sorted(),
+      audience = getCourseById(courseId).audience,
       status = firstCreatedReferral.status,
       submittedOn = firstCreatedReferral.submittedOn,
       prisonNumber = firstCreatedReferral.prisonNumber,
@@ -309,6 +312,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       id = secondCreatedReferral.id,
       courseName = getCourseById(courseId).name,
       audiences = getCourseById(courseId).audiences.map { it.value }.sorted(),
+      audience = getCourseById(courseId).audience,
       status = secondCreatedReferral.status,
       submittedOn = secondCreatedReferral.submittedOn,
       prisonNumber = secondCreatedReferral.prisonNumber,
@@ -323,6 +327,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
 
       actualSummary.id shouldBe expectedSummary.id
       actualSummary.courseName shouldBe expectedSummary.courseName
+      actualSummary.audience shouldBe expectedSummary.audience
       actualSummary.audiences shouldContainExactlyInAnyOrder expectedSummary.audiences
       actualSummary.status shouldBe expectedSummary.status
       actualSummary.submittedOn shouldBe expectedSummary.submittedOn

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -73,6 +73,7 @@ constructor(
       id = UUID.randomUUID(),
       courseName = "Course for referralSummary1",
       audiences = listOf("Audience 1", "Audience 2"),
+      audience = "Audience 1",
       status = ReferralStatus.referralStarted,
       prisonNumber = PRISON_NUMBER_1,
       referrerUsername = CLIENT_USERNAME,
@@ -82,6 +83,7 @@ constructor(
       id = UUID.randomUUID(),
       courseName = "Course for referralSummary2",
       audiences = listOf("Audience 2", "Audience 3"),
+      audience = "Audience 2",
       status = ReferralStatus.referralSubmitted,
       submittedOn = LocalDateTime.MIN.toString(),
       prisonNumber = PRISON_NUMBER_1,
@@ -92,6 +94,7 @@ constructor(
       id = UUID.randomUUID(),
       courseName = "Course for referralSummary3",
       audiences = listOf("Audience 3", "Audience 4"),
+      audience = "Audience 3",
       status = ReferralStatus.referralSubmitted,
       submittedOn = LocalDateTime.MIN.toString(),
       prisonNumber = PRISON_NUMBER_1,
@@ -430,6 +433,7 @@ constructor(
       id = firstReferralId,
       courseName = "Course for referralSummary1",
       audiences = audiencesForFirstReferral,
+      audience = "Audience 1",
       status = ReferralStatus.referralStarted,
       prisonNumber = PRISON_NUMBER_1,
       referrerUsername = CLIENT_USERNAME,
@@ -439,6 +443,7 @@ constructor(
       id = secondReferralId,
       courseName = "Course for referralSummary2",
       audiences = audiencesForSecondReferral,
+      audience = "Audience 2",
       status = ReferralStatus.referralSubmitted,
       submittedOn = LocalDateTime.MIN.toString(),
       prisonNumber = PRISON_NUMBER_1,
@@ -472,6 +477,7 @@ constructor(
     firstReferral?.let { referral ->
       referral.courseName shouldBe "Course for referralSummary1"
       referral.audiences shouldContainExactlyInAnyOrder audiencesForFirstReferral
+      referral.audience shouldBe "Audience 1"
       referral.status shouldBe ReferralStatus.referralStarted
       referral.prisonNumber shouldBe PRISON_NUMBER_1
       referral.referrerUsername shouldBe CLIENT_USERNAME
@@ -482,6 +488,7 @@ constructor(
     secondReferral?.let { referral ->
       referral.courseName shouldBe "Course for referralSummary2"
       referral.audiences shouldContainExactlyInAnyOrder audiencesForSecondReferral
+      referral.audience shouldBe "Audience 2"
       referral.status shouldBe ReferralStatus.referralSubmitted
       referral.submittedOn shouldBe LocalDateTime.MIN.toString()
       referral.prisonNumber shouldBe PRISON_NUMBER_1
@@ -551,6 +558,7 @@ constructor(
     firstPageResponse.content?.find { it.id == firstReferralId }?.let { referral ->
       referral.courseName shouldBe "Course name"
       referral.audiences shouldContainExactlyInAnyOrder audiencesForFirstReferral
+      referral.audience shouldBe "Audience 1"
       referral.status shouldBe ReferralStatus.referralStarted
       referral.prisonNumber shouldBe PRISON_NUMBER_1
       referral.referrerUsername shouldBe CLIENT_USERNAME
@@ -577,6 +585,7 @@ constructor(
     secondPageResponse.content?.find { it.id == secondReferralId }?.let { referral ->
       referral.courseName shouldBe "Another course name"
       referral.audiences shouldContainExactlyInAnyOrder audiencesForSecondReferral
+      referral.audience shouldBe "Audience 2"
       referral.status shouldBe ReferralStatus.referralSubmitted
       referral.submittedOn shouldBe LocalDateTime.MIN.toString()
       referral.prisonNumber shouldBe PRISON_NUMBER_1
@@ -673,6 +682,7 @@ constructor(
       id = firstReferralId,
       courseName = "Course for referralSummary1",
       audiences = audiencesForFirstReferral,
+      audience = "Audience 1",
       status = ReferralStatus.referralStarted,
       prisonNumber = PRISON_NUMBER_1,
       referrerUsername = REFERRER_USERNAME,
@@ -682,6 +692,7 @@ constructor(
       id = secondReferralId,
       courseName = "Course for referralSummary2",
       audiences = audiencesForSecondReferral,
+      audience = "Audience 2",
       status = ReferralStatus.referralSubmitted,
       submittedOn = LocalDateTime.MIN.toString(),
       prisonNumber = PRISON_NUMBER_1,
@@ -716,6 +727,7 @@ constructor(
     firstReferral?.let { referral ->
       referral.courseName shouldBe "Course for referralSummary1"
       referral.audiences shouldContainExactlyInAnyOrder audiencesForFirstReferral
+      referral.audience shouldBe "Audience 1"
       referral.status shouldBe ReferralStatus.referralStarted
       referral.prisonNumber shouldBe PRISON_NUMBER_1
       referral.referrerUsername shouldBe REFERRER_USERNAME
@@ -726,6 +738,7 @@ constructor(
     secondReferral?.let { referral ->
       referral.courseName shouldBe "Course for referralSummary2"
       referral.audiences shouldContainExactlyInAnyOrder audiencesForSecondReferral
+      referral.audience shouldBe "Audience 2"
       referral.status shouldBe ReferralStatus.referralSubmitted
       referral.submittedOn shouldBe LocalDateTime.MIN.toString()
       referral.prisonNumber shouldBe PRISON_NUMBER_1
@@ -796,6 +809,7 @@ constructor(
     firstPageResponse.content?.find { it.id == firstReferralId }?.let { referral ->
       referral.courseName shouldBe "Course name"
       referral.audiences shouldContainExactlyInAnyOrder audiencesForFirstReferral
+      referral.audience shouldBe "Audience 1"
       referral.status shouldBe ReferralStatus.referralStarted
       referral.prisonNumber shouldBe PRISON_NUMBER_1
       referral.referrerUsername shouldBe REFERRER_USERNAME
@@ -822,6 +836,7 @@ constructor(
     secondPageResponse.content?.find { it.id == secondReferralId }?.let { referral ->
       referral.courseName shouldBe "Another course name"
       referral.audiences shouldContainExactlyInAnyOrder audiencesForSecondReferral
+      referral.audience shouldBe "Audience 2"
       referral.status shouldBe ReferralStatus.referralSubmitted
       referral.submittedOn shouldBe LocalDateTime.MIN.toString()
       referral.prisonNumber shouldBe PRISON_NUMBER_1


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->

https://trello.com/c/omP71TsY/799-add-a-new-audience-field-to-a-course-m
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
