### PR TITLE
#1306 remove referable from course

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
@@ -31,8 +31,6 @@ data class CourseEntity(
   var identifier: String,
   var description: String? = null,
   var alternateName: String? = null,
-  @Deprecated("Referrals are now made to specific offerings of a course, not the course itself")
-  var referable: Boolean = true,
 
   @ElementCollection(fetch = FetchType.EAGER)
   @Fetch(SUBSELECT)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/CourseUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/CourseUpdate.kt
@@ -6,6 +6,4 @@ data class CourseUpdate(
   val identifier: String,
   val audience: String,
   val alternateName: String? = null,
-  @Deprecated("Referrals are now made to specific offerings of a course, not the course itself")
-  val referable: Boolean = true,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/RecordTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/RecordTransformers.kt
@@ -23,14 +23,12 @@ fun CourseEntity.toApi(): Course = Course(
   coursePrerequisites = prerequisites.map(PrerequisiteEntity::toApi),
   audiences = audiences.map(AudienceEntity::toApi),
   audience = audience,
-  referable = referable,
 )
 
 fun CourseEntity.toCourseRecord(): CourseRecord = CourseRecord(
   name = name,
   description = description ?: "",
   alternateName = alternateName,
-  referable = referable,
   identifier = identifier,
   audience = audience,
 )
@@ -68,7 +66,6 @@ fun CourseRecord.toDomain(): CourseUpdate = CourseUpdate(
   description = description.trim(),
   audience = audience,
   alternateName = alternateName?.trim(),
-  referable = referable,
 )
 
 fun OfferingRecord.toDomain(): OfferingUpdate = OfferingUpdate(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
@@ -64,7 +64,6 @@ constructor(
           audiences = audienceStrings(update.audience).mapNotNull { audienceName -> allAudiences[audienceName] }
             .toMutableSet(),
           audience = update.audience,
-          referable = update.referable,
         )
       }
     }
@@ -86,7 +85,6 @@ constructor(
           name = update.name
           description = update.description
           alternateName = update.alternateName
-          referable = update.referable
 
           val audiencesByValue = audiences.associateBy(AudienceEntity::value)
           val audiencesToAdd = expectedAudienceStrings - audiencesByValue.keys

--- a/src/main/resources/db/migration/V30__retire_referable_from_course.sql
+++ b/src/main/resources/db/migration/V30__retire_referable_from_course.sql
@@ -1,0 +1,1 @@
+ALTER TABLE course DROP COLUMN referable;

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1104,17 +1104,12 @@ components:
         audience:
           type: string
           example: 'Gang offence'
-        referable:
-          type: boolean
-          default: true
-          deprecated: true
       required:
         - id
         - name
         - coursePrerequisites
         - audiences
         - audience
-        - referable
 
     CourseRecord:
       title: 'CourseRecord'
@@ -1132,16 +1127,11 @@ components:
           type: string
         comments:
           type: string
-        referable:
-          type: boolean
-          default: true
-          deprecated: true
       required:
         - name
         - identifier
         - description
         - audience
-        - referable
 
     CoursePrerequisite:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/PersistenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/PersistenceHelper.kt
@@ -31,14 +31,13 @@ class PersistenceHelper {
       .executeUpdate()
   }
 
-  fun createCourse(courseId: UUID, identifier: String, name: String, description: String, altName: String, referable: Boolean, audience: String = "Gang offence") {
-    entityManager.createNativeQuery("INSERT INTO course (course_id, identifier, name, description, alternate_name, referable, audience) VALUES (:id, :identifier, :name, :description, :altName, :referable, :audience)")
+  fun createCourse(courseId: UUID, identifier: String, name: String, description: String, altName: String, audience: String = "Gang offence") {
+    entityManager.createNativeQuery("INSERT INTO course (course_id, identifier, name, description, alternate_name, audience) VALUES (:id, :identifier, :name, :description, :altName, :audience)")
       .setParameter("id", courseId)
       .setParameter("identifier", identifier)
       .setParameter("name", name)
       .setParameter("description", description)
       .setParameter("altName", altName)
-      .setParameter("referable", referable)
       .setParameter("audience", audience)
       .executeUpdate()
   }
@@ -50,13 +49,14 @@ class PersistenceHelper {
       .executeUpdate()
   }
 
-  fun createOffering(offeringId: UUID, courseId: UUID, orgId: String, contactEmail: String, secondaryContactEmail: String) {
-    entityManager.createNativeQuery("INSERT INTO offering (offering_id, course_id, organisation_id, contact_email, secondary_contact_email) VALUES (:id, :courseId, :orgId, :contactEmail, :secondaryContactEmail)")
+  fun createOffering(offeringId: UUID, courseId: UUID, orgId: String, contactEmail: String, secondaryContactEmail: String, referable: Boolean) {
+    entityManager.createNativeQuery("INSERT INTO offering (offering_id, course_id, organisation_id, contact_email, secondary_contact_email, referable) VALUES (:id, :courseId, :orgId, :contactEmail, :secondaryContactEmail, :referable)")
       .setParameter("id", offeringId)
       .setParameter("courseId", courseId)
       .setParameter("orgId", orgId)
       .setParameter("contactEmail", contactEmail)
       .setParameter("secondaryContactEmail", secondaryContactEmail)
+      .setParameter("referable", referable)
       .executeUpdate()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/CsvGenerators.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/CsvGenerators.kt
@@ -5,7 +5,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Cours
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.OfferingRecord
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.PrerequisiteRecord
 
-const val COURSES_PREFIX = "name,identifier,description,audience,referable,alternateName,comments\n"
+const val COURSES_PREFIX = "name,identifier,description,audience,alternateName,comments\n"
 const val PREREQUISITES_PREFIX = "name,description,course,identifier,comments,,,,\n"
 const val OFFERINGS_PREFIX = "course,identifier,organisation,contact email,secondary contact email,prisonId,referable\n"
 
@@ -16,7 +16,6 @@ fun generateCourseRecords(count: Int): List<CourseRecord> {
       identifier = "Identifier-$it",
       description = "Description for Course-$it",
       audience = "Audience-$it",
-      referable = true,
       alternateName = "AltName-$it",
       comments = "Comment-$it",
     )
@@ -55,7 +54,7 @@ fun List<CourseRecord>.toCourseCsv(): String = if (isEmpty()) {
   joinToString(
     prefix = COURSES_PREFIX,
     separator = "\n",
-    transform = { """"${it.name}","${it.identifier}","${it.description}","${it.audience}","${it.referable}","${it.alternateName}",${randomSentence(1..20)}""" },
+    transform = { """"${it.name}","${it.identifier}","${it.description}","${it.audience}","${it.alternateName}",${randomSentence(1..20)}""" },
     postfix = "\n",
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
@@ -40,13 +40,13 @@ class CourseIntegrationTest : IntegrationTestBase() {
     persistenceHelper.clearAllTableContent()
 
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
-    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC", true)
-    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC", false)
+    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC")
+    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC")
 
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_1")
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_2")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationIntegrationTest.kt
@@ -244,13 +244,13 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     val otherPrisonNumber = randomPrisonNumber()
 
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
-    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC", true)
-    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC", false)
+    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC")
+    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC")
 
     val expectedPrisonNumberCourseIds = getCourseIds().map {
       createCourseParticipation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -46,13 +46,13 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     persistenceHelper.clearAllTableContent()
 
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true, "General offence")
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
-    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC", true, "General offence")
-    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC", false, "General offence")
+    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC", "General offence")
+    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC", "General offence")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
@@ -52,68 +52,68 @@ class PactContractTest : IntegrationTestBase() {
   @State("Course d3abc217-75ee-46e9-a010-368f30282367 exists")
   fun `ensure course d3abc217-75ee-46e9-a010-368f30282367 exists`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
   }
 
   @State("Course d3abc217-75ee-46e9-a010-368f30282367 has offerings 790a2dfe-7de5-4504-bb9c-83e6e53a6537 and 7fffcc6a-11f8-4713-be35-cf5ff1aee517")
   fun `ensure course d3abc217-75ee-46e9-a010-368f30282367 has offerings 790a2dfe-7de5-4504-bb9c-83e6e53a6537 and 7fffcc6a-11f8-4713-be35-cf5ff1aee517`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
   }
 
   @State("Courses d3abc217-75ee-46e9-a010-368f30282367, 28e47d30-30bf-4dab-a8eb-9fda3f6400e8, and 1811faa6-d568-4fc4-83ce-41118b90242e and no others exist")
   fun `ensure courses d3abc217-75ee-46e9-a010-368f30282367, 28e47d30-30bf-4dab-a8eb-9fda3f6400e8, and 1811faa6-d568-4fc4-83ce-41118b90242e and no others exist`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
-    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC", true)
-    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC", false)
+    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC")
+    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC")
   }
 
   @State("In order, the names of all the courses are Super Course, Custom Course, and RAPID Course")
   fun `ensure in order, the names of all the courses are Super Course, Custom Course, and RAPID Course`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
-    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC", true)
-    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC", false)
+    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC")
+    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC")
   }
 
   @State("Offering 790a2dfe-7de5-4504-bb9c-83e6e53a6537 exists for course d3abc217-75ee-46e9-a010-368f30282367")
   fun `ensure offering 790a2dfe-7de5-4504-bb9c-83e6e53a6537 exists for course d3abc217-75ee-46e9-a010-368f30282367`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
   }
 
   @State("Offering 790a2dfe-7de5-4504-bb9c-83e6e53a6537 exists")
   fun `ensure offering 790a2dfe-7de5-4504-bb9c-83e6e53a6537 exists`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
   }
 
   @State("Offering 7fffcc6a-11f8-4713-be35-cf5ff1aee517 exists")
   fun `ensure offering 7fffcc6a-11f8-4713-be35-cf5ff1aee517 exists`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
   }
 
   @State("Participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 exists")
@@ -140,10 +140,10 @@ class PactContractTest : IntegrationTestBase() {
   @State("Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status REFERRAL_STARTED")
   fun `ensure referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status REFERRAL_STARTED`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_1")
 
@@ -153,10 +153,10 @@ class PactContractTest : IntegrationTestBase() {
   @State("Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists")
   fun `ensure referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_1")
 
@@ -166,10 +166,10 @@ class PactContractTest : IntegrationTestBase() {
   @State("Referral(s) exist for the logged in user")
   fun `ensure referrals exist for the logged in user`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_1")
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_2")
@@ -184,10 +184,10 @@ class PactContractTest : IntegrationTestBase() {
   @State("Referral(s) exist for logged in user with status REFERRAL_SUBMITTED")
   fun `ensure referrals exist for logged in user with status REFERRAL_SUBMITTED`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_2")
 
@@ -200,10 +200,10 @@ class PactContractTest : IntegrationTestBase() {
   @State("Referral(s) exist for organisation BWN")
   fun `ensure referrals exist for organisation BWN`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_1")
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_2")
@@ -218,13 +218,13 @@ class PactContractTest : IntegrationTestBase() {
   @State("Organisation BWN has courses d3abc217-75ee-46e9-a010-368f30282367, 28e47d30-30bf-4dab-a8eb-9fda3f6400e8, and 1811faa6-d568-4fc4-83ce-41118b90242e and no others")
   fun `ensure organisation BWN has courses d3abc217-75ee-46e9-a010-368f30282367, 28e47d30-30bf-4dab-a8eb-9fda3f6400e8, and 1811faa6-d568-4fc4-83ce-41118b90242e and no others`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
-    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC", true)
-    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC", false)
+    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC")
+    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC")
 
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_1")
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_2")
@@ -237,13 +237,13 @@ class PactContractTest : IntegrationTestBase() {
   @State("Super Course referral(s) exist for organisation BWM with status REFERRAL_SUBMITTED to offerings for courses with audience General offence")
   fun `ensure Super Course referral(s) exist for organisation BWM with status REFERRAL_SUBMITTED to offerings for courses with audience General offence`() {
     persistenceHelper.createAudience(UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"), "General offence")
-    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", true)
+    persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++")
     persistenceHelper.createCourseAudience(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), UUID.fromString("1f7fdb91-49b3-4eae-9815-dbf30ddd30a0"))
-    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk")
-    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk")
+    persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+    persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
-    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC", true)
-    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC", false)
+    persistenceHelper.createCourse(UUID.fromString("28e47d30-30bf-4dab-a8eb-9fda3f6400e8"), "CC", "Custom Course", "Sample description", "CC")
+    persistenceHelper.createCourse(UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"), "RC", "RAPID Course", "Sample description", "RC")
 
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_1")
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_2")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseEntityFactory.kt
@@ -19,7 +19,6 @@ class CourseEntityFactory : Factory<CourseEntity> {
   private var identifier: Yielded<String> = { randomUppercaseString() }
   private var description: Yielded<String?> = { null }
   private var alternateName: Yielded<String?> = { null }
-  private var referable: Yielded<Boolean> = { true }
   private var prerequisites: Yielded<MutableSet<PrerequisiteEntity>> = { mutableSetOf() }
   private var offerings: Yielded<MutableSet<OfferingEntity>> = { mutableSetOf() }
   private var audiences: Yielded<MutableSet<AudienceEntity>> = { mutableSetOf() }
@@ -68,7 +67,6 @@ class CourseEntityFactory : Factory<CourseEntity> {
     identifier = this.identifier(),
     description = this.description(),
     alternateName = this.alternateName(),
-    referable = this.referable(),
     prerequisites = this.prerequisites(),
     offerings = this.offerings(),
     audiences = this.audiences(),
@@ -83,7 +81,6 @@ class CourseUpdateFactory : Factory<CourseUpdate> {
   private var description: Yielded<String> = { randomSentence() }
   private var audience: Yielded<String> = { randomUppercaseString() }
   private var alternateName: Yielded<String?> = { null }
-  private var referable: Yielded<Boolean> = { true }
 
   fun withIdentifier(identifier: String) = apply {
     this.identifier = { identifier }
@@ -99,7 +96,6 @@ class CourseUpdateFactory : Factory<CourseUpdate> {
     identifier = this.identifier(),
     audience = this.audience(),
     alternateName = this.alternateName(),
-    referable = this.referable(),
   )
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/transformer/RecordTransformersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/transformer/RecordTransformersTest.kt
@@ -45,7 +45,6 @@ class RecordTransformersTest {
       description shouldBe null
       alternateName shouldBe null
       coursePrerequisites.shouldBeEmpty()
-      referable.shouldBe(true)
     }
   }
 
@@ -83,6 +82,7 @@ class RecordTransformersTest {
       organisationId shouldBe offering.organisationId
       contactEmail shouldBe offering.contactEmail
       secondaryContactEmail shouldBe offering.secondaryContactEmail
+      referable shouldBe true
     }
   }
 


### PR DESCRIPTION
## Context

> [see #1306 on the Accredited Programmes Trello board.](https://trello.com/c/vTrRy6WC/1306-remove-old-referable-field-from-course-entity-s)

## Changes in this PR

This is part 3 of our moving of the `referable` attribute from Course to Offering, as began in #255 and then actioned on the UI side. This PR deletes `referable` from Course so that referrals can only be made to a specific course Offering.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
