### PR TITLE
Store person details on referral creation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/PersonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/PersonEntity.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.util.UUID
+
+@Entity
+@Table(name = "person")
+data class PersonEntity(
+
+  @Column
+  var surname: String,
+  @Column
+  var forename: String,
+  @Column(unique = true)
+  val prisonNumber: String,
+  @Column
+  var conditionalReleaseDate: LocalDate?,
+  @Column
+  var paroleEligibilityDate: LocalDate?,
+  @Column
+  var tariffExpiryDate: LocalDate?,
+  @Column
+  var earliestReleaseDate: LocalDate?,
+  @Column
+  var earliestReleaseDateType: String?,
+  @Column
+  var indeterminateSentence: Boolean?,
+  @Column
+  var nonDtoReleaseDateType: String?,
+
+  @Id
+  @GeneratedValue
+  @Column(name = "person_id")
+  var id: UUID = UUID.randomUUID(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/PersonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/PersonRepository.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.PersonEntity
+import java.util.UUID
+
+@Repository
+interface PersonRepository : JpaRepository<PersonEntity, UUID> {
+
+  fun findPersonEntityByPrisonNumber(prisonerNumber: String): PersonEntity?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralSummaryBuilderService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralSummaryBuilderService.kt
@@ -52,7 +52,7 @@ class ReferralSummaryBuilderService {
     }
   }
 
-  private fun getEarliestReleaseDate(sentence: Sentence?): LocalDate? {
+  fun getEarliestReleaseDate(sentence: Sentence?): LocalDate? {
     return when {
       sentence?.indeterminateSentence == true -> sentence.tariffExpiryDate
       sentence?.paroleEligibilityDate != null -> sentence.paroleEligibilityDate

--- a/src/main/resources/db/migration/V31__add_person_table.sql
+++ b/src/main/resources/db/migration/V31__add_person_table.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS person
+(
+    person_id UUID primary key,
+    prison_number TEXT NOT NULL UNIQUE,
+    forename TEXT NOT NULL,
+    surname TEXT NOT NULL,
+    conditional_release_date DATE,
+    parole_eligibility_date DATE,
+    tariff_expiry_date DATE,
+    earliest_release_date DATE,
+    earliest_release_date_type TEXT,
+    indeterminate_sentence Boolean,
+    non_dto_release_date_type TEXT
+);
+
+CREATE INDEX idx_person_prison_number
+    ON person(prison_number);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
@@ -8,6 +8,7 @@ val COURSE_ID: UUID = UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367")
 val COURSE_OFFERING_ID: UUID = UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517")
 const val PRISON_NUMBER_1 = "C3456CC"
 const val PRISON_NUMBER_2 = "D3456DD"
+const val PRISON_NUMBER_3 = "C6666CC"
 const val PRISON_NAME = "Moorland"
 const val CLIENT_USERNAME = "TEST_REFERRER_USER_1"
 const val PRISONER_FIRST_NAME = "John"
@@ -54,3 +55,15 @@ val PRISONER_2 = Prisoner(
   indeterminateSentence = INDETERMINATE_SENTENCE,
 )
 val PRISONERS = listOf(PRISONER_1, PRISONER_2)
+
+val PRISONER_3 = Prisoner(
+  prisonerNumber = PRISON_NUMBER_3,
+  bookingId = BOOKING_ID,
+  firstName = "JOHN",
+  lastName = "SMITH",
+  nonDtoReleaseDateType = NON_DTO_RELEASE_DATE_TYPE,
+  conditionalReleaseDate = CONDITIONAL_RELEASE_DATE,
+  tariffDate = TARIFF_EXPIRY_DATE,
+  paroleEligibilityDate = PAROLE_ELIGIBILITY_DATE,
+  indeterminateSentence = INDETERMINATE_SENTENCE,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/PersonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/PersonEntityFactory.kt
@@ -1,0 +1,37 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomAlphanumericString
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomPrisonNumber
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.PersonEntity
+import java.time.LocalDate
+import java.util.UUID
+
+class PersonEntityFactory : Factory<PersonEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var forename: Yielded<String> = { randomAlphanumericString() }
+  private var surname: Yielded<String> = { randomAlphanumericString() }
+  private var prisonNumber: Yielded<String> = { randomPrisonNumber() }
+  private var conditionalReleaseDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var paroleEligibilityDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var tariffExpiryDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var earliestReleaseDateType: Yielded<String> = { randomAlphanumericString() }
+  private var earliestReleaseDate: Yielded<LocalDate> = { LocalDate.now() }
+  private var indeterminateSentence: Yielded<Boolean> = { false }
+  private var nonDtoReleaseDateType: Yielded<String> = { randomAlphanumericString() }
+
+  override fun produce() = PersonEntity(
+    id = id(),
+    forename = this.forename(),
+    surname = this.surname(),
+    conditionalReleaseDate = conditionalReleaseDate(),
+    paroleEligibilityDate = paroleEligibilityDate(),
+    tariffExpiryDate = tariffExpiryDate(),
+    earliestReleaseDate = earliestReleaseDate(),
+    earliestReleaseDateType = earliestReleaseDateType(),
+    prisonNumber = prisonNumber(),
+    indeterminateSentence = indeterminateSentence(),
+    nonDtoReleaseDateType = nonDtoReleaseDateType(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -30,11 +30,13 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.c
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferrerUserEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OfferingRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PersonRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferrerUserRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralSummaryBuilderService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OfferingEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.PersonEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralSummaryProjectionFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferrerUserEntityFactory
 import java.util.Optional
@@ -111,6 +113,9 @@ class ReferralServiceTest {
   @MockK(relaxed = true)
   private lateinit var referralSummaryBuilderService: ReferralSummaryBuilderService
 
+  @MockK(relaxed = true)
+  private lateinit var personRepository: PersonRepository
+
   @InjectMockKs
   private lateinit var referralService: ReferralService
 
@@ -145,6 +150,12 @@ class ReferralServiceTest {
       .withId(UUID.randomUUID())
       .produce()
     every { offeringRepository.findById(any()) } returns Optional.of(offering)
+
+    val person = PersonEntityFactory()
+      .produce()
+    every { personRepository.findPersonEntityByPrisonNumber(any()) } returns person
+
+    every { personRepository.save(any()) } returns person
 
     val referralId = UUID.randomUUID()
     every { referralRepository.save(any<ReferralEntity>()) } answers {
@@ -187,6 +198,12 @@ class ReferralServiceTest {
     every { referralRepository.save(any<ReferralEntity>()) } answers {
       firstArg<ReferralEntity>().apply { id = referralId }
     }
+
+    val person = PersonEntityFactory()
+      .produce()
+    every { personRepository.findPersonEntityByPrisonNumber(any()) } returns person
+
+    every { personRepository.save(any()) } returns person
 
     val createdReferralId = referralService.createReferral(PRISON_NUMBER_1, offering.id!!)
 

--- a/src/test/resources/simulations/__files/prison-search-results.json
+++ b/src/test/resources/simulations/__files/prison-search-results.json
@@ -1,0 +1,51 @@
+[
+  {
+    "prisonerNumber": "C6666CC",
+    "bookingId": "1201102",
+    "bookNumber": "38518A",
+    "firstName": "JOHN",
+    "lastName": "SMITH",
+    "dateOfBirth": "1940-12-20",
+    "gender": "Male",
+    "youthOffender": false,
+    "status": "INACTIVE TRN",
+    "lastMovementTypeCode": "TRN",
+    "lastMovementReasonCode": "MED",
+    "inOutStatus": "TRN",
+    "prisonId": "TRN",
+    "prisonName": "Transfer",
+    "aliases": [
+      {
+        "firstName": "DOUGLAS",
+        "lastName": "ADORNO",
+        "dateOfBirth": "1939-11-19",
+        "gender": "Male",
+        "ethnicity": "Asian/Asian British: Indian"
+      }
+    ],
+    "alerts": [
+      {
+        "alertType": "H",
+        "alertCode": "HA2",
+        "active": true,
+        "expired": false
+      }
+    ],
+    "legalStatus": "RECALL",
+    "imprisonmentStatus": "CUR_ORA",
+    "imprisonmentStatusDescription": "ORA Recalled from Curfew Conditions",
+    "recall": true,
+    "indeterminateSentence": false,
+    "receptionDate": "2021-01-08",
+    "locationDescription": "Transfer",
+    "restrictedPatient": false,
+    "currentIncentive": {
+      "level": {
+        "code": "ENH",
+        "description": "Enhanced"
+      },
+      "dateTime": "2022-06-08T14:41:18",
+      "nextReviewDate": "2023-06-08"
+    }
+  }
+]

--- a/src/test/resources/simulations/mappings/prison-search-api.json
+++ b/src/test/resources/simulations/mappings/prison-search-api.json
@@ -1,0 +1,20 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "urlPattern": "/prisoner-search/prisoner-numbers",
+        "method": "POST",
+        "bodyPatterns" : [ {
+          "contains" : "C6666CC"
+        } ]
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "bodyFileName": "prison-search-results.json"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Context
We need to display a person in prison’s name and sentence dates in the “Refer” caselist and allow users to sort by these columns. Fetching and storing this in advance will allow us to make use of out-of-the-box sorting we’re currently doing with JPQL.

<!-- Is there a Trello ticket you can link to? -->

[1288](https://trello.com/c/pKRNcV1D/1288-fetch-and-store-person-in-prisons-details-when-creating-a-new-referral-m)
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
