### PR TITLE
Update local person details when a referral is selected

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -40,9 +40,9 @@ constructor(
       } ?: throw Exception("Unable to start referral")
     }
 
-  override fun getReferralById(id: UUID): ResponseEntity<Referral> =
+  override fun getReferralById(id: UUID, updatePerson: Boolean): ResponseEntity<Referral> =
     referralService
-      .getReferralById(id)
+      .getReferralById(id, updatePerson)
       ?.let { ResponseEntity.ok(it.toApi()) }
       ?: throw NotFoundException("No Referral found at /referrals/$id")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -108,7 +108,14 @@ constructor(
     }
   }
 
-  fun getReferralById(referralId: UUID): ReferralEntity? = referralRepository.findById(referralId).getOrNull()
+  fun getReferralById(referralId: UUID, updatePersonDetails: Boolean = false): ReferralEntity? {
+    val referral = referralRepository.findById(referralId).getOrNull()
+
+    if (referral != null && updatePersonDetails) {
+      createOrUpdatePerson(referral.prisonNumber)
+    }
+    return referral
+  }
 
   fun updateReferralById(referralId: UUID, update: ReferralUpdate) {
     val referral = referralRepository.getReferenceById(referralId)

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -350,6 +350,13 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: updatePerson
+          in: query
+          description: parameter to decide whether to update the local person data
+          required: false
+          schema:
+            type: boolean
+            default: true
       responses:
         200:
           description: Information about the referral

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -223,7 +223,7 @@ constructor(
 
     every { referralService.getReferralById(any()) } returns referral
 
-    mockMvc.get("/referrals/${referral.id}") {
+    mockMvc.get("/referrals/${referral.id}?updatePerson=false") {
       accept = MediaType.APPLICATION_JSON
       header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
     }.andExpect {
@@ -258,7 +258,7 @@ constructor(
 
     every { referralService.getReferralById(any()) } returns null
 
-    mockMvc.get("/referrals/$referralId") {
+    mockMvc.get("/referrals/$referralId?updatePerson=false") {
       accept = MediaType.APPLICATION_JSON
       header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
     }.andExpect {


### PR DESCRIPTION
## Context

We store a Person’s name and sentence information on their Referral when a Referral is created. We need to update this regularly to ensure it doesn’t get out of date when the record is updated in upstream systems e.g. NOMIS.

The default API should NOT update the person. A parameter updatePerson=true shall be added to the endpoint which will carry out the update.


<!-- Is there a Trello ticket you can link to? -->
[1302](https://trello.com/c/IpxbwG3o/1302-fetch-and-update-person-in-prisons-details-when-viewing-a-referral-s)
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
