### PR TITLE
[1301] - fetch and store prisonName when creating a referral

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonRegisterApi/PrisonRegisterApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonRegisterApi/PrisonRegisterApiClient.kt
@@ -13,7 +13,7 @@ class PrisonRegisterApiClient(
   webClient: WebClient,
 ) : BaseHMPPSClient(webClient, jacksonObjectMapper()) {
 
-  fun getPrisonDetailsByPrisonId(prisonId: String) = getRequest<List<PrisonDetails>> {
+  fun getPrisonDetailsByPrisonId(prisonId: String) = getRequest<PrisonDetails> {
     path = "/prisons/id/$prisonId"
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonRegisterApi/model/PrisonDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonRegisterApi/model/PrisonDetails.kt
@@ -4,6 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class PrisonDetails(
-  var prisonId: String? = null,
-  var prisonName: String? = null,
+  var prisonId: String,
+  var prisonName: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OrganisationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OrganisationEntity.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "organisation")
+data class OrganisationEntity(
+
+  @Id
+  @GeneratedValue
+  @Column(name = "organisation_id")
+  var id: UUID = UUID.randomUUID(),
+
+  @Column
+  var code: String,
+
+  @Column
+  var name: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/OrganisationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/OrganisationRepository.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OrganisationEntity
+import java.util.UUID
+
+@Repository
+interface OrganisationRepository : JpaRepository<OrganisationEntity, UUID> {
+
+  fun findOrganisationEntityByCode(code: String): OrganisationEntity?
+}

--- a/src/main/resources/db/migration/V33__add_organisation_table.sql
+++ b/src/main/resources/db/migration/V33__add_organisation_table.sql
@@ -1,0 +1,12 @@
+
+DROP TABLE organisation;
+
+CREATE TABLE IF NOT EXISTS organisation
+(
+    organisation_id UUID primary key,
+    code TEXT NOT NULL,
+    name TEXT NOT NULL
+);
+
+CREATE INDEX idx_organisation_code
+    ON organisation(code);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/OrganisationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/OrganisationEntityFactory.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomAlphanumericString
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OrganisationEntity
+import java.util.UUID
+
+class OrganisationEntityFactory : Factory<OrganisationEntity> {
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var code: Yielded<String> = { randomAlphanumericString() }
+  private var name: Yielded<String> = { randomAlphanumericString() }
+
+  override fun produce() = OrganisationEntity(
+    id = id(),
+    code = this.code(),
+    name = this.name(),
+  )
+
+  fun withId(id: UUID) = apply {
+    this.id = { id }
+  }
+
+  fun withCode(code: String) = apply {
+    this.code = { code }
+  }
+
+  fun withName(name: String) = apply {
+    this.name = { name }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseParticipationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseParticipationRepositoryTest.kt
@@ -128,6 +128,6 @@ class CourseParticipationRepositoryTest {
       this.createdByUsername shouldBe CLIENT_USERNAME
       this.lastModifiedByUsername shouldBe null
     }
-    persistedCourseParticipation.createdDateTime.shouldBeWithin(Duration.ofSeconds(1), transactionStartTime)
+    persistedCourseParticipation.createdDateTime.shouldBeWithin(Duration.ofSeconds(2), transactionStartTime)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.service
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.match
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -19,6 +20,7 @@ import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonRegisterApi.PrisonRegisterApiService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonRegisterApi.model.PrisonDetails
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerSearchApi.PrisonerSearchApiService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.CLIENT_USERNAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.ORGANISATION_ID_MDI
@@ -30,12 +32,14 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.c
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferrerUserEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.projection.ReferralSummaryProjection
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OfferingRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OrganisationRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PersonRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferrerUserRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralSummaryBuilderService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OfferingEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OrganisationEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.PersonEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralSummaryProjectionFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferrerUserEntityFactory
@@ -116,6 +120,9 @@ class ReferralServiceTest {
   @MockK(relaxed = true)
   private lateinit var personRepository: PersonRepository
 
+  @MockK(relaxed = true)
+  private lateinit var organisationRepository: OrganisationRepository
+
   @InjectMockKs
   private lateinit var referralService: ReferralService
 
@@ -148,6 +155,7 @@ class ReferralServiceTest {
 
     val offering = OfferingEntityFactory()
       .withId(UUID.randomUUID())
+      .withOrganisationId(ORGANISATION_ID_MDI)
       .produce()
     every { offeringRepository.findById(any()) } returns Optional.of(offering)
 
@@ -156,6 +164,9 @@ class ReferralServiceTest {
     every { personRepository.findPersonEntityByPrisonNumber(any()) } returns person
 
     every { personRepository.save(any()) } returns person
+
+    val organisation = OrganisationEntityFactory().withCode(ORGANISATION_ID_MDI).produce()
+    every { organisationRepository.findOrganisationEntityByCode(ORGANISATION_ID_MDI) } returns organisation
 
     val referralId = UUID.randomUUID()
     every { referralRepository.save(any<ReferralEntity>()) } answers {
@@ -174,6 +185,68 @@ class ReferralServiceTest {
           it.prisonNumber == PRISON_NUMBER_1 &&
             it.referrer.username == CLIENT_USERNAME &&
             it.offering.id == offering.id
+        },
+      )
+    }
+  }
+
+  @Test
+  fun `createReferral with new organisation and existing user should create referral successfully`() {
+    mockSecurityContext(CLIENT_USERNAME)
+
+    val referrer = ReferrerUserEntityFactory()
+      .withUsername(CLIENT_USERNAME)
+      .produce()
+    every { referrerUserRepository.findById(CLIENT_USERNAME) } returns Optional.of(referrer)
+
+    val prisonCode = "XXX"
+    val prisonName = "Secret Prison"
+
+    val offering = OfferingEntityFactory()
+      .withId(UUID.randomUUID())
+      .withOrganisationId(prisonCode)
+      .produce()
+    every { offeringRepository.findById(any()) } returns Optional.of(offering)
+
+    val person = PersonEntityFactory()
+      .produce()
+    every { personRepository.findPersonEntityByPrisonNumber(any()) } returns person
+
+    every { personRepository.save(any()) } returns person
+
+    every { organisationRepository.findOrganisationEntityByCode(prisonCode) } returns null
+
+    val prisonDetails = PrisonDetails(prisonCode, prisonName)
+    every { prisonRegisterApiService.getPrisonById(prisonCode) } returns prisonDetails
+
+    every { organisationRepository.save(any()) } returns OrganisationEntityFactory().produce()
+
+    val referralId = UUID.randomUUID()
+    every { referralRepository.save(any<ReferralEntity>()) } answers {
+      firstArg<ReferralEntity>().apply { id = referralId }
+    }
+
+    val createdReferralId = referralService.createReferral(PRISON_NUMBER_1, offering.id!!)
+
+    createdReferralId shouldBe referralId
+
+    verify { referrerUserRepository.findById(CLIENT_USERNAME) }
+    verify { offeringRepository.findById(offering.id!!) }
+    verify {
+      referralRepository.save(
+        match {
+          it.prisonNumber == PRISON_NUMBER_1 &&
+            it.referrer.username == CLIENT_USERNAME &&
+            it.offering.id == offering.id
+        },
+      )
+    }
+
+    verify {
+      organisationRepository.save(
+        match {
+          it.code == prisonCode &&
+            it.name == prisonName
         },
       )
     }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/WvDsOYFf/1301-fetch-and-store-prison-name-when-creating-a-referral-m

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR
* when a referral is created and the offering chosen has an organisation which doesn't already exist in our organisation table, then we create the organisation. 
* Organisation names don't change that often, so we don't update them on referral creation. (We could potentially have a cron job which does updates once a day)

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
