### PR TITLE
[1301] fix multiple organisastions from being created

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonRegisterApi/PrisonRegisterApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonRegisterApi/PrisonRegisterApiService.kt
@@ -18,29 +18,36 @@ constructor(
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
+
   fun getAllPrisons(): Map<String?, String?> {
-    return getPrisonDetails { it.associate { details -> details.prisonId to details.prisonName } }
-  }
-
-  fun getPrisonById(prisonId: String): PrisonDetails? {
-    return getPrisonDetails { it.firstOrNull() }
-  }
-
-  private inline fun <reified T> getPrisonDetails(
-    retrieveResult: (List<PrisonDetails>) -> T,
-  ): T {
-    val prisonDetailsResult = when (val result = prisonRegisterApiClient.getAllPrisonDetails()) {
-      is ClientResult.Success -> AuthorisableActionResult.Success(result.body)
+    val prisonDetailsResult = when (val allPrisonDetails = prisonRegisterApiClient.getAllPrisonDetails()) {
+      is ClientResult.Success -> AuthorisableActionResult.Success(allPrisonDetails.body)
       is ClientResult.Failure.StatusCode -> {
-        log.warn("Failure to retrieve data. Status code ${result.status} reason ${result.toException().message}")
-        AuthorisableActionResult.Success(emptyList())
+        log.warn("Failure to retrieve data. Status code ${allPrisonDetails.status} reason ${allPrisonDetails.toException().message}")
+        AuthorisableActionResult.Success(listOf<PrisonDetails>())
       }
       is ClientResult.Failure -> {
-        log.warn("Failure to retrieve data ${result.toException().message}")
-        AuthorisableActionResult.Success(emptyList())
+        log.warn("Failure to retrieve data ${allPrisonDetails.toException().message}")
+        AuthorisableActionResult.Success(listOf<PrisonDetails>())
       }
     }
 
-    return retrieveResult(prisonDetailsResult.entity)
+    return prisonDetailsResult.entity.associate { it.prisonId to it.prisonName }
+  }
+
+  fun getPrisonById(prisonId: String): PrisonDetails? {
+    val prisonDetailsResult = when (val prison = prisonRegisterApiClient.getPrisonDetailsByPrisonId(prisonId)) {
+      is ClientResult.Success -> AuthorisableActionResult.Success(prison.body)
+      is ClientResult.Failure.StatusCode -> {
+        log.warn("Failure to retrieve data. Status code ${prison.status} reason ${prison.toException().message}")
+        AuthorisableActionResult.Success(null)
+      }
+      is ClientResult.Failure -> {
+        log.warn("Failure to retrieve data ${prison.toException().message}")
+        AuthorisableActionResult.Success(null)
+      }
+    }
+
+    return prisonDetailsResult.entity
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.service
 
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.string.match
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
@@ -220,8 +219,8 @@ class ReferralServiceTest {
 
     every { organisationRepository.findOrganisationEntityByCode(prisonCode) } returns null
 
-    val prisonDetails = PrisonDetails(prisonCode, prisonName)
-    every { prisonRegisterApiService.getPrisonById(prisonCode) } returns prisonDetails
+    val prisonDetail = PrisonDetails(prisonCode, prisonName)
+    every { prisonRegisterApiService.getPrisonById(prisonCode) } returns prisonDetail
 
     every { organisationRepository.save(any()) } returns OrganisationEntityFactory().produce()
 


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->

https://trello.com/c/WvDsOYFf/1301-fetch-and-store-prison-name-when-creating-a-referral-m

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

* We were using the wrong endpoint to fetch prison details and ended up storing duplicate prison details
* As part of this change, we are invoking a specific endpoint to fetch prison details

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
