### PR TITLE
update status history when assessment is submitted.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralStatusHistoryEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralStatusHistoryEntity.kt
@@ -42,8 +42,8 @@ data class ReferralStatusHistoryEntity(
   @JoinColumn(name = "reason")
   val reason: ReferralStatusReasonEntity? = null,
   val notes: String? = null,
-  val statusEndDate: LocalDateTime? = null,
-  val durationAtThisStatus: Long? = null,
+  var statusEndDate: LocalDateTime? = null,
+  var durationAtThisStatus: Long? = null,
 )
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -155,6 +155,7 @@ constructor(
 
   fun submitReferralById(referralId: UUID) {
     val referral = referralRepository.getReferenceById(referralId)
+    val existingStatus = referral.status
 
     val requiredFields = listOf(
       referral.offering.id to "offeringId",
@@ -190,6 +191,8 @@ constructor(
         throw IllegalArgumentException("Referral $referralId is already submitted and currently being assessed")
       }
     }
+
+    referralStatusHistoryService.updateReferralHistory(referral, existingStatus)
   }
 
   fun getReferralViewByOrganisationId(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -251,6 +251,11 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     submitReferral(readyToSubmitReferral.id)
 
     getReferralById(readyToSubmitReferral.id).status shouldBeEqual REFERRAL_SUBMITTED.lowercase()
+
+    val statusHistories = referralStatusHistoryRepository.getAllByReferralIdOrderByStatusStartDateDesc(referralCreated.referralId)
+    statusHistories.size shouldBeEqual 2
+    statusHistories[0].status.code shouldBeEqual "REFERRAL_SUBMITTED"
+    statusHistories[1].status.code shouldBeEqual "REFERRAL_STARTED"
   }
 
   @Test


### PR DESCRIPTION
## Context

Additional work to update the status history of the referral when the status is updated. 

This will update the end date time of the previous history record and record the duration and also create the new record assigning the previous status allowing us to (eventually) plot the referral journey and how long it took. 

<!-- Is there a Trello ticket you can link to? -->
[1344](https://trello.com/c/izfZWZG0/1344-referral-status-history-api)
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
