### PR TITLE
Added extra filters for open, closed and draft referrals

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
   val jsonWebtokenVersion = "0.12.5"
   val springSecurityVersion = "6.2.1"
 
-  runtimeOnly("org.postgresql:postgresql:42.7.1")
+  runtimeOnly("org.postgresql:postgresql:42.7.2")
 
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-security")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusEntity.kt
@@ -13,9 +13,11 @@ import java.util.UUID
 data class ReferralStatusEntity(
   @Id
   val code: String,
-  var description: String,
-  var colour: String,
-  var active: Boolean,
+  val description: String,
+  val colour: String,
+  val active: Boolean,
+  val draft: Boolean,
+  val closed: Boolean,
 )
 
 @Entity
@@ -23,9 +25,9 @@ data class ReferralStatusEntity(
 data class ReferralStatusCategoryEntity(
   @Id
   val code: String,
-  var description: String,
-  var referralStatusCode: String,
-  var active: Boolean,
+  val description: String,
+  val referralStatusCode: String,
+  val active: Boolean,
 )
 
 @Entity
@@ -33,15 +35,24 @@ data class ReferralStatusCategoryEntity(
 data class ReferralStatusReasonEntity(
   @Id
   val code: String,
-  var description: String,
-  var referralStatusCategoryCode: String,
-  var active: Boolean,
+  val description: String,
+  val referralStatusCategoryCode: String,
+  val active: Boolean,
 )
 
 @Repository
 interface ReferralStatusRepository : JpaRepository<ReferralStatusEntity, UUID> {
   fun findByCode(code: String): ReferralStatusEntity?
   fun findAllByActiveIsTrue(): List<ReferralStatusEntity>
+
+  // get draft statuses only
+  fun findAllByActiveIsTrueAndDraftIsTrue(): List<ReferralStatusEntity>
+
+  // get closed statuses only
+  fun findAllByActiveIsTrueAndClosedIsTrue(): List<ReferralStatusEntity>
+
+  // get open statuses only
+  fun findAllByActiveIsTrueAndClosedIsFalseAndDraftIsFalse(): List<ReferralStatusEntity>
 }
 
 fun ReferralStatusRepository.getByCode(code: String) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -83,12 +83,13 @@ constructor(
     @RequestParam(value = "status", required = false) status: List<String>?,
     @RequestParam(value = "audience", required = false) audience: String?,
     @RequestParam(value = "courseName", required = false) courseName: String?,
+    @RequestParam(value = "statusGroup", required = false) statusGroup: String?,
     @RequestParam(value = "sortColumn", required = false) sortColumn: String?,
     @RequestParam(value = "sortDirection", required = false) sortDirection: String?,
   ): ResponseEntity<PaginatedReferralView> {
     val pageable = PageRequest.of(page, size, getSortBy(sortColumn ?: DEFAULT_SORT, sortDirection ?: DEFAULT_DIRECTION))
     val apiReferralSummaryPage =
-      referralService.getReferralViewByOrganisationId(organisationId, pageable, status, audience, courseName)
+      referralService.getReferralViewByOrganisationId(organisationId, pageable, status, audience, courseName, statusGroup)
 
     return ResponseEntity.ok(
       PaginatedReferralView(
@@ -108,14 +109,16 @@ constructor(
     @RequestParam(value = "status", required = false) status: List<String>?,
     @RequestParam(value = "audience", required = false) audience: String?,
     @RequestParam(value = "courseName", required = false) courseName: String?,
+    @RequestParam(value = "statusGroup", required = false) statusGroup: String?,
     @RequestParam(value = "sortColumn", required = false) sortColumn: String?,
     @RequestParam(value = "sortDirection", required = false) sortDirection: String?,
   ): ResponseEntity<PaginatedReferralView> {
     val pageable = PageRequest.of(page, size, getSortBy(sortColumn ?: DEFAULT_SORT, sortDirection ?: DEFAULT_DIRECTION))
     val username: String =
       securityService.getCurrentUserName() ?: throw AccessDeniedException("unauthorised, username not present in token")
+
     val apiReferralSummaryPage =
-      referralService.getReferralViewByUsername(username, pageable, status, audience, courseName)
+      referralService.getReferralViewByUsername(username, pageable, status, audience, courseName, statusGroup)
 
     return ResponseEntity.ok(
       PaginatedReferralView(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralReferenceDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralReferenceDataService.kt
@@ -22,12 +22,14 @@ class ReferralReferenceDataService(
           code = it.code,
           description = it.description,
           colour = it.colour,
+          closed = it.closed,
+          draft = it.draft,
         )
       }
 
   fun getReferralStatus(code: String) =
     referralStatusRepository.getByCode(code).let {
-      ReferralStatusRefData(it.code, it.description, it.colour)
+      ReferralStatusRefData(it.code, it.description, it.colour, it.closed, it.draft)
     }
 
   fun getReferralStatusCategories(statusCode: String) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralStatusHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralStatusHistoryService.kt
@@ -57,7 +57,7 @@ class ReferralStatusHistoryService(
     val statusHistory = referralStatusHistoryRepository.getAllByReferralIdOrderByStatusStartDateDesc(referral.id!!)
     statusHistory.firstOrNull()?.let {
       it.statusEndDate = datetime
-      it.durationAtThisStatus = ChronoUnit.MILLIS.between(datetime, it.statusStartDate)
+      it.durationAtThisStatus = ChronoUnit.MILLIS.between(it.statusStartDate, datetime)
     }
 
     referralStatusHistoryRepository.save(
@@ -65,7 +65,6 @@ class ReferralStatusHistoryService(
         referralId = referral.id!!,
         status = status,
         previousStatus = previousStatus,
-        statusEndDate = datetime,
       ),
     )
   }

--- a/src/main/resources/db/migration/V44__Add_draft_closed_to_status.sql
+++ b/src/main/resources/db/migration/V44__Add_draft_closed_to_status.sql
@@ -1,0 +1,7 @@
+ALTER TABLE referral_status ADD COLUMN draft boolean default false;
+ALTER TABLE referral_status ADD COLUMN closed boolean default false;
+
+update referral_status set draft = true where code =  'REFERRAL_STARTED';
+update referral_status set closed = true where code = 'PROGRAMME_COMPLETE';
+update referral_status set closed = true where code = 'WITHDRAWN';
+update referral_status set closed = true where code = 'NOT_SUITABLE';

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -5,7 +5,7 @@ info:
 servers:
   - url: /
 security:
-  - bearerAuth: []
+  - bearerAuth: [ ]
 paths:
 
   /prisoner-search:
@@ -576,6 +576,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: statusGroup
+          in: query
+          description: Additional filter to only show "open", "closed" or "draft" referrals
+          required: false
+          schema:
+            type: string
         - name: sortColumn
           in: query
           description: Column to sort by default "surname"
@@ -642,6 +648,12 @@ paths:
         - name: courseName
           in: query
           description: Filter by the name of the course associated with this referral
+          required: false
+          schema:
+            type: string
+        - name: statusGroup
+          in: query
+          description: Additional filter to only show "open", "closed" or "draft" referrals
           required: false
           schema:
             type: string
@@ -2194,6 +2206,12 @@ components:
         colour:
           type: string
           example: light-grey
+        closed:
+          description: flag to show this is a closed status
+          type: boolean
+        draft:
+          description: flag to show this is a draft status
+          type: boolean
       required:
         - code
         - description

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
@@ -24,7 +24,7 @@ private const val REASON_DUPLICATE = "W_DUPLICATE"
 @Import(JwtAuthHelper::class)
 class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
 
-  val withdrawnStatusExpected = ReferralStatusRefData(code = WITHDRAWN, description = "Withdrawn", colour = "light-grey")
+  val withdrawnStatusExpected = ReferralStatusRefData(code = WITHDRAWN, description = "Withdrawn", colour = "light-grey", draft = false, closed = true)
   val categoryExpected = ReferralStatusCategory(code = CATEGORY_ADMIN, description = "Administrative error", referralStatusCode = WITHDRAWN)
   val reasonExpected = ReferralStatusReason(code = REASON_DUPLICATE, description = "Duplicate referral", referralCategoryCode = CATEGORY_ADMIN)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRI
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRER_USERNAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferrerUserEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.view.ReferralViewRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OfferingRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OrganisationRepository
@@ -68,6 +69,9 @@ class ReferralServiceTest {
 
   @MockK(relaxed = true)
   private lateinit var referralStatusHistoryService: ReferralStatusHistoryService
+
+  @MockK(relaxed = true)
+  private lateinit var referralStatusRepository: ReferralStatusRepository
 
   @InjectMockKs
   private lateinit var referralService: ReferralService


### PR DESCRIPTION
## Context

Added new flags to referral status reference data of draft and closed - this is to indicate that the status is a draft or a closed status (both false will mean open) 

This is so that the UI can filter on the three status groups without having to know what the statuses are. 

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
