### PR TITLE
added status transition workflow

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusTransitionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusTransitionEntity.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import org.hibernate.annotations.Immutable
+import org.springframework.data.jpa.repository.EntityGraph
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Entity
+@Table(name = "referral_status_transitions")
+@Immutable
+class ReferralStatusTransitionEntity(
+  @Id
+  @Column(name = "referral_status_transition_id")
+  val id: UUID,
+  val ptUser: Boolean,
+  val pomUser: Boolean,
+  @ManyToOne
+  @JoinColumn(name = "transitionFromStatus")
+  val fromStatus: ReferralStatusEntity,
+  @ManyToOne
+  @JoinColumn(name = "transitionToStatus")
+  val toStatus: ReferralStatusEntity,
+)
+
+@Repository
+interface ReferralStatusTransitionRepository : JpaRepository<ReferralStatusTransitionEntity, UUID> {
+
+  @EntityGraph(attributePaths = ["fromStatus", "toStatus"])
+  @Query(
+    """
+      select st from ReferralStatusTransitionEntity st
+      where st.fromStatus.code = :fromStatus
+      and st.ptUser = true
+    """,
+  )
+  fun getNextPTTransitions(fromStatus: String): List<ReferralStatusTransitionEntity>
+
+  @EntityGraph(attributePaths = ["fromStatus", "toStatus"])
+  @Query(
+    """
+      select st from ReferralStatusTransitionEntity st
+      where st.fromStatus.code = :fromStatus
+      and st.pomUser = true
+    """,
+  )
+  fun getNextPOMTransitions(fromStatus: String): List<ReferralStatusTransitionEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferenceDataTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferenceDataTransformer.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer
+
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatusRefData
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusEntity
+fun ReferralStatusEntity.toModel() = ReferralStatusRefData(code = code, description = description, colour = colour, closed = closed, draft = draft)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralReferenceDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralReferenceDataService.kt
@@ -7,13 +7,16 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Refer
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusReasonRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusTransitionRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.getByCode
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toModel
 
 @Service
 class ReferralReferenceDataService(
   private val referralStatusRepository: ReferralStatusRepository,
   private val referralStatusCategoryRepository: ReferralStatusCategoryRepository,
   private val referralStatusReasonRepository: ReferralStatusReasonRepository,
+  private val referralStatusTransitionRepository: ReferralStatusTransitionRepository,
 ) {
   fun getReferralStatuses() =
     referralStatusRepository.findAllByActiveIsTrue()
@@ -67,4 +70,12 @@ class ReferralReferenceDataService(
         referralCategoryCode = it.referralStatusCategoryCode,
       )
     }
+
+  fun getNextStatusTransitions(currentStatus: String, ptRole: Boolean = false): List<ReferralStatusRefData> {
+    return if (ptRole) {
+      referralStatusTransitionRepository.getNextPTTransitions(currentStatus).map { it.toStatus.toModel() }
+    } else {
+      referralStatusTransitionRepository.getNextPOMTransitions(currentStatus).map { it.toStatus.toModel() }
+    }
+  }
 }

--- a/src/main/resources/db/migration/V45__Add_missing_status.sql
+++ b/src/main/resources/db/migration/V45__Add_missing_status.sql
@@ -1,0 +1,5 @@
+update referral_status set closed = true where code = 'DESELECTED';
+
+INSERT INTO referral_status VALUES ('NOT_ELIGIBLE','Not Eligible','light-grey', true, false, true );
+INSERT INTO referral_status VALUES ('ON_HOLD_REFERRAL_SUBMITTED','On hold - referral submitted','pink', true, false, false );
+INSERT INTO referral_status VALUES ('ON_HOLD_ASSESSMENT_STARTED','On hold - assessment started','pink', true, false, false );

--- a/src/main/resources/db/migration/V46__status_transitions.sql
+++ b/src/main/resources/db/migration/V46__status_transitions.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS referral_status_transitions
+(
+    referral_status_transition_id UUID PRIMARY KEY,
+    pt_user BOOLEAN NOT NULL,
+    pom_user BOOLEAN NOT NULL,
+    transition_from_status TEXT NOT NULL,
+    transition_to_status TEXT NOT NULL
+);
+
+ALTER TABLE referral_status_transitions
+    ADD CONSTRAINT from_status_fk
+        FOREIGN KEY (transition_from_status) REFERENCES referral_status(code);
+
+ALTER TABLE referral_status_transitions
+    ADD CONSTRAINT to_status_fk
+        FOREIGN KEY (transition_to_status) REFERENCES referral_status(code);

--- a/src/main/resources/db/migration/V47__populate_status_transitions.sql
+++ b/src/main/resources/db/migration/V47__populate_status_transitions.sql
@@ -1,0 +1,63 @@
+insert into referral_status_transitions values ('7cca5375-df34-443d-baa8-f517b2ba0d5f', true, true, 'REFERRAL_STARTED','REFERRAL_SUBMITTED');
+
+--PT transitions
+insert into referral_status_transitions values ('29a74834-8a81-4f99-bb0b-7d2f66723b56', true, false, 'REFERRAL_SUBMITTED','AWAITING_ASSESSMENT');
+insert into referral_status_transitions values ('8a6cc070-f076-49d8-b5d9-9fba748f6bae', true, false, 'REFERRAL_SUBMITTED','NOT_ELIGIBLE');
+insert into referral_status_transitions values ('5ab83de8-0102-4279-93c2-f926aeb716fa', true, false, 'REFERRAL_SUBMITTED','ON_HOLD_REFERRAL_SUBMITTED');
+insert into referral_status_transitions values ('1352df62-d7bb-40ef-92d7-654cdaa12081', true, false, 'REFERRAL_SUBMITTED','WITHDRAWN');
+
+insert into referral_status_transitions values ('e2b303eb-9ac8-4e10-9cea-0ba90450e3e0', true, false, 'AWAITING_ASSESSMENT','ASSESSMENT_STARTED');
+insert into referral_status_transitions values ('b1c6291e-17ad-469a-ab77-12f361aef0b6', true, false, 'AWAITING_ASSESSMENT','NOT_ELIGIBLE');
+insert into referral_status_transitions values ('e6dc8e4b-2644-4504-a072-acc9f3a58c85', true, false, 'AWAITING_ASSESSMENT','ON_HOLD_AWAITING_ASSESSMENT');
+insert into referral_status_transitions values ('b510c888-c906-4ff7-82d4-a43c990a8a55', true, false, 'AWAITING_ASSESSMENT','WITHDRAWN');
+
+insert into referral_status_transitions values ('aec54f43-2d8c-4a04-9eaa-5410da266f56', true, false, 'ASSESSMENT_STARTED','ASSESSED_SUITABLE');
+insert into referral_status_transitions values ('038e0761-347c-4936-b0c6-95fc672645c2', true, false, 'ASSESSMENT_STARTED','SUITABLE_NOT_READY');
+insert into referral_status_transitions values ('7d04fcc8-946d-4945-9a43-43f590f5f5b4', true, false, 'ASSESSMENT_STARTED','NOT_SUITABLE');
+insert into referral_status_transitions values ('2414ad6e-47b2-4579-a144-d39d856a9d81', true, false, 'ASSESSMENT_STARTED','ON_HOLD_ASSESSMENT_STARTED');
+insert into referral_status_transitions values ('eafe7046-3921-461b-86fb-04bcc937fd45', true, false, 'ASSESSMENT_STARTED','WITHDRAWN');
+
+insert into referral_status_transitions values ('4a730684-2262-4f60-bb61-8e3251be828e', true, false, 'ASSESSED_SUITABLE','ON_PROGRAMME');
+insert into referral_status_transitions values ('6ff18bb3-0a2a-44e1-afcc-8c62ced3fc36', true, false, 'ASSESSED_SUITABLE','SUITABLE_NOT_READY');
+insert into referral_status_transitions values ('fd475c09-ab1f-4cfa-97d0-1bb2fe6e5318', true, false, 'ASSESSED_SUITABLE','WITHDRAWN');
+
+insert into referral_status_transitions values ('92aa0c54-4450-41fc-886a-9da6fbfaed90', true, false, 'SUITABLE_NOT_READY','ASSESSED_SUITABLE');
+insert into referral_status_transitions values ('c1afa295-0a69-494f-925e-b1971de660dd', true, false, 'SUITABLE_NOT_READY','WITHDRAWN');
+
+insert into referral_status_transitions values ('e8263d79-2c84-426e-a374-2395997e884d', true, false, 'ON_PROGRAMME','PROGRAMME_COMPLETE');
+insert into referral_status_transitions values ('7fae085c-73d3-480e-a418-7bc91f6a881e', true, false, 'ON_PROGRAMME','DESELECTED');
+insert into referral_status_transitions values ('ab9406a3-41f9-4386-8074-544bbdda7bdf', true, false, 'ON_PROGRAMME','ASSESSED_SUITABLE');
+insert into referral_status_transitions values ('e7a3aa5c-7e4d-4053-8fe9-c30515717af7', true, false, 'ON_PROGRAMME','SUITABLE_NOT_READY');
+
+insert into referral_status_transitions values ('770b978f-b1e6-4885-8b0f-8612fb22ae62', true, false, 'ON_HOLD_REFERRAL_SUBMITTED','REFERRAL_SUBMITTED');
+insert into referral_status_transitions values ('2485ad6d-b2b6-4055-9e7b-6beb1879e80a', true, false, 'ON_HOLD_REFERRAL_SUBMITTED','WITHDRAWN');
+
+insert into referral_status_transitions values ('ac4d01a8-6c37-4a2f-95e1-213d895c3146', true, false, 'ON_HOLD_AWAITING_ASSESSMENT','AWAITING_ASSESSMENT');
+insert into referral_status_transitions values ('c4e20256-9508-41ff-899c-5aad527860c0', true, false, 'ON_HOLD_AWAITING_ASSESSMENT','WITHDRAWN');
+
+insert into referral_status_transitions values ('a7ccf929-d91a-4dfc-b536-f42b0815aa49', true, false, 'ON_HOLD_ASSESSMENT_STARTED','ASSESSMENT_STARTED');
+insert into referral_status_transitions values ('2b98eefb-7950-43ea-9800-bd5622bbb4fa', true, false, 'ON_HOLD_ASSESSMENT_STARTED','WITHDRAWN');
+
+--POM transitions
+
+insert into referral_status_transitions values ('5026ce4c-acf6-41c3-80b7-9eeaaa1c966d', false, true, 'REFERRAL_SUBMITTED','ON_HOLD_REFERRAL_SUBMITTED');
+insert into referral_status_transitions values ('18f4de44-3f8f-47ea-80d0-a3af02c97f86', false, true, 'REFERRAL_SUBMITTED','WITHDRAWN');
+
+insert into referral_status_transitions values ('0774e02f-ba90-4819-a854-847319b6e1be', false, true, 'AWAITING_ASSESSMENT','ON_HOLD_AWAITING_ASSESSMENT');
+insert into referral_status_transitions values ('bd0d6d96-bc82-4e15-bbd6-07fc5a0c28bd', false, true, 'AWAITING_ASSESSMENT','WITHDRAWN');
+
+insert into referral_status_transitions values ('cd320dfb-1860-4ca7-b82c-9fba2a682a2d', false, true, 'ASSESSMENT_STARTED','ON_HOLD_ASSESSMENT_STARTED');
+insert into referral_status_transitions values ('bc896255-655d-4720-bfac-5bd24c9c3f8e', false, true, 'ASSESSMENT_STARTED','WITHDRAWN');
+
+insert into referral_status_transitions values ('54911a5b-6de5-4d3a-8168-11d4c5a6e585', false, true, 'ASSESSED_SUITABLE','WITHDRAWN');
+
+insert into referral_status_transitions values ('5865dd8a-6c04-40a9-94dc-55930156bad2', false, true, 'SUITABLE_NOT_READY','WITHDRAWN');
+
+insert into referral_status_transitions values ('6b86eb83-a100-431a-a24c-f9c6c63d633f', false, true, 'ON_HOLD_REFERRAL_SUBMITTED','REFERRAL_SUBMITTED');
+insert into referral_status_transitions values ('1313fc0c-1351-4caf-a4c1-ff05588ea642', false, true, 'ON_HOLD_REFERRAL_SUBMITTED','WITHDRAWN');
+
+insert into referral_status_transitions values ('e030adcb-03a1-446b-a8cf-c57c70574e0c', false, true, 'ON_HOLD_AWAITING_ASSESSMENT','AWAITING_ASSESSMENT');
+insert into referral_status_transitions values ('aa2ae2c2-c499-4107-b6b5-d9379e5427a4', false, true, 'ON_HOLD_AWAITING_ASSESSMENT','WITHDRAWN');
+
+insert into referral_status_transitions values ('7e5a4eff-472d-4b86-9484-ba78f7f23761', false, true, 'ON_HOLD_ASSESSMENT_STARTED','ASSESSMENT_STARTED');
+insert into referral_status_transitions values ('6a066fb7-dd3a-4e6a-a6d0-3f4a82b5a62f', false, true, 'ON_HOLD_ASSESSMENT_STARTED','WITHDRAWN');

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -435,6 +435,43 @@ paths:
         404:
           description: The referral does not exist
 
+  /referrals/{id}/status-transitions:
+    get:
+      tags:
+        - Referrals
+      summary: Retrieve the next available status transitions for a referral
+      operationId: getNextStatusTransitions
+      parameters:
+        - name: id
+          in: path
+          description: The id (UUID) of a referral
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: ptUser
+          in: query
+          description: is the user a Programme Team user
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        200:
+          description: The list of statuses a referral can move on to
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ReferralStatusRefData'
+        401:
+          description: The request was unauthorised
+        403:
+          description: Forbidden.  The client is not authorised to access this referral.
+        404:
+          description: The referral does not exist
+
   /referrals/{id}/status:
     put:
       summary: Change a referral's status
@@ -505,6 +542,13 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: updatePerson
+          in: query
+          description: parameter to decide whether to update the local person data
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         201:
           description: A list of status history
@@ -1734,6 +1778,10 @@ components:
           type: string
         notes:
           type: string
+        ptUser:
+          type: boolean
+          description: is the user a pt user
+          default: false
       required:
         - status
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.reposito
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferrerUserRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.AuditService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralReferenceDataService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralStatusHistoryService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OfferingEntityFactory
@@ -80,6 +81,9 @@ class ReferralServiceTest {
 
   @MockK(relaxed = true)
   private lateinit var referralStatusReasonRepository: ReferralStatusReasonRepository
+
+  @MockK(relaxed = true)
+  private lateinit var referralReferenceDataService: ReferralReferenceDataService
 
   @InjectMockKs
   private lateinit var referralService: ReferralService


### PR DESCRIPTION
## Context

Added a simple workflow so that the next status of a referral can be sought depending on whether or not the user is a PT user. Also added validation to the existing update referral so that you can't change to an invalid status. 

Also added updatePerson flag to the status-history endpoint since this is now the entry point into viewing a referral

<!-- Is there a Trello ticket you can link to? -->
Trello --> [1401](https://trello.com/c/yoW6RGxe/1401-create-status-workflow)

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
