### PR TITLE
Added status flow diagram markup

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/StatusFlowDiagram.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/StatusFlowDiagram.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.controller
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusTransitionRepository
+
+@RestController
+@RequestMapping("status-transition-diagram")
+class StatusFlowDiagram(
+  private val transitionRepository: ReferralStatusTransitionRepository,
+  private val statusRepository: ReferralStatusRepository,
+) {
+  @GetMapping
+  fun getStatusFlowDiagram(): String {
+    val transitions = transitionRepository.findAll()
+    val statuses = statusRepository.findAll()
+
+    val nodeDefinitions = statuses.map { "${it.code} [shape=box fillcolor=\"${it.boxColour()}\"];" }
+    val ptlines = transitions.filter { it.ptUser }.map { "${it.fromStatus.code} -> ${it.toStatus.code};" }
+    val pomlines = transitions.filter { it.pomUser }.map { "${it.fromStatus.code} -> ${it.toStatus.code};" }
+
+    val content =
+      """
+        ${nodeDefinitions.joinToString("\n")}
+        edge [color=red];
+        ${ptlines.joinToString("\n")}
+        edge [color=blue];
+        ${pomlines.joinToString("\n")}
+      """.trimIndent()
+
+    return """
+      digraph StatusFlow {
+      node [style=filled fillcolor="#f8f8f8"]
+      subgraph legend {
+        label = "Legend";
+        PT [label="PT Transition", color=red, shape=box];
+        POM [label="POM Transition", color=blue, shape=box];
+        START [label="Start status", shape=box fillcolor="#DAF7A6"];
+        END [label="End status", shape=box fillcolor="#FC6109"];
+      }
+      $content
+      }
+    """.trimIndent()
+  }
+
+  fun ReferralStatusEntity.boxColour(): String {
+    if (draft) return "#DAF7A6"
+    if (closed) return "#FC6109"
+    return "#f8f8f8"
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
@@ -25,18 +25,18 @@ private const val REASON_DUPLICATE = "W_DUPLICATE"
 class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
 
   val withdrawnStatusExpected = ReferralStatusRefData(
-      code = WITHDRAWN,
-      description = "Withdrawn",
-      colour = "light-grey",
-      draft = false,
-      closed = true,
+    code = WITHDRAWN,
+    description = "Withdrawn",
+    colour = "light-grey",
+    draft = false,
+    closed = true,
   )
   val categoryExpected =
     ReferralStatusCategory(code = CATEGORY_ADMIN, description = "Administrative error", referralStatusCode = WITHDRAWN)
   val reasonExpected = ReferralStatusReason(
-      code = REASON_DUPLICATE,
-      description = "Duplicate referral",
-      referralCategoryCode = CATEGORY_ADMIN,
+    code = REASON_DUPLICATE,
+    description = "Duplicate referral",
+    referralCategoryCode = CATEGORY_ADMIN,
   )
 
   @Test
@@ -98,7 +98,6 @@ class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
     response.shouldNotBeNull()
     response shouldBeEqual reasonExpected
   }
-
 
   @Test
   fun `get diagram`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
@@ -24,9 +24,20 @@ private const val REASON_DUPLICATE = "W_DUPLICATE"
 @Import(JwtAuthHelper::class)
 class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
 
-  val withdrawnStatusExpected = ReferralStatusRefData(code = WITHDRAWN, description = "Withdrawn", colour = "light-grey", draft = false, closed = true)
-  val categoryExpected = ReferralStatusCategory(code = CATEGORY_ADMIN, description = "Administrative error", referralStatusCode = WITHDRAWN)
-  val reasonExpected = ReferralStatusReason(code = REASON_DUPLICATE, description = "Duplicate referral", referralCategoryCode = CATEGORY_ADMIN)
+  val withdrawnStatusExpected = ReferralStatusRefData(
+      code = WITHDRAWN,
+      description = "Withdrawn",
+      colour = "light-grey",
+      draft = false,
+      closed = true,
+  )
+  val categoryExpected =
+    ReferralStatusCategory(code = CATEGORY_ADMIN, description = "Administrative error", referralStatusCode = WITHDRAWN)
+  val reasonExpected = ReferralStatusReason(
+      code = REASON_DUPLICATE,
+      description = "Duplicate referral",
+      referralCategoryCode = CATEGORY_ADMIN,
+  )
 
   @Test
   fun `get all referral statuses`() {
@@ -88,6 +99,16 @@ class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
     response shouldBeEqual reasonExpected
   }
 
+
+  @Test
+  fun `get diagram`() {
+    mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
+
+    val response = getStatusTransitionDiagram()
+    response.shouldNotBeNull()
+    println(response)
+  }
+
   fun getReferralStatuses() =
     webTestClient
       .get()
@@ -108,6 +129,17 @@ class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
       .expectBody<ReferralStatusRefData>()
+      .returnResult().responseBody!!
+
+  fun getStatusTransitionDiagram() =
+    webTestClient
+      .get()
+      .uri("/status-transition-diagram")
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<String>()
       .returnResult().responseBody!!
 
   fun getReferralStatusCategories(statusCode: String) =


### PR DESCRIPTION
## Context

Added an endpoint to generate the markup for a status flow diagram:

![status_flow](https://github.com/ministryofjustice/hmpps-accredited-programmes-api/assets/78762879/3e0a72ea-6914-47e6-a177-786ed2553a16)

the endpoint to generate the markup is /status-transition-diagram

paste the contents of the file into: http://magjac.com/graphviz-visual-editor/

or to generate an image save this as status_flow.dot

install graph viz: `brew install graphviz`

then run 

`dot -Tpng status_flow.dot -o status_flow.png `

to save the image

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
