### PR TITLE
returning business exception

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -74,7 +74,7 @@ constructor(
     val offering = offeringRepository.findById(offeringId)
       .orElseThrow { Exception("Offering not found") }
 
-    if (enabledOrganisationService.getEnabledOrganisation(offering.organisationId) != null) {
+    if (enabledOrganisationService.getEnabledOrganisation(offering.organisationId) == null) {
       throw BusinessException("Organisation ${offering.organisationId} not enabled for referrals")
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -74,10 +74,8 @@ constructor(
     val offering = offeringRepository.findById(offeringId)
       .orElseThrow { Exception("Offering not found") }
 
-    val disabledOrganisation = enabledOrganisationService.getEnabledOrganisation(offering.organisationId) == null
-
-    if (disabledOrganisation) {
-      throw Exception("organisation not enabled for referrals")
+    if (enabledOrganisationService.getEnabledOrganisation(offering.organisationId) != null) {
+      throw BusinessException("Organisation ${offering.organisationId} not enabled for referrals")
     }
 
     createOrUpdatePerson(prisonNumber)


### PR DESCRIPTION
## Context

Rather than return a runtime exception - return a business exception which could in the future be handled by the front end - at the moment Runtime errors cause a 500 error in the front end. Where as the Business Exception will cause a 400 error with an explanation. 

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
