### PR TITLE
1418 - audience background colour to be read from backend

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
@@ -41,6 +41,7 @@ data class CourseEntity(
   val offerings: MutableSet<OfferingEntity> = mutableSetOf(),
 
   var audience: String,
+  var audience_colour: String?,
   var withdrawn: Boolean = false,
 ) {
   fun addOffering(offering: OfferingEntity) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/CourseUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/CourseUpdate.kt
@@ -5,5 +5,6 @@ data class CourseUpdate(
   val description: String,
   val identifier: String,
   val audience: String,
+  val audienceColour: String?,
   val alternateName: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/RecordTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/RecordTransformers.kt
@@ -20,6 +20,7 @@ fun CourseEntity.toApi(): Course = Course(
   alternateName = alternateName,
   coursePrerequisites = prerequisites.map(PrerequisiteEntity::toApi),
   audience = audience,
+  audienceColour = audience_colour,
 )
 
 fun CourseEntity.toCourseRecord(): CourseRecord = CourseRecord(
@@ -28,6 +29,7 @@ fun CourseEntity.toCourseRecord(): CourseRecord = CourseRecord(
   alternateName = alternateName,
   identifier = identifier,
   audience = audience,
+  audienceColour = audience_colour,
 )
 
 fun PrerequisiteEntity.toApi(): CoursePrerequisite = CoursePrerequisite(
@@ -58,6 +60,7 @@ fun CourseRecord.toDomain(): CourseUpdate = CourseUpdate(
   identifier = identifier.trim(),
   description = description.trim(),
   audience = audience,
+  audienceColour = audienceColour?.let { it.trim().ifEmpty { null } },
   alternateName = alternateName?.trim(),
 )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
@@ -68,6 +68,7 @@ constructor(
           description = update.description,
           alternateName = update.alternateName,
           audience = update.audience,
+          audience_colour = update.audienceColour,
         )
       }
     }

--- a/src/main/resources/db/migration/V53__add_audience_color_to_course.sql
+++ b/src/main/resources/db/migration/V53__add_audience_color_to_course.sql
@@ -1,0 +1,9 @@
+ALTER TABLE COURSE
+    ADD COLUMN audience_colour text;
+
+update COURSE set audience_colour = 'turquoise' where audience = 'Extremism offence';
+update COURSE set audience_colour = 'purple' where audience = 'Gang offence';
+update COURSE set audience_colour = 'pink' where audience = 'General offence';
+update COURSE set audience_colour = 'yellow' where audience = 'General violence offence';
+update COURSE set audience_colour = 'green' where audience = 'Intimate partner violence offence';
+update COURSE set audience_colour = 'orange' where audience = 'Sexual offence';

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1493,6 +1493,9 @@ components:
         audience:
           type: string
           example: 'Gang offence'
+        audienceColour:
+          type: string
+          example: 'purple'
       required:
         - id
         - name
@@ -1513,6 +1516,9 @@ components:
           type: string
         audience:
           type: string
+        audienceColour:
+          type: string
+          example: 'purple'
         comments:
           type: string
       required:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseEntityFactory.kt
@@ -21,6 +21,7 @@ class CourseEntityFactory : Factory<CourseEntity> {
   private var prerequisites: Yielded<MutableSet<PrerequisiteEntity>> = { mutableSetOf() }
   private var offerings: Yielded<MutableSet<OfferingEntity>> = { mutableSetOf() }
   private var audience: Yielded<String> = { randomUppercaseString() }
+  private var audienceColour: Yielded<String> = { randomUppercaseString() }
   private var withdrawn: Yielded<Boolean> = { false }
 
   fun withId(id: UUID?) = apply {
@@ -64,6 +65,7 @@ class CourseEntityFactory : Factory<CourseEntity> {
     prerequisites = this.prerequisites(),
     offerings = this.offerings(),
     audience = this.audience(),
+    audience_colour = this.audienceColour(),
     withdrawn = this.withdrawn(),
   )
 }
@@ -73,6 +75,7 @@ class CourseUpdateFactory : Factory<CourseUpdate> {
   private var identifier: Yielded<String> = { randomUppercaseString() }
   private var description: Yielded<String> = { randomSentence() }
   private var audience: Yielded<String> = { randomUppercaseString() }
+  private var audienceColour: Yielded<String> = { randomUppercaseString() }
   private var alternateName: Yielded<String?> = { null }
   private var referable: Yielded<Boolean> = { true }
 
@@ -84,11 +87,16 @@ class CourseUpdateFactory : Factory<CourseUpdate> {
     this.audience = { audience }
   }
 
+  fun withAudienceColour(audienceColour: String) = apply {
+    this.audienceColour = { audienceColour }
+  }
+
   override fun produce() = CourseUpdate(
     name = this.name(),
     description = this.description(),
     identifier = this.identifier(),
     audience = this.audience(),
+    audienceColour = this.audienceColour(),
     alternateName = this.alternateName(),
   )
 }


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
https://trello.com/c/sEF8y4PT/1418-api-changes-to-courses-offerings-endpoints

<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

* Add a new field to store background colour of audience
* update existing courses withe the colour
* Add the `audience_colour` to the course response

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
