### PR TITLE
added hold and release flags to referral status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusEntity.kt
@@ -22,6 +22,8 @@ data class ReferralStatusEntity(
   val active: Boolean,
   val draft: Boolean,
   val closed: Boolean,
+  val hold: Boolean,
+  val release: Boolean,
 )
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferenceDataTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferenceDataTransformer.kt
@@ -4,4 +4,16 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Refer
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusEntity
 
 fun ReferralStatusEntity.toModel() =
-  ReferralStatusRefData(code = code, description = description, colour = colour, hintText = hintText, confirmationText = confirmationText, closed = closed, draft = draft, hasNotes = hasNotes, hasConfirmation = hasConfirmation)
+  ReferralStatusRefData(
+    code = code,
+    description = description,
+    colour = colour,
+    hintText = hintText,
+    confirmationText = confirmationText,
+    closed = closed,
+    draft = draft,
+    hasNotes = hasNotes,
+    hasConfirmation = hasConfirmation,
+    hold = hold,
+    release = release,
+  )

--- a/src/main/resources/db/migration/V54__Add_hold_release_to_status.sql
+++ b/src/main/resources/db/migration/V54__Add_hold_release_to_status.sql
@@ -1,0 +1,13 @@
+ALTER TABLE referral_status ADD COLUMN hold boolean default false;
+ALTER TABLE referral_status ADD COLUMN release boolean default false;
+
+update referral_status set hold = true where code =  'ON_HOLD_REFERRAL_SUBMITTED';
+update referral_status set hold = true where code =  'ON_HOLD_ASSESSMENT_STARTED';
+update referral_status set hold = true where code =  'ON_HOLD_AWAITING_ASSESSMENT';
+update referral_status set hold = true where code =  'SUITABLE_NOT_READY';
+
+update referral_status set release = true where code = 'REFERRAL_SUBMITTED';
+update referral_status set release = true where code = 'ASSESSMENT_STARTED';
+update referral_status set release = true where code = 'AWAITING_ASSESSMENT';
+update referral_status set release = true where code = 'ASSESSED_AS_SUITABLE';
+

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -2346,6 +2346,12 @@ components:
         draft:
           description: flag to show this is a draft status
           type: boolean
+        hold:
+          description: flag to show this is a hold status
+          type: boolean
+        release:
+          description: flag to show this is a release status
+          type: boolean
       required:
         - code
         - description

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -320,8 +320,30 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     val statuses = getReferralTransitions(referralCreated.referralId)
     statuses.size shouldBeEqual 2
 
-    val withdrawnStatus = ReferralStatusRefData(code = REFERRAL_WITHDRAWN, description = REFERRAL_WITHDRAWN_DESCRIPTION, colour = REFERRAL_WITHDRAWN_COLOUR, hintText = REFERRAL_WITHDRAWN_HINT, hasNotes = true, hasConfirmation = false, closed = true, draft = false)
-    val onHoldStatus = ReferralStatusRefData(code = ON_HOLD_REFERRAL_SUBMITTED, description = ON_HOLD_REFERRAL_SUBMITTED_DESCRIPTION, colour = ON_HOLD_REFERRAL_SUBMITTED_COLOUR, hintText = ON_HOLD_REFERRAL_SUBMITTED_HINT, hasNotes = true, hasConfirmation = false, closed = false, draft = false)
+    val withdrawnStatus = ReferralStatusRefData(
+      code = REFERRAL_WITHDRAWN,
+      description = REFERRAL_WITHDRAWN_DESCRIPTION,
+      colour = REFERRAL_WITHDRAWN_COLOUR,
+      hintText = REFERRAL_WITHDRAWN_HINT,
+      hasNotes = true,
+      hasConfirmation = false,
+      closed = true,
+      draft = false,
+      hold = false,
+      release = false,
+    )
+    val onHoldStatus = ReferralStatusRefData(
+      code = ON_HOLD_REFERRAL_SUBMITTED,
+      description = ON_HOLD_REFERRAL_SUBMITTED_DESCRIPTION,
+      colour = ON_HOLD_REFERRAL_SUBMITTED_COLOUR,
+      hintText = ON_HOLD_REFERRAL_SUBMITTED_HINT,
+      hasNotes = true,
+      hasConfirmation = false,
+      closed = false,
+      draft = false,
+      hold = true,
+      release = false,
+    )
 
     statuses shouldContainAnyOf listOf(withdrawnStatus, onHoldStatus)
   }


### PR DESCRIPTION
## Context

Add flags to the referral statuses to indicate that they are hold and release statuses.

This is to help the front end to determine whether or not to display the ‘put on hold’ or ‘release from hold’ buttons.

Need to add these flags to each endpoint that returns a status - so:

/referrals/{id}/status-transitions

/reference-data/referral-statuses

/reference-data/referral-statuses/{code}



<!-- Is there a Trello ticket you can link to? -->
[1465](https://trello.com/c/9yrFbAa8/1465-api-add-hold-and-release-flags-to-referral-status)
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
