### PR TITLE
Added additional descriptions and hint text

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusTransitionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusTransitionEntity.kt
@@ -28,6 +28,8 @@ class ReferralStatusTransitionEntity(
   @ManyToOne
   @JoinColumn(name = "transitionToStatus")
   val toStatus: ReferralStatusEntity,
+  val description: String?,
+  val hintText: String?,
 )
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferenceDataTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferenceDataTransformer.kt
@@ -3,12 +3,12 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transf
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.ReferralStatusRefData
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusEntity
 
-fun ReferralStatusEntity.toModel() =
+fun ReferralStatusEntity.toModel(altDescription: String?, altHintText: String?) =
   ReferralStatusRefData(
     code = code,
-    description = description,
+    description = altDescription ?: description,
     colour = colour,
-    hintText = hintText,
+    hintText = altHintText ?: hintText,
     confirmationText = confirmationText,
     closed = closed,
     draft = draft,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralReferenceDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralReferenceDataService.kt
@@ -87,9 +87,9 @@ class ReferralReferenceDataService(
 
   fun getNextStatusTransitions(currentStatus: String, ptRole: Boolean = false): List<ReferralStatusRefData> {
     return if (ptRole) {
-      referralStatusTransitionRepository.getNextPTTransitions(currentStatus).map { it.toStatus.toModel() }
+      referralStatusTransitionRepository.getNextPTTransitions(currentStatus).map { it.toStatus.toModel(it.description, it.hintText) }
     } else {
-      referralStatusTransitionRepository.getNextPOMTransitions(currentStatus).map { it.toStatus.toModel() }
+      referralStatusTransitionRepository.getNextPOMTransitions(currentStatus).map { it.toStatus.toModel(it.description, it.hintText) }
     }
   }
 }

--- a/src/main/resources/db/migration/V56__Add_description_hint_to_status_transitions.sql
+++ b/src/main/resources/db/migration/V56__Add_description_hint_to_status_transitions.sql
@@ -1,0 +1,35 @@
+ALTER TABLE referral_status_transitions ADD COLUMN hint_text text;
+ALTER TABLE referral_status_transitions ADD COLUMN description text;
+
+delete from referral_status_transitions where transition_from_status = 'AWAITING_ASSESSMENT' and transition_to_status = 'NOT_ELIGIBLE';
+
+update referral_status_transitions set description = 'On hold' where transition_from_status = 'REFERRAL_SUBMITTED' and transition_to_status = 'ON_HOLD_REFERRAL_SUBMITTED';
+
+update referral_status_transitions set description = 'On hold' where transition_from_status = 'AWAITING_ASSESSMENT' and transition_to_status = 'ON_HOLD_AWAITING_ASSESSMENT';
+
+update referral_status_transitions set description = 'Assessed as suitable and ready to continue' where transition_from_status = 'ASSESSMENT_STARTED' and transition_to_status = 'ASSESSED_SUITABLE';
+update referral_status_transitions set hint_text = 'This person meets the suitability criteria. They can now be considered to join the programme.' where transition_from_status = 'ASSESSMENT_STARTED' and transition_to_status = 'ASSESSED_SUITABLE';
+
+update referral_status_transitions set description = 'Assessed as suitable but not ready' where transition_from_status = 'ASSESSMENT_STARTED' and transition_to_status = 'SUITABLE_NOT_READY';
+update referral_status_transitions set hint_text = 'This person meets the suitability criteria but is not ready to start the programme. The referral will be paused until they are ready.' where transition_from_status = 'ASSESSMENT_STARTED' and transition_to_status = 'SUITABLE_NOT_READY';
+
+update referral_status_transitions set description = 'On hold - assessment not completed' where transition_from_status = 'ASSESSMENT_STARTED' and transition_to_status = 'ON_HOLD_ASSESSMENT_STARTED';
+update referral_status_transitions set hint_text = 'The assessment has not been completed, but the referral will be paused until the person is ready to continue.' where transition_from_status = 'ASSESSMENT_STARTED' and transition_to_status = 'ON_HOLD_ASSESSMENT_STARTED';
+
+update referral_status_transitions set description = 'Assessed as suitable but not ready' where transition_from_status = 'ASSESSED_SUITABLE' and transition_to_status = 'SUITABLE_NOT_READY';
+update referral_status_transitions set hint_text = 'This person meets the suitability criteria but is not ready to start the programme. The referral wil be paused until they are ready.' where transition_from_status = 'ASSESSED_SUITABLE' and transition_to_status = 'SUITABLE_NOT_READY';
+
+update referral_status_transitions set description = 'Assessed as suitable and ready' where transition_from_status = 'ON_PROGRAMME' and transition_to_status = 'ASSESSED_SUITABLE';
+update referral_status_transitions set hint_text = 'This person has been deselected. However, they still meet the suitability criteria and can be considered to join a programme when it runs again.' where transition_from_status = 'ON_PROGRAMME' and transition_to_status = 'ASSESSED_SUITABLE';
+
+update referral_status_transitions set description = 'Assessed as suitable but not ready' where transition_from_status = 'ON_PROGRAMME' and transition_to_status = 'SUITABLE_NOT_READY';
+update referral_status_transitions set hint_text = 'This person meet the suitability criteria but is not ready to start the programme. The referral will be paused until they are ready.' where transition_from_status = 'ON_PROGRAMME' and transition_to_status = 'SUITABLE_NOT_READY';
+
+update referral_status_transitions set description = 'Assessed as suitable and ready and ready to continue' where transition_from_status = 'ASSESSED_SUITABLE' and transition_to_status = 'SUITABLE_NOT_READY';
+update referral_status_transitions set hint_text = 'The referral will resume because the person is suitable and ready to be considered for a programme.' where transition_from_status = 'ASSESSED_SUITABLE' and transition_to_status = 'SUITABLE_NOT_READY';
+
+update referral_status_transitions set description = 'Assessed as suitable and ready and ready to continue' where transition_from_status = 'ASSESSED_STARTED' and transition_to_status = 'ASSESSED_SUITABLE';
+update referral_status_transitions set hint_text = 'This person meets the suitability criteria. they can now be considered to join this programme.' where transition_from_status = 'ASSESSED_STARTED' and transition_to_status = 'ASSESSED_SUITABLE';
+
+update referral_status_transitions set description = 'Assessed as suitable but not ready' where transition_from_status = 'ASSESSED_STARTED' and transition_to_status = 'SUITABLE_NOT_READY';
+update referral_status_transitions set hint_text = 'This person meet the suitability criteria but is not ready to start the programme. The referral will be paused until they are ready.' where transition_from_status = 'SUITABLE_NOT_READY' and transition_to_status = 'ASSESSED_SUITABLE';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -397,6 +397,17 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       "Deselect and close referral",
       "Deselect and keep referral open",
     )
+
+    // check that the follow on statuses are correct and that the alternative descriptions and hint text have been set
+    val deselectStatuses = getReferralTransitions(referralCreated.referralId, ptUser = true, deselectAndKeepOpen = true)
+    val assessedSuitable = deselectStatuses.first { it.code == "ASSESSED_SUITABLE" }
+    val assessedSuitableNotReady = deselectStatuses.first { it.code == "SUITABLE_NOT_READY" }
+
+    assessedSuitable.description shouldBe "Assessed as suitable and ready"
+    assessedSuitable.hintText shouldBe "This person has been deselected. However, they still meet the suitability criteria and can be considered to join a programme when it runs again."
+
+    assessedSuitableNotReady.description shouldBe "Assessed as suitable but not ready"
+    assessedSuitableNotReady.hintText shouldBe "This person meet the suitability criteria but is not ready to start the programme. The referral will be paused until they are ready."
   }
 
   @Test
@@ -547,10 +558,10 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     }
   }
 
-  fun getReferralTransitions(referralId: UUID, ptUser: Boolean = false) =
+  fun getReferralTransitions(referralId: UUID, ptUser: Boolean = false, deselectAndKeepOpen: Boolean = false) =
     webTestClient
       .get()
-      .uri("/referrals/$referralId/status-transitions?ptUser=$ptUser")
+      .uri("/referrals/$referralId/status-transitions?ptUser=$ptUser&deselectAndKeepOpen=$deselectAndKeepOpen")
       .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .accept(MediaType.APPLICATION_JSON)
       .exchange()


### PR DESCRIPTION
## Context

Currently there is a ‘hint text’ associated with the referral status. Sometimes during status transitions this text is different depending on what the status transition is.

Need to present the UI with this alternative hint text when it is present for the chosen transition.


<!-- Is there a Trello ticket you can link to? -->

[1464](https://trello.com/c/qIYcbWpo/1464-api-create-alternative-hint-text-for-status-transitions)
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
