### PR TITLE
Initial attempt at status ordering

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusEntity.kt
@@ -24,6 +24,7 @@ data class ReferralStatusEntity(
   val closed: Boolean,
   val hold: Boolean,
   val release: Boolean,
+  val defaultOrder: Int,
 )
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusTransitionEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusTransitionEntity.kt
@@ -41,6 +41,7 @@ interface ReferralStatusTransitionRepository : JpaRepository<ReferralStatusTrans
       select st from ReferralStatusTransitionEntity st
       where st.fromStatus.code = :fromStatus
       and st.ptUser = true
+      order by st.toStatus.defaultOrder asc
     """,
   )
   fun getNextPTTransitions(fromStatus: String): List<ReferralStatusTransitionEntity>
@@ -51,6 +52,7 @@ interface ReferralStatusTransitionRepository : JpaRepository<ReferralStatusTrans
       select st from ReferralStatusTransitionEntity st
       where st.fromStatus.code = :fromStatus
       and st.pomUser = true
+      order by st.toStatus.defaultOrder asc
     """,
   )
   fun getNextPOMTransitions(fromStatus: String): List<ReferralStatusTransitionEntity>

--- a/src/main/resources/db/migration/V57__Add_default_order_to_status.sql
+++ b/src/main/resources/db/migration/V57__Add_default_order_to_status.sql
@@ -1,0 +1,21 @@
+ALTER TABLE referral_status ADD COLUMN default_order smallint;
+
+update referral_status set default_order = 1 where code = 'REFERRAL_SUBMITTED';
+update referral_status set default_order = 1 where code = 'ASSESSMENT_STARTED';
+update referral_status set default_order = 1 where code = 'AWAITING_ASSESSMENT';
+update referral_status set default_order = 1 where code = 'REFERRAL_STARTED';
+update referral_status set default_order = 1 where code = 'DESELECTED';
+update referral_status set default_order = 1 where code = 'ASSESSED_SUITABLE';
+update referral_status set default_order = 1 where code = 'ON_PROGRAMME';
+update referral_status set default_order = 1 where code = 'PROGRAMME_COMPLETE';
+update referral_status set default_order = 20 where code = 'NOT_ELIGIBLE';
+update referral_status set default_order = 40 where code = 'SUITABLE_NOT_READY';
+update referral_status set default_order = 40 where code = 'ON_HOLD_REFERRAL_SUBMITTED';
+update referral_status set default_order = 40 where code = 'ON_HOLD_ASSESSMENT_STARTED';
+update referral_status set default_order = 40 where code = 'ON_HOLD_AWAITING_ASSESSMENT';
+update referral_status set default_order = 50 where code = 'NOT_SUITABLE';
+update referral_status set default_order = 100 where code = 'WITHDRAWN';
+
+
+update referral_status_transitions set description = 'Remove hold' where transition_from_status = 'ON_HOLD_AWAITING_ASSESSMENT' and transition_to_status = 'AWAITING_ASSESSMENT';
+update referral_status_transitions set hint_text = 'The referral will resume because the person is ready to continue.' where transition_from_status = 'AWAITING_ASSESSMENT' and transition_to_status = 'ASSESSED_SUITABLE';


### PR DESCRIPTION
## Context

An attempt at ordering statuses. Have gone with a weighting approach rather than specific ordering since statuses can appear on any lists. but as a rule of thumb withdrawn is at the bottom, then not suitable, on hold, not eligible then everything else. 

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
