### PR TITLE
fixed to take notice of ptUser flag

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -210,20 +210,28 @@ constructor(
       primaryDescription = "Submitting this will change the status to ${chosenStatus.description.lowercase()}.",
       secondaryHeading = "Confirm status change",
       secondaryDescription = chosenStatus.confirmationText,
-      warningText = if (chosenStatus.closed == true) {
-        "Submitting this will close the referral."
-      } else if (chosenStatus.hold == true) {
-        "Submitting this will pause the referral."
-      } else if (chosenStatus.release == true) {
-        "This will resume the referral."
-      } else {
-        ""
+      warningText = when {
+        chosenStatus.closed == true -> {
+          "Submitting this will close the referral."
+        }
+
+        chosenStatus.hold == true -> {
+          "Submitting this will pause the referral."
+        }
+
+        chosenStatus.release == true -> {
+          "This will resume the referral."
+        }
+
+        else -> {
+          ""
+        }
       },
       hasConfirmation = chosenStatus.hasConfirmation,
     )
 
     // now see if there are any specific confirmation fields for this transition.
-    val statusTransition = referenceDataService.getStatusTransition(referral.status, chosenStatusCode)
+    val statusTransition = referenceDataService.getStatusTransition(referral.status, chosenStatusCode, ptUser)
     if (statusTransition != null) {
       defaultConfirmationFields = defaultConfirmationFields.copy(
         primaryHeading = statusTransition.primaryHeading ?: defaultConfirmationFields.primaryHeading,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -363,6 +363,41 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     confirmationFields.warningText shouldBe "Submitting this will pause the referral."
   }
 
+
+  @Test
+  fun `Get referral confirmation text assessment started to suitable not ready`() {
+    val course = getAllCourses().first()
+    val offering = getAllOfferingsForCourse(course.id).first()
+    val referralCreated = createReferral(offering.id)
+
+    val referralStatusUpdate1 = ReferralStatusUpdate(
+      status = REFERRAL_SUBMITTED,
+      ptUser = true,
+    )
+    updateReferralStatus(referralCreated.referralId, referralStatusUpdate1)
+    val referralStatusUpdate2 = ReferralStatusUpdate(
+      status = "AWAITING_ASSESSMENT",
+      ptUser = true,
+    )
+    updateReferralStatus(referralCreated.referralId, referralStatusUpdate2)
+
+    val referralStatusUpdate3 = ReferralStatusUpdate(
+      status = "ASSESSMENT_STARTED",
+      ptUser = true,
+    )
+    updateReferralStatus(referralCreated.referralId, referralStatusUpdate3)
+
+
+    val confirmationFields = getConfirmationText(
+      referralId = referralCreated.referralId,
+      chosenStatusCode = "SUITABLE_NOT_READY",
+      ptUser = true,
+    )
+
+    confirmationFields.primaryHeading shouldBe "Pause referral: suitable but not ready"
+    confirmationFields.primaryDescription shouldBe "The referral will be paused until the person is ready to continue."
+  }
+
   @Test
   fun `Get referral status transitions for on programme`() {
     val course = getAllCourses().first()
@@ -581,7 +616,12 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       .expectBody<List<ReferralStatusRefData>>()
       .returnResult().responseBody!!
 
-  fun getConfirmationText(referralId: UUID, chosenStatusCode: String, ptUser: Boolean = false, deselectAndKeepOpen: Boolean = false) =
+  fun getConfirmationText(
+    referralId: UUID,
+    chosenStatusCode: String,
+    ptUser: Boolean = false,
+    deselectAndKeepOpen: Boolean = false,
+  ) =
     webTestClient
       .get()
       .uri("/referrals/$referralId/confirmation-text/$chosenStatusCode?ptUser=$ptUser&deselectAndKeepOpen=$deselectAndKeepOpen")
@@ -593,7 +633,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       .returnResult().responseBody!!
 
   @Test
-  fun `Retrieving a list of draft referral views for an organisation using regerralGroup should return 200 with correct body`() {
+  fun `Retrieving a list of draft referral views for an organisation using referral group should return 200 with correct body`() {
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
     val course = getAllCourses().first()
     val offering = getAllOfferingsForCourse(course.id).first()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -363,7 +363,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
     confirmationFields.warningText shouldBe "Submitting this will pause the referral."
   }
 
-
   @Test
   fun `Get referral confirmation text assessment started to suitable not ready`() {
     val course = getAllCourses().first()
@@ -386,7 +385,6 @@ class ReferralIntegrationTest : IntegrationTestBase() {
       ptUser = true,
     )
     updateReferralStatus(referralCreated.referralId, referralStatusUpdate3)
-
 
     val confirmationFields = getConfirmationText(
       referralId = referralCreated.referralId,


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
