### PR TITLE
Added specific rules for deselection

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -242,6 +242,17 @@ constructor(
       )
     }
 
+    // if current status is ON_PROGRAMME and deselect and keep open option is checked then change the status transitions again to the bespoke ones:
+    if ((referral.status == "ON_PROGRAMME") && deselectAndKeepOpen && chosenStatusCode == "DESELECTED") {
+      defaultConfirmationFields = ConfirmationFields(
+        primaryHeading = "Deselection: keep referral open",
+        primaryDescription = "This person cannot complete the programme now. They may be able to join or restart in the future.",
+        secondaryHeading = "Choose the deselection status",
+        secondaryDescription = "The referral will be paused at this status, for example Deselected - assessed as suitable.",
+        warningText = "",
+      )
+    }
+
     return ResponseEntity.ok(
       defaultConfirmationFields,
     )

--- a/src/main/resources/db/migration/V63__Status_transition_withdraw_confirm_text.sql
+++ b/src/main/resources/db/migration/V63__Status_transition_withdraw_confirm_text.sql
@@ -1,0 +1,21 @@
+update referral_status_transitions set primary_heading = 'Withdraw referral' where  transition_to_status = 'WITHDRAWN';
+update referral_status_transitions set primary_description = 'If you withdraw the referral the referral will be closed.' where transition_to_status = 'WITHDRAWN';
+update referral_status_transitions set secondary_heading = 'Give a reason' where  transition_to_status = 'WITHDRAWN';
+update referral_status_transitions set secondary_description = 'Provide more information about the reason for withdrawing this referral.' where transition_to_status = 'WITHDRAWN';
+
+update referral_status_transitions set primary_heading = 'Deselect person: close referral' where  transition_to_status = 'DESELECTED';
+update referral_status_transitions set primary_description = 'This person cannot continue this programme. The referral will be closed.' where transition_to_status = 'DESELECTED';
+update referral_status_transitions set secondary_heading = 'Give a reason' where  transition_to_status = 'DESELECTED';
+update referral_status_transitions set secondary_description = 'Give more information about the reason for deselecting this person.' where transition_to_status = 'DESELECTED';
+
+update referral_status_transitions set primary_heading = 'Deselect person: assessed as suitable' where transition_from_status = 'PROGRAMME_COMPLETE' and transition_to_status = 'ASSESSED_SUITABLE';
+update referral_status_transitions set primary_description = 'This person cannot complete the programme now. They may be able to join or restart when the programme runs again.' where transition_from_status = 'PROGRAMME_COMPLETE' and transition_to_status = 'ASSESSED_SUITABLE';
+update referral_status_transitions set secondary_heading = 'Give a reason' where transition_from_status = 'PROGRAMME_COMPLETE' and transition_to_status = 'ASSESSED_SUITABLE';
+update referral_status_transitions set secondary_description = 'Give more information about the reason for deselecting this person.' where transition_from_status = 'PROGRAMME_COMPLETE' and transition_to_status = 'ASSESSED_SUITABLE';
+update referral_status_transitions set warning_text = 'Submitting this will change the status to assessed as suitable.' where transition_from_status = 'PROGRAMME_COMPLETE' and transition_to_status = 'ASSESSED_SUITABLE';
+
+update referral_status_transitions set primary_heading = 'Deselect person: suitable but not ready' where transition_from_status = 'PROGRAMME_COMPLETE' and transition_to_status = 'SUITABLE_NOT_READY';
+update referral_status_transitions set primary_description = 'This person cannot complete the programme now. The referral will be paused until the person is ready to continue.' where transition_from_status = 'PROGRAMME_COMPLETE' and transition_to_status = 'SUITABLE_NOT_READY';
+update referral_status_transitions set secondary_heading = 'Give a reason' where transition_from_status = 'PROGRAMME_COMPLETE' and transition_to_status = 'SUITABLE_NOT_READY';
+update referral_status_transitions set secondary_description = 'Give more information about the reason for deselecting this person.' where transition_from_status = 'PROGRAMME_COMPLETE' and transition_to_status = 'SUITABLE_NOT_READY';
+update referral_status_transitions set warning_text = 'Submitting this will change the status to suitable not ready.' where transition_from_status = 'PROGRAMME_COMPLETE' and transition_to_status = 'SUITABLE_NOT_READY';


### PR DESCRIPTION
## Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
