### PR TITLE
added course display name for list screens

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ testing {
           testTask.configure {
             // Uncomment this next line if you need to debug tests in CI
             // testLogging.showStandardStreams = true
-            maxParallelForks = maxOf(1, Runtime.getRuntime().availableProcessors() - 1)
+            maxParallelForks = 1
             environment["pact_do_not_track"] = "true"
             environment["pact.provider.tag"] = environment["PACT_PROVIDER_TAG"]
             environment["pact.provider.version"] = environment["PACT_PROVIDER_VERSION"]

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
@@ -45,6 +45,7 @@ data class CourseEntity(
   var audience: String,
   var audienceColour: String?,
   var withdrawn: Boolean = false,
+  val listDisplayName: String? = null,
 ) {
   fun addOffering(offering: OfferingEntity) {
     offering.course = this

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/view/ReferralViewEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/view/ReferralViewEntity.kt
@@ -38,6 +38,7 @@ data class ReferralViewEntity(
   val audience: String?,
   var submittedOn: LocalDateTime? = null,
   val sentenceType: String?,
+  val listDisplayName: String?,
 )
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
@@ -57,4 +57,5 @@ fun ReferralViewEntity.toApi() = ReferralView(
   forename = forename,
   surname = surname,
   sentenceType = sentenceType,
+  listDisplayName = listDisplayName,
 )

--- a/src/main/resources/db/migration/V67__Update_course_name_referral_view.sql
+++ b/src/main/resources/db/migration/V67__Update_course_name_referral_view.sql
@@ -1,0 +1,50 @@
+ALTER TABLE COURSE
+    ADD COLUMN list_display_name text;
+
+update course set list_display_name = 'Becoming New Me Plus: general violence' where name = 'Becoming New Me Plus' and audience = 'General violence offence';
+update course set list_display_name = 'Becoming New Me Plus: intimate partner violence' where name = 'Becoming New Me Plus' and audience = 'Intimate partner violence offence';
+update course set list_display_name = 'Becoming New Me Plus: sexual offence' where name = 'Becoming New Me Plus' and audience = 'Sexual offence';
+
+update course set list_display_name = 'Kaizen: general violence' where name = 'Kaizen' and audience = 'General violence offence';
+update course set list_display_name = 'Kaizen: intimate partner violence' where name = 'Kaizen' and audience = 'Intimate partner violence offence';
+update course set list_display_name = 'Kaizen: sexual offence' where name = 'Kaizen' and audience = 'Sexual offence';
+
+update course set list_display_name = 'New Me Strengths: general violence' where name = 'New Me Strengths' and audience = 'General violence offence';
+update course set list_display_name = 'New Me Strengths: intimate partner violence' where name = 'New Me Strengths' and audience = 'Intimate partner violence offence';
+update course set list_display_name = 'New Me Strengths: sexual offence' where name = 'New Me Strengths ' and audience = 'Sexual offence';
+
+
+drop view referral_view;
+
+create or replace view referral_view as
+select r.referral_id,
+       r.prison_number,
+       p.forename,
+       p.surname,
+       p.conditional_release_date,
+       p.parole_eligibility_date,
+       p.tariff_expiry_date,
+       p.earliest_release_date,
+       p.earliest_release_date_type,
+       p.non_dto_release_date_type,
+       o.organisation_id,
+       org.name as organisation_name,
+       r.status,
+       rs.description as status_description,
+       rs.colour as status_colour,
+       r.referrer_username,
+       c.name as course_name,
+       c.audience,
+       r.submitted_on,
+       p.sentence_type,
+       case
+           when c.list_display_name is not null then c.list_display_name
+           else c.name
+           end as list_display_name
+
+from referral r
+         left outer join person p on r.prison_number = p.prison_number
+         left outer join offering o on o.offering_id = r.offering_id
+         left outer join course c on c.course_id = o.course_id
+         left outer join organisation org on org.code = o.organisation_id
+         left outer join referral_status rs on rs.code = r.status

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -1992,6 +1992,9 @@ components:
         sentenceType:
           type: string
           description: Sentence type description or 'Multiple sentences' if there are more than one
+        listDisplayName:
+          type: string
+          description: The course display name when it is in a list.
 
     ReferralStatusHistory:
       type: object

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralIntegrationTest.kt
@@ -590,6 +590,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
           forename = PRISONER_1.firstName,
           surname = PRISONER_1.lastName,
           sentenceType = "CJA03 Standard Determinate Sentence",
+
         ),
       ).forEach { referralView ->
         actualSummary.id shouldBe referralView.id
@@ -603,6 +604,7 @@ class ReferralIntegrationTest : IntegrationTestBase() {
         actualSummary.forename shouldBe referralView.forename
         actualSummary.surname shouldBe referralView.surname
         actualSummary.sentenceType shouldBe referralView.sentenceType
+        actualSummary.listDisplayName shouldBe referralView.courseName
       }
     }
   }


### PR DESCRIPTION
## Context

Updating the way course name is displayed in list screens so that the course has the strand information in it. 

<!-- Is there a Trello ticket you can link to? -->
[1529](https://trello.com/c/wEmxE1EZ/1529-fix-programme-name-in-referrer-case-list)
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
