### PR TITLE
added endpoint to get performance figures for status transitions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,6 @@ workflows:
             branches:
               only:
                 - main
-                - APG-216
       - hmpps/deploy_env:
           name: deploy_dev
           env: "dev"
@@ -116,87 +115,86 @@ workflows:
             branches:
               only:
                 - main
-                - APG-216
           requires:
             - validate
             - build_docker
             - helm_lint
           helm_timeout: 5m
-#      - end_to_end_test:
-#          context: hmpps-common-vars
-#          filters:
-#            branches:
-#              only:
-#                - main
-#          requires:
-#            - deploy_dev
-#      - tag_pact_version:
-#          name: "tag_pact_version_dev"
-#          tag: "deployed:dev"
-#          requires: [ deploy_dev ]
-#          context: [ hmpps-common-vars ]
-#
-#      - request-preprod-approval:
-#          type: approval
-#          requires:
-#            - deploy_dev
-#      - hmpps/deploy_env:
-#          name: deploy_preprod
-#          env: "preprod"
-#          context:
-#            - hmpps-common-vars
-#            - hmpps-accredited-programmes-api-preprod
-#          requires:
-#            - request-preprod-approval
-#      - tag_pact_version:
-#          name: "tag_pact_version_preprod"
-#          tag: "deployed:preprod"
-#          requires: [ deploy_preprod ]
-#          context: [ hmpps-common-vars ]
-#
-#      - request-prod-approval:
-#          type: approval
-#          requires:
-#            - deploy_preprod
-#      - hmpps/deploy_env:
-#          name: deploy_prod
-#          env: "prod"
-#          slack_notification: true
-#          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-#          context:
-#            - hmpps-common-vars
-#            - hmpps-accredited-programmes-api-prod
-#          requires:
-#            - request-prod-approval
-#      - tag_pact_version:
-#          name: "tag_pact_version_prod"
-#          tag: "deployed:prod"
-#          requires: [ deploy_prod ]
-#          context: [ hmpps-common-vars ]
-#
-#  security:
-#    triggers:
-#      - schedule:
-#          cron: "10 5 * * 1-5"
-#          filters:
-#            branches:
-#              only:
-#                - main
-#    jobs:
-#      - hmpps/gradle_owasp_dependency_check:
-#          jdk_tag: "21.0"
-#          slack_channel: << pipeline.parameters.alerts-slack-channel >>
-#          context:
-#            - hmpps-common-vars
-#      - hmpps/trivy_latest_scan:
-#          slack_channel: << pipeline.parameters.alerts-slack-channel >>
-#          context:
-#            - hmpps-common-vars
-#      - hmpps/veracode_pipeline_scan:
-#          slack_channel: << pipeline.parameters.alerts-slack-channel >>
-#          context:
-#            - veracode-credentials
-#            - hmpps-common-vars
+      - end_to_end_test:
+          context: hmpps-common-vars
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - deploy_dev
+      - tag_pact_version:
+          name: "tag_pact_version_dev"
+          tag: "deployed:dev"
+          requires: [ deploy_dev ]
+          context: [ hmpps-common-vars ]
+
+      - request-preprod-approval:
+          type: approval
+          requires:
+            - deploy_dev
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: "preprod"
+          context:
+            - hmpps-common-vars
+            - hmpps-accredited-programmes-api-preprod
+          requires:
+            - request-preprod-approval
+      - tag_pact_version:
+          name: "tag_pact_version_preprod"
+          tag: "deployed:preprod"
+          requires: [ deploy_preprod ]
+          context: [ hmpps-common-vars ]
+
+      - request-prod-approval:
+          type: approval
+          requires:
+            - deploy_preprod
+      - hmpps/deploy_env:
+          name: deploy_prod
+          env: "prod"
+          slack_notification: true
+          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+          context:
+            - hmpps-common-vars
+            - hmpps-accredited-programmes-api-prod
+          requires:
+            - request-prod-approval
+      - tag_pact_version:
+          name: "tag_pact_version_prod"
+          tag: "deployed:prod"
+          requires: [ deploy_prod ]
+          context: [ hmpps-common-vars ]
+
+  security:
+    triggers:
+      - schedule:
+          cron: "10 5 * * 1-5"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - hmpps/gradle_owasp_dependency_check:
+          jdk_tag: "21.0"
+          slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          context:
+            - hmpps-common-vars
+      - hmpps/trivy_latest_scan:
+          slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          context:
+            - hmpps-common-vars
+      - hmpps/veracode_pipeline_scan:
+          slack_channel: << pipeline.parameters.alerts-slack-channel >>
+          context:
+            - veracode-credentials
+            - hmpps-common-vars
   security-weekly:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ workflows:
             branches:
               only:
                 - main
+                - APG-216
       - hmpps/deploy_env:
           name: deploy_dev
           env: "dev"
@@ -115,86 +116,87 @@ workflows:
             branches:
               only:
                 - main
+                - APG-216
           requires:
             - validate
             - build_docker
             - helm_lint
           helm_timeout: 5m
-      - end_to_end_test:
-          context: hmpps-common-vars
-          filters:
-            branches:
-              only:
-                - main
-          requires:
-            - deploy_dev
-      - tag_pact_version:
-          name: "tag_pact_version_dev"
-          tag: "deployed:dev"
-          requires: [ deploy_dev ]
-          context: [ hmpps-common-vars ]
-
-      - request-preprod-approval:
-          type: approval
-          requires:
-            - deploy_dev
-      - hmpps/deploy_env:
-          name: deploy_preprod
-          env: "preprod"
-          context:
-            - hmpps-common-vars
-            - hmpps-accredited-programmes-api-preprod
-          requires:
-            - request-preprod-approval
-      - tag_pact_version:
-          name: "tag_pact_version_preprod"
-          tag: "deployed:preprod"
-          requires: [ deploy_preprod ]
-          context: [ hmpps-common-vars ]
-
-      - request-prod-approval:
-          type: approval
-          requires:
-            - deploy_preprod
-      - hmpps/deploy_env:
-          name: deploy_prod
-          env: "prod"
-          slack_notification: true
-          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
-          context:
-            - hmpps-common-vars
-            - hmpps-accredited-programmes-api-prod
-          requires:
-            - request-prod-approval
-      - tag_pact_version:
-          name: "tag_pact_version_prod"
-          tag: "deployed:prod"
-          requires: [ deploy_prod ]
-          context: [ hmpps-common-vars ]
-
-  security:
-    triggers:
-      - schedule:
-          cron: "10 5 * * 1-5"
-          filters:
-            branches:
-              only:
-                - main
-    jobs:
-      - hmpps/gradle_owasp_dependency_check:
-          jdk_tag: "21.0"
-          slack_channel: << pipeline.parameters.alerts-slack-channel >>
-          context:
-            - hmpps-common-vars
-      - hmpps/trivy_latest_scan:
-          slack_channel: << pipeline.parameters.alerts-slack-channel >>
-          context:
-            - hmpps-common-vars
-      - hmpps/veracode_pipeline_scan:
-          slack_channel: << pipeline.parameters.alerts-slack-channel >>
-          context:
-            - veracode-credentials
-            - hmpps-common-vars
+#      - end_to_end_test:
+#          context: hmpps-common-vars
+#          filters:
+#            branches:
+#              only:
+#                - main
+#          requires:
+#            - deploy_dev
+#      - tag_pact_version:
+#          name: "tag_pact_version_dev"
+#          tag: "deployed:dev"
+#          requires: [ deploy_dev ]
+#          context: [ hmpps-common-vars ]
+#
+#      - request-preprod-approval:
+#          type: approval
+#          requires:
+#            - deploy_dev
+#      - hmpps/deploy_env:
+#          name: deploy_preprod
+#          env: "preprod"
+#          context:
+#            - hmpps-common-vars
+#            - hmpps-accredited-programmes-api-preprod
+#          requires:
+#            - request-preprod-approval
+#      - tag_pact_version:
+#          name: "tag_pact_version_preprod"
+#          tag: "deployed:preprod"
+#          requires: [ deploy_preprod ]
+#          context: [ hmpps-common-vars ]
+#
+#      - request-prod-approval:
+#          type: approval
+#          requires:
+#            - deploy_preprod
+#      - hmpps/deploy_env:
+#          name: deploy_prod
+#          env: "prod"
+#          slack_notification: true
+#          slack_channel_name: << pipeline.parameters.releases-slack-channel >>
+#          context:
+#            - hmpps-common-vars
+#            - hmpps-accredited-programmes-api-prod
+#          requires:
+#            - request-prod-approval
+#      - tag_pact_version:
+#          name: "tag_pact_version_prod"
+#          tag: "deployed:prod"
+#          requires: [ deploy_prod ]
+#          context: [ hmpps-common-vars ]
+#
+#  security:
+#    triggers:
+#      - schedule:
+#          cron: "10 5 * * 1-5"
+#          filters:
+#            branches:
+#              only:
+#                - main
+#    jobs:
+#      - hmpps/gradle_owasp_dependency_check:
+#          jdk_tag: "21.0"
+#          slack_channel: << pipeline.parameters.alerts-slack-channel >>
+#          context:
+#            - hmpps-common-vars
+#      - hmpps/trivy_latest_scan:
+#          slack_channel: << pipeline.parameters.alerts-slack-channel >>
+#          context:
+#            - hmpps-common-vars
+#      - hmpps/veracode_pipeline_scan:
+#          slack_channel: << pipeline.parameters.alerts-slack-channel >>
+#          context:
+#            - veracode-credentials
+#            - hmpps-common-vars
   security-weekly:
     triggers:
       - schedule:


### PR DESCRIPTION
## Context

Added endpoint to return performance statistics for various status transitions: 

Example URL:

https://accredited-programmes-api-dev.hmpps.service.justice.gov.uk/statistics/performance/status-duration?startDate=2022-01-01&statuses=REFERRAL_SUBMITTED,AWAITING_ASSESSMENT

{
    "performance": [
        {
            "status": "AWAITING_ASSESSMENT",
            "averageDuration": "41 hours 30 minutes 57 seconds",
            "averageDurationUnderOneHour": "00 hours 01 minutes 21 seconds",
            "minDuration": "00 hours 00 minutes 01 seconds",
            "maxDuration": "1677 hours 29 minutes 30 seconds"
        },
        {
            "status": "REFERRAL_SUBMITTED",
            "averageDuration": "87 hours 47 minutes 08 seconds",
            "averageDurationUnderOneHour": "00 hours 01 minutes 01 seconds",
            "minDuration": "00 hours 00 minutes 01 seconds",
            "maxDuration": "1846 hours 40 minutes 04 seconds"
        }
    ]
}

<!-- Is there a Trello or Jira ticket you can link to? -->
[APG-216](https://dsdmoj.atlassian.net/browse/APG-216)
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->


[APG-216]: https://dsdmoj.atlassian.net/browse/APG-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ