### PR TITLE
change to put/post endpoints for offerings

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseController.kt
@@ -115,13 +115,22 @@ constructor(
     return ResponseEntity.ok(mappedOfferings)
   }
 
-  override fun addUpdateCourseOfferings(
+  override fun addCourseOffering(
     id: UUID,
-    courseOffering: List<CourseOffering>,
-  ): ResponseEntity<List<CourseOffering>> {
+    courseOffering: CourseOffering,
+  ): ResponseEntity<CourseOffering> {
     val course = courseService.getCourseById(id)
       ?: throw NotFoundException("No Course found at /courses/$id")
-    return ResponseEntity.ok(courseService.updateOfferings(course, courseOffering))
+    return ResponseEntity.status(HttpStatus.CREATED).body(courseService.createOrUpdateOffering(course, courseOffering))
+  }
+
+  override fun updateCourseOffering(
+    id: UUID,
+    courseOffering: CourseOffering,
+  ): ResponseEntity<CourseOffering> {
+    val course = courseService.getCourseById(id)
+      ?: throw NotFoundException("No Course found at /courses/$id")
+    return ResponseEntity.ok(courseService.createOrUpdateOffering(course, courseOffering))
   }
 
   override fun deleteCourseOffering(id: UUID, offeringId: UUID): ResponseEntity<Unit> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
@@ -257,32 +257,28 @@ constructor(
     return courseSaved.prerequisites.map { it.toApi() }
   }
 
-  fun updateOfferings(course: CourseEntity, courseOffering: List<CourseOffering>): List<CourseOffering> {
+  fun createOrUpdateOffering(course: CourseEntity, courseOffering: CourseOffering): CourseOffering {
     val validPrisons = prisonRegisterApiService.getPrisons()
 
-    val offerings = listOf<OfferingEntity>()
-    courseOffering.forEach {
-      validPrisons.firstOrNull { prison -> prison.prisonId == it.organisationId }
-        ?: throw NotFoundException("No prison found with code ${it.organisationId}")
-      // validate that there isn't already an offering for this course/organisation
-      val existingOffering =
-        offeringRepository.findByCourseIdAndOrganisationIdAndWithdrawnIsFalse(course.id!!, it.organisationId)
-      existingOffering?.let {
-        throw BusinessException("Offering already exists for course ${course.name} and organisation ${it.organisationId}")
-      }
-      val offeringToAdd = OfferingEntity(
-        id = it.id,
-        organisationId = it.organisationId,
-        contactEmail = it.contactEmail,
-        secondaryContactEmail = it.secondaryContactEmail,
-        withdrawn = it.withdrawn ?: false,
-        referable = it.referable,
-      )
-
-      offeringToAdd.course = course
-      offerings + offeringToAdd
+    validPrisons.firstOrNull { prison -> prison.prisonId == courseOffering.organisationId }
+      ?: throw NotFoundException("No prison found with code ${courseOffering.organisationId}")
+    // validate that there isn't already an offering for this course/organisation
+    val existingOffering =
+      offeringRepository.findByCourseIdAndOrganisationIdAndWithdrawnIsFalse(course.id!!, courseOffering.organisationId)
+    existingOffering?.let {
+      throw BusinessException("Offering already exists for course ${course.name} and organisation ${it.organisationId}")
     }
-    return offeringRepository.saveAll(offerings).map { it.toApi() }
+    val offering = OfferingEntity(
+      id = courseOffering.id,
+      organisationId = courseOffering.organisationId,
+      contactEmail = courseOffering.contactEmail,
+      secondaryContactEmail = courseOffering.secondaryContactEmail,
+      withdrawn = courseOffering.withdrawn ?: false,
+      referable = courseOffering.referable,
+    )
+    offering.course = course
+
+    return offeringRepository.save(offering).toApi()
   }
 
   fun deleteCourseOffering(id: UUID, offeringId: UUID) {

--- a/src/main/resources/static/api.yml
+++ b/src/main/resources/static/api.yml
@@ -535,8 +535,8 @@ paths:
     put:
       tags:
         - Course Offerings
-      summary: Add or update course offerings
-      operationId: addUpdateCourseOfferings
+      summary: update a course offering
+      operationId: updateCourseOffering
       parameters:
         - name: id
           in: path
@@ -550,19 +550,40 @@ paths:
         content:
           'application/json':
             schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/CourseOffering'
-
+              $ref: '#/components/schemas/CourseOffering'
       responses:
         200:
           description: successful operation
           content:
             'application/json':
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CourseOffering'
+                $ref: '#/components/schemas/CourseOffering'
+    post:
+      tags:
+        - Course Offerings
+      summary: Add a course offering
+      operationId: addCourseOffering
+      parameters:
+        - name: id
+          in: path
+          description: A course identifier
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/CourseOffering'
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/CourseOffering'
 
   /courses/{id}/offerings/{offeringId}:
     delete:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
@@ -531,27 +531,25 @@ class CourseIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Create offerings returns 200`() {
     webTestClient
-      .put()
+      .post()
       .uri("/courses/$NEW_COURSE_ID/offerings")
       .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
       .contentType(MediaType.APPLICATION_JSON)
       .accept(MediaType.APPLICATION_JSON)
       .bodyValue(
-        listOf(
-          CourseOffering(
-            id = null,
-            organisationId = "AWI",
-            contactEmail = "awi1@whatton.com",
-            secondaryContactEmail = "awi2@whatton.com",
-            referable = true,
-            withdrawn = false,
-            organisationEnabled = true,
-          ),
+        CourseOffering(
+          id = null,
+          organisationId = "AWI",
+          contactEmail = "awi1@whatton.com",
+          secondaryContactEmail = "awi2@whatton.com",
+          referable = true,
+          withdrawn = false,
+          organisationEnabled = true,
         ),
       )
       .exchange()
-      .expectStatus().isOk
-      .expectBody<List<CourseOffering>>()
+      .expectStatus().isCreated
+      .expectBody<CourseOffering>()
       .returnResult().responseBody!!
   }
 }


### PR DESCRIPTION
## Context

following discussions with UI team - decided to change the put offerings from a list to a single item. Also added a post offering to make it clearer what is being done. 

<!-- Is there a Trello or Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
