### PR TITLE
fix to offering delete

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/OfferingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/OfferingRepository.kt
@@ -12,6 +12,7 @@ interface OfferingRepository : JpaRepository<OfferingEntity, UUID> {
   fun findAllByCourseId(courseId: UUID): List<OfferingEntity>
   fun findByCourseIdAndOrganisationIdAndWithdrawnIsFalse(courseId: UUID, organisationId: String): OfferingEntity?
   fun findByCourseIdAndIdAndWithdrawnIsFalse(courseId: UUID, offeringId: UUID): OfferingEntity?
+
   @Modifying
   @Query("delete from OfferingEntity o where o.id = :offeringId")
   fun delete(offeringId: UUID)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/OfferingRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/OfferingRepository.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OfferingEntity
 import java.util.UUID
@@ -9,6 +11,8 @@ import java.util.UUID
 interface OfferingRepository : JpaRepository<OfferingEntity, UUID> {
   fun findAllByCourseId(courseId: UUID): List<OfferingEntity>
   fun findByCourseIdAndOrganisationIdAndWithdrawnIsFalse(courseId: UUID, organisationId: String): OfferingEntity?
-
   fun findByCourseIdAndIdAndWithdrawnIsFalse(courseId: UUID, offeringId: UUID): OfferingEntity?
+  @Modifying
+  @Query("delete from OfferingEntity o where o.id = :offeringId")
+  fun delete(offeringId: UUID)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
@@ -289,7 +289,7 @@ constructor(
     if (referralRepository.countAllByOfferingId(offeringId) > 0) {
       throw BusinessException("Offering is in use and cannot be deleted. This offering should be withdrawn")
     }
-    offeringRepository.delete(existingOffering)
+    offeringRepository.delete(existingOffering.id!!)
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
@@ -22,7 +22,9 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.api.model.Cours
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.COURSE_OFFERING_ID
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OfferingRepository
 import java.time.LocalDateTime
+import java.util.Optional
 import java.util.UUID
 
 val COURSE_ID: UUID = UUID.fromString("790a2dfe-8df1-4504-bb9c-83e6e53a6537")
@@ -39,6 +41,9 @@ class CourseIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var courseRepository: CourseRepository
+
+  @Autowired
+  lateinit var offeringRepository: OfferingRepository
 
   @BeforeEach
   fun setUp() {
@@ -515,6 +520,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
+    courseRepository.findById(UNUSED_COURSE_ID) shouldBe Optional.empty()
   }
 
   @Test
@@ -526,6 +532,8 @@ class CourseIntegrationTest : IntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .exchange()
       .expectStatus().isOk
+
+    offeringRepository.findById(UUID.fromString(UNUSED_OFFERING_ID)) shouldBe Optional.empty()
   }
 
   @Test


### PR DESCRIPTION
## Context

The default hibernate.delete method doesn't work for offering (really not sure why as it works for course) 

Anyway I've added a delete query which does work, feels like a hack and will look into this again at some point. 

Also added additional tests. 

<!-- Is there a Trello or Jira ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
