### PR TITLE
APG 390 store basic skills score

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/view/PniResultEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/view/PniResultEntity.kt
@@ -36,4 +36,6 @@ data class PniResultEntity(
   val pniValid: Boolean,
   @Column
   val pniResultJson: String?,
+  @Column
+  val basicSkillsScore: Int?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/LearningNeeds.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/LearningNeeds.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysAccommodation
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysLearning
 
 /**
  *
@@ -35,4 +37,19 @@ data class LearningNeeds(
 
   @Schema(example = "free text about this persons learning needs", description = "")
   @get:JsonProperty("basicSkillsScoreDescription") val basicSkillsScoreDescription: String? = null,
-)
+) {
+  constructor(
+    oasysAccommodation: OasysAccommodation?,
+    oasysLearning: OasysLearning?,
+  ) : this(
+    noFixedAbodeOrTransient = oasysAccommodation?.noFixedAbodeOrTransient == YES,
+    workRelatedSkills = oasysLearning?.workRelatedSkills,
+    problemsReadWriteNum = oasysLearning?.problemsReadWriteNum,
+    learningDifficulties = oasysLearning?.learningDifficulties,
+    qualifications = oasysLearning?.qualifications,
+    basicSkillsScore = oasysLearning?.basicSkillsScore,
+    basicSkillsScoreDescription = oasysLearning?.eTEIssuesDetails,
+  )
+}
+
+private const val YES = "Yes"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/NeedsScore.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/NeedsScore.kt
@@ -6,11 +6,13 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class NeedsScore(
   @Schema(example = "5", required = true)
   @get:JsonProperty("overallNeedsScore") val overallNeedsScore: Int,
+  @Schema(example = "6")
+  @get:JsonProperty("basicSkillsScore") val basicSkillsScore: Int?,
   @Schema(example = "High Intensity BC", required = true)
   @get:JsonProperty("classification") val classification: String,
   @Schema(example = "5", required = true)
   @get:JsonProperty("DomainScore") val domainScore: DomainScore,
-) {
+  ) {
   fun validate() =
     listOf(
       domainScore.thinkingDomainScore.isAllValuesPresent(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/NeedsScore.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/NeedsScore.kt
@@ -12,7 +12,7 @@ data class NeedsScore(
   @get:JsonProperty("classification") val classification: String,
   @Schema(example = "5", required = true)
   @get:JsonProperty("DomainScore") val domainScore: DomainScore,
-  ) {
+) {
   fun validate() =
     listOf(
       domainScore.thinkingDomainScore.isAllValuesPresent(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/OasysTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/OasysTransformer.kt
@@ -1,10 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer
 
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysAccommodation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysAttitude
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysBehaviour
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysHealth
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysLearning
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysLifestyle
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysOffenceDetail
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysOffendingInfo
@@ -19,7 +17,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.A
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Attitude
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Behaviour
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Health
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.LearningNeeds
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Lifestyle
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.OffenceDetail
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Psychiatric
@@ -102,16 +99,6 @@ fun OasysAttitude.toModel() = Attitude(
   proCriminalAttitudes = proCriminalAttitudes,
   motivationToAddressBehaviour = motivationToAddressBehaviour,
   hostileOrientation = hostileOrientation,
-)
-
-fun learningNeeds(oasysAccommodation: OasysAccommodation?, oasysLearning: OasysLearning?) = LearningNeeds(
-  noFixedAbodeOrTransient = oasysAccommodation?.noFixedAbodeOrTransient == YES,
-  workRelatedSkills = oasysLearning?.workRelatedSkills,
-  problemsReadWriteNum = oasysLearning?.problemsReadWriteNum,
-  learningDifficulties = oasysLearning?.learningDifficulties,
-  qualifications = oasysLearning?.qualifications,
-  basicSkillsScore = oasysLearning?.basicSkillsScore,
-  basicSkillsScoreDescription = oasysLearning?.eTEIssuesDetails,
 )
 
 fun risks(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysService.kt
@@ -40,7 +40,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.P
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Relationships
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Risks
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.RoshAnalysis
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.learningNeeds
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.risks
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toModel
 import java.time.LocalDateTime
@@ -141,7 +140,7 @@ class OasysService(
 
     val oasysLearning = getLearning(assessmentId)
     val oasysAccommodation = getAccommodation(assessmentId)
-    return learningNeeds(oasysAccommodation, oasysLearning)
+    return LearningNeeds(oasysAccommodation, oasysLearning)
   }
 
   fun getRisks(prisonNumber: String): Risks {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniNeedsEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniNeedsEngine.kt
@@ -23,6 +23,7 @@ class PniNeedsEngine(
     individualNeedsAndRiskScores: IndividualNeedsAndRiskScores,
     prisonNumber: String,
     gender: String?,
+    basicSkillsScore: Int?,
   ): NeedsScore {
     val sexDomainScore = getSexDomainScore(individualNeedsAndRiskScores, prisonNumber, gender)
     val individualNeedsScores = individualNeedsAndRiskScores.individualNeedsScores
@@ -53,6 +54,7 @@ class PniNeedsEngine(
           individualSelfManagementScores = individualNeedsScores.individualSelfManagementScores,
         ),
       ),
+      basicSkillsScore = basicSkillsScore,
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniService.kt
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysAttitude
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysBehaviour
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysLearning
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysLifestyle
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysPsychiatric
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysRelationships
@@ -73,6 +74,8 @@ class PniService(
     // section 12
     val attitude = oasysService.getAttitude(assessmentId)
 
+    val learning = oasysService.getLearning(assessmentId)
+
     // risks
     val oasysOffendingInfo = oasysService.getOffendingInfo(assessmentId)
     val oasysRiskPredictor = oasysService.getRiskPredictors(assessmentId)
@@ -104,13 +107,18 @@ class PniService(
     )
 
     if (savePni) {
-      pniResultEntityRepository.save(buildEntity(pniScore, assessmentIdDate, referralId))
+      pniResultEntityRepository.save(buildEntity(pniScore, assessmentIdDate, referralId, learning))
     }
 
     return pniScore
   }
 
-  private fun buildEntity(pniScore: PniScore, assessmentIdDate: Pair<Long, LocalDateTime?>, referralId: UUID?): PniResultEntity {
+  private fun buildEntity(
+    pniScore: PniScore,
+    assessmentIdDate: Pair<Long, LocalDateTime?>,
+    referralId: UUID?,
+    learning: OasysLearning?,
+  ): PniResultEntity {
     return PniResultEntity(
       crn = pniScore.crn,
       prisonNumber = pniScore.prisonNumber,
@@ -124,6 +132,7 @@ class PniService(
       pniValid = pniScore.validationErrors.isEmpty(),
       pniResultJson = objectMapper.writeValueAsString(pniScore),
       pniAssessmentDate = LocalDateTime.now(),
+      basicSkillsScore = learning?.basicSkillsScore?.toInt(),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniService.kt
@@ -85,7 +85,7 @@ class PniService(
       individualRiskScores = buildRiskScores(oasysRiskPredictor, relationships),
     )
 
-    val overallNeedsScore = pniNeedsEngine.getOverallNeedsScore(individualNeedsAndRiskScores, prisonNumber, gender)
+    val overallNeedsScore = pniNeedsEngine.getOverallNeedsScore(individualNeedsAndRiskScores, prisonNumber, gender, learning?.basicSkillsScore?.toInt())
 
     log.info("Overall needs score for prisonNumber $prisonNumber is ${overallNeedsScore.overallNeedsScore} classification ${overallNeedsScore.classification} ")
 

--- a/src/main/resources/db/migration/V93__add_basic_skills_score_to_pni_result.sql
+++ b/src/main/resources/db/migration/V93__add_basic_skills_score_to_pni_result.sql
@@ -1,0 +1,1 @@
+ALTER TABLE pni_result ADD COLUMN basic_skills_score SMALLINT;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PniIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PniIntegrationTest.kt
@@ -50,6 +50,7 @@ class PniIntegrationTest :
     programmePathway = "HIGH_INTENSITY_BC",
     needsScore = NeedsScore(
       overallNeedsScore = 6,
+      basicSkillsScore = 33,
       classification = "HIGH_NEED",
       domainScore = DomainScore(
         sexDomainScore = SexDomainScore(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PniIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PniIntegrationTest.kt
@@ -103,18 +103,22 @@ class PniIntegrationTest :
 
   @Test
   fun `Save pni info for prisoner successful`() {
+    // Given
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
     val prisonNumber = "A9999BB"
+    // When
     getPniInfoByPrisonNumberAndSave(prisonNumber)
-    val results = pniResultEntityRepository.findAllByPrisonNumber(prisonNumber)
-    results[0].prisonNumber shouldBe prisonNumber
-    results[0].crn shouldBe pniScore(prisonNumber).crn
-    results[0].needsClassification shouldBe pniScore(prisonNumber).needsScore.classification
-    results[0].overallNeedsScore shouldBe pniScore(prisonNumber).needsScore.overallNeedsScore
-    results[0].programmePathway shouldBe pniScore(prisonNumber).programmePathway
-    results[0].riskClassification shouldBe pniScore(prisonNumber).riskScore.classification
-    results[0].pniResultJson shouldBe objectMapper.writeValueAsString(pniScore(prisonNumber))
-    results[0].pniValid shouldBe false
+    // Then
+    val pniResults = pniResultEntityRepository.findAllByPrisonNumber(prisonNumber)
+    pniResults[0].prisonNumber shouldBe prisonNumber
+    pniResults[0].crn shouldBe pniScore(prisonNumber).crn
+    pniResults[0].needsClassification shouldBe pniScore(prisonNumber).needsScore.classification
+    pniResults[0].overallNeedsScore shouldBe pniScore(prisonNumber).needsScore.overallNeedsScore
+    pniResults[0].programmePathway shouldBe pniScore(prisonNumber).programmePathway
+    pniResults[0].riskClassification shouldBe pniScore(prisonNumber).riskScore.classification
+    pniResults[0].pniResultJson shouldBe objectMapper.writeValueAsString(pniScore(prisonNumber))
+    pniResults[0].pniValid shouldBe false
+    pniResults[0].basicSkillsScore shouldBe 33
   }
 
   fun getPniInfoByPrisonNumber(prisonNumber: String) =


### PR DESCRIPTION
## Context

(https://dsdmoj.atlassian.net/jira/software/c/projects/APG/boards/1435?selectedIssue=APG-390)

## Changes in this PR

- Add new column for basic skills test to pni_results table
- Add basic skills score to NeedsScore to allow persistence as JSON
- Update corresponding entity class to reflect the above
- Updates to PniService implementation to retrieve basic skills score and persist
- Updates to integration test to verify score is saved


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
