### PR TITLE
APG 330 return reason in status history

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -583,8 +583,6 @@ class ReferralController(
       required = true,
     ) @PathVariable("id") id: UUID,
   ): ResponseEntity<List<ReferralStatusHistory>> {
-    referralService
-      .getReferralById(id)
     return ResponseEntity.ok(
       referralStatusHistoryService.getReferralStatusHistories(id),
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralStatusHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralStatusHistory.kt
@@ -17,6 +17,8 @@ import java.util.UUID
  * @param notes The notes associated with the status change.
  * @param statusStartDate Date referral was changed to this status.
  * @param username Username of the person who changed to this status
+ * @param categoryDescription The description of the referral status category.
+ * @param reasonDescription The description of the referral status reason.
  */
 data class ReferralStatusHistory(
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/StatusHistoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/StatusHistoryIntegrationTest.kt
@@ -131,15 +131,18 @@ class StatusHistoryIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `get referral status history for a referral`() {
+    // Given
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
-
-    val response = getStatusHistories(referralId)
-    response.shouldNotBeNull()
-
-    response.size shouldBeEqual 1
-    val statusHistoryOne = response[0]
+    // When
+    val referralStatusHistories = getStatusHistories(referralId)
+    // Then
+    referralStatusHistories.shouldNotBeNull()
+    referralStatusHistories.size shouldBeEqual 1
+    val statusHistoryOne = referralStatusHistories[0]
     statusHistoryOne.status?.shouldBeEqual(WITHDRAWN)
     statusHistoryOne.previousStatus?.shouldBeEqual(REFERRAL_STARTED)
+    statusHistoryOne.categoryDescription?.shouldBeEqual("Administrative error")
+    statusHistoryOne.reasonDescription?.shouldBeEqual("Duplicate referral")
   }
 
   fun getStatusHistories(id: UUID?) =


### PR DESCRIPTION
## Context

## Changes in this PR

- Update integration test to verify reason code is returned for getReferralStatusHistories controller endpoint
- Remove spurious call to service from controller method

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
