### PR TITLE
APG 409 return on programme count

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,13 +15,13 @@ parameters:
 jobs:
   validate:
     executor:
-      name: hmpps/java_localstack_postgres
+      name: hmpps/localstack
       jdk_tag: "21.0"
       localstack_tag: "3.0"
-      postgres_tag: "16.1"
     steps:
       - checkout
       - hmpps/install_aws_cli
+      - setup_remote_docker
       - run:
           name: Wait for SQS to be ready
           command: curl -4 --connect-timeout 30 --retry-connrefused --retry 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,9 +15,10 @@ parameters:
 jobs:
   validate:
     executor:
-      name: hmpps/localstack
+      name: hmpps/java_localstack_postgres
       jdk_tag: "21.0"
-      localstack_tag: "3"
+      localstack_tag: "3.0"
+      postgres_tag: "16.1"
     steps:
       - checkout
       - hmpps/install_aws_cli

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To run linting and tests, do:
 ```
 
 Repository integration tests use an embedded H2 database. REST API tests start a
-local server which listens on a random port.
+local server which listens on a random port, and spin up a containerised Postgres instance as a backend Database via the test containers API.
 
 ### Pact
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:4.4.4")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
-  runtimeOnly("org.postgresql:postgresql:42.7.4")
 
   testImplementation("com.h2database:h2")
   testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
@@ -49,6 +48,11 @@ dependencies {
   testImplementation("org.springframework.security:spring-security-test:$springSecurityVersion")
   testImplementation("com.github.tomakehurst:wiremock-standalone:3.0.1")
   testImplementation("org.awaitility:awaitility-kotlin")
+
+  testImplementation("org.testcontainers:testcontainers:1.20.1")
+  testImplementation("org.testcontainers:postgresql:1.20.1")
+  testImplementation("org.testcontainers:junit-jupiter:1.20.1")
+  testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 
 java {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/StatisticsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/StatisticsController.kt
@@ -93,6 +93,13 @@ class StatisticsController(
         endDate!!,
         locationCodes,
       )
+
+      ReportType.ON_PROGRAMME_COUNT -> statisticsRepository.finalStatusCodeCounts(
+        startDate,
+        endDate!!,
+        locationCodes,
+        "ON_PROGRAMME",
+      )
     }
     return ReportContent(
       reportType = reportType.name,
@@ -157,6 +164,7 @@ enum class ReportType {
   NOT_SUITABLE_COUNT,
   DESELECTED_COUNT,
   PNI_PATHWAY_COUNT,
+  ON_PROGRAMME_COUNT,
 }
 
 data class ReportTypes(val types: List<String>)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/AuditIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/AuditIntegrationTest.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.ent
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @Import(JwtAuthHelper::class)
-class AuditIntegrationTest {
+class AuditIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var auditRepository: AuditRepository
@@ -27,7 +27,7 @@ class AuditIntegrationTest {
   lateinit var auditService: AuditService
 
   @Test
-  fun `Creating an interal audit record is successful with expected body`() {
+  fun `Creating an internal audit record is successful with expected body`() {
     val offeringEntity = OfferingEntityFactory().produce()
     offeringEntity.course = CourseEntityFactory().produce()
     val referralEntity = ReferralEntityFactory().withOffering(offeringEntity).produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/IntegrationTestBase.kt
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseParticipationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseParticipationRepositoryTest.kt
@@ -25,7 +25,7 @@ import java.time.Year
 @SpringBootTest
 @AutoConfigureTestDatabase
 @Transactional
-@ActiveProfiles("test")
+@ActiveProfiles("test-h2")
 class CourseParticipationRepositoryTest {
 
   @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseRepositoryTest.kt
@@ -20,7 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.ent
 @SpringBootTest
 @AutoConfigureTestDatabase
 @Transactional
-@ActiveProfiles("test")
+@ActiveProfiles("test-h2")
 class CourseRepositoryTest {
 
   @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/OfferingRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/OfferingRepositoryTest.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.ent
 @SpringBootTest
 @AutoConfigureTestDatabase
 @Transactional
-@ActiveProfiles("test")
+@ActiveProfiles("test-h2")
 class OfferingRepositoryTest {
 
   @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
@@ -20,7 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.ent
 @SpringBootTest
 @AutoConfigureTestDatabase
 @Transactional
-@ActiveProfiles("test")
+@ActiveProfiles("test-h2")
 class ReferralRepositoryTest {
 
   @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseControllerTest.kt
@@ -24,7 +24,7 @@ import java.util.UUID
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("test-h2")
 @Import(JwtAuthHelper::class)
 class CourseControllerTest
 @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseParticipationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseParticipationControllerTest.kt
@@ -38,7 +38,7 @@ import java.util.UUID
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("test-h2")
 @Import(JwtAuthHelper::class)
 class CourseParticipationControllerTest
 @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/OfferingControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/OfferingControllerTest.kt
@@ -20,7 +20,7 @@ import java.util.UUID
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("test-h2")
 @Import(JwtAuthHelper::class)
 class OfferingControllerTest@Autowired
 constructor(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/OrganisationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/OrganisationControllerTest.kt
@@ -28,7 +28,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.ent
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("test-h2")
 @Import(JwtAuthHelper::class)
 class OrganisationControllerTest
 @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/PeopleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/PeopleControllerTest.kt
@@ -29,7 +29,7 @@ import java.time.format.DateTimeFormatter
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("test-h2")
 @Import(JwtAuthHelper::class)
 class PeopleControllerTest
 @Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -50,7 +50,7 @@ private const val MY_REFERRALS_ENDPOINT = "/referrals/me/dashboard"
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc
-@ActiveProfiles("test")
+@ActiveProfiles("test-h2")
 @Import(JwtAuthHelper::class)
 class ReferralControllerTest
 @Autowired

--- a/src/test/resources/application-test-h2.yml
+++ b/src/test/resources/application-test-h2.yml
@@ -1,0 +1,64 @@
+server:
+  shutdown: immediate
+
+logging:
+  level:
+    uk.gov: DEBUG
+
+management.endpoint:
+  health.cache.time-to-live: 0
+  info.cache.time-to-live: 0
+
+pactbroker:
+  host: 'pact-broker-prod.apps.live-1.cloud-platform.service.justice.gov.uk'
+  scheme: https
+
+spring:
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  datasource:
+    url: 'jdbc:h2:mem:postgres;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH'
+    username: sa
+
+  sql:
+    init:
+      mode: always
+
+hmpps:
+  auth:
+    url: http://localhost:#WIREMOCK_PORT/auth
+    client-id: integration-test-client-id
+    client-secret: secret
+  sqs:
+    provider: localstack
+    queues:
+      hmppsdomaineventsqueue:
+        queueName: hmpps_domain_events_queue
+        dlqName: hmpps_domain_events_dlq
+        subscribeTopicId: hmppsdomaineventstopic
+        subscribeFilter: '{"eventType":[ "prisoner-offender-search.prisoner.updated"] }'
+        asyncQueueClient: true
+
+    topics:
+      hmppsdomaineventstopic:
+        arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
+
+services:
+  prison-api:
+    base-url: http://localhost:#WIREMOCK_PORT
+  prisoner-search-api:
+    base-url: http://localhost:#WIREMOCK_PORT
+  prison-register-api:
+    base-url: http://localhost:#WIREMOCK_PORT
+  oasys-api:
+    base-url: http://localhost:#WIREMOCK_PORT
+  manage-offences-api:
+    base-url: http://localhost:#WIREMOCK_PORT
+  case-notes-api:
+    base-url: http://localhost:#WIREMOCK_PORT
+
+feature-switch:
+  case-notes-enabled: true

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -19,10 +19,18 @@ spring:
     properties:
       hibernate:
         format_sql: true
-
   datasource:
-    url: 'jdbc:h2:mem:postgres;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DEFAULT_NULL_ORDERING=HIGH'
-    username: sa
+    driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 2
+      idle-timeout: 300000
+      max-lifetime: 1800000
+      connection-timeout: 30000
+
+  sql:
+    init:
+      mode: always
 
 hmpps:
   auth:


### PR DESCRIPTION
## Context

Enable the return of report counts for referrals with a status of ON_PROGRAMME 

## Changes in this PR

- Update StatisticsController to enable returning of ON PROGRAMME report types
- Update StatisticsIntegrationTest to verify correct behaviour when returning ON PROGRAMME reports types
- Enabled using Postgres as a backend for Integration tests with test containers and updated IntegrationTestBase accordingly
- Added additional test config yaml for H2 databases to allow existing tests that use it to continue doing so
- Updated the active Spring Boot profile for tests that use an H2 backend
- Enabled remote docker for circleCi to allow test containers to execute

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
