### PR TITLE
APG 387 return all referral status reasons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,5 +77,5 @@ sonar-project.properties
 
 ### MacOS ###
 .DS_Store
-.kotlin/*
+.kotlin/
 

--- a/postman/collections/Accredited Programmes API.postman_collection.json
+++ b/postman/collections/Accredited Programmes API.postman_collection.json
@@ -3512,7 +3512,7 @@
 					"response": []
 				},
 				{
-					"name": "Get Referral Status Reasons",
+					"name": "Get Referral Status Reasons By Category Code",
 					"request": {
 						"auth": {
 							"type": "oauth2",
@@ -3576,7 +3576,7 @@
 								},
 								{
 									"key": "categoryCode",
-									"value": "W_MOTIVATION"
+									"value": "W_ADMIN"
 								}
 							]
 						}
@@ -3644,6 +3644,83 @@
 								{
 									"key": "code",
 									"value": "W_MOTIVATION"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get All Referral Status Reasons By Referral Status Type",
+					"request": {
+						"auth": {
+							"type": "oauth2",
+							"oauth2": [
+								{
+									"key": "scope",
+									"value": "read",
+									"type": "string"
+								},
+								{
+									"key": "clientSecret",
+									"value": "{{oauth_client_secret}}",
+									"type": "string"
+								},
+								{
+									"key": "clientId",
+									"value": "{{oauth_client_id}}",
+									"type": "string"
+								},
+								{
+									"key": "accessTokenUrl",
+									"value": "{{access_token_url}}",
+									"type": "string"
+								},
+								{
+									"key": "tokenName",
+									"value": "HMPPS Auth",
+									"type": "string"
+								},
+								{
+									"key": "refreshTokenUrl",
+									"value": "",
+									"type": "string"
+								},
+								{
+									"key": "grant_type",
+									"value": "client_credentials",
+									"type": "string"
+								},
+								{
+									"key": "authUrl",
+									"value": "http://localhost:9090/auth/oauth/token?grant_type=client_credentials",
+									"type": "string"
+								},
+								{
+									"key": "addTokenTo",
+									"value": "header",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{accredited_programmes_api}}/reference-data/referral-statuses/:referralStatusType/categories/reasons",
+							"host": [
+								"{{accredited_programmes_api}}"
+							],
+							"path": [
+								"reference-data",
+								"referral-statuses",
+								":referralStatusType",
+								"categories",
+								"reasons"
+							],
+							"variable": [
+								{
+									"key": "referralStatusType",
+									"value": "WITHDRAWN"
 								}
 							]
 						}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusEntity.kt
@@ -97,6 +97,19 @@ interface ReferralStatusReasonRepository : JpaRepository<ReferralStatusReasonEnt
   ): List<ReferralStatusReasonEntity>
 
   fun findByCode(code: String): ReferralStatusReasonEntity?
+
+  @Query(
+    """
+    SELECT r.*
+    FROM referral_status_reason r
+    JOIN referral_status_category c 
+    ON r.referral_status_category_code = c.code
+    WHERE c.referral_status_code = :statusCode
+    AND c.active = true
+  """,
+    nativeQuery = true,
+  )
+  fun findReferralStatusReasonsByStatusCode(statusCode: String): List<ReferralStatusReasonEntity>
 }
 
 fun ReferralStatusReasonRepository.getByCode(code: String) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferenceDataController.kt
@@ -1,14 +1,21 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.controller
 
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusCategory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusReason
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusRefData
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusType
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralReferenceDataService
 
 @RestController
@@ -59,4 +66,20 @@ class ReferenceDataController(
   fun getReferralStatusReason(@PathVariable code: String): ReferralStatusReason =
     referenceDataService
       .getReferralStatusReason(code)
+
+  @Operation(
+    summary = "Gets a full list of Referral Status Reasons for a status type (WITHDRAWN or DESELECTED)",
+    operationId = "getReferralStatusReasonsForReferralStatusType",
+    description = """Get all Referral Status Reasons (code, description, referralCategoryCode) for the provided type""",
+    responses = [
+      ApiResponse(responseCode = "200", description = "Successful operation", content = [Content(schema = Schema(implementation = ReferralStatusReason::class))]),
+      ApiResponse(responseCode = "400", description = "No data exists for the provided type", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
+      ApiResponse(responseCode = "401", description = "Unauthorised. The request was unauthorised.", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
+      ApiResponse(responseCode = "403", description = "Forbidden.  The client is not authorised to access person.", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
+    ],
+  )
+  @GetMapping("/referral-statuses/{referralStatusType}/categories/reasons", produces = ["application/json"])
+  fun getReferralStatusReasonsForReferralStatusType(
+    @Parameter(description = "The referral status type (WITHDRAWN or DESELECTED)", required = true) @PathVariable referralStatusType: ReferralStatusType,
+  ): List<ReferralStatusReason> = referenceDataService.getAllReferralStatusReasonsForType(referralStatusType)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralStatusType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralStatusType.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
+
+enum class ReferralStatusType {
+  WITHDRAWN,
+  DESELECTED,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferenceDataTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferenceDataTransformer.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer
 
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusReasonEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusReason
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusRefData
 
 fun ReferralStatusEntity.toModel(altDescription: String?, altHintText: String?) =
@@ -18,4 +20,11 @@ fun ReferralStatusEntity.toModel(altDescription: String?, altHintText: String?) 
     release = release,
     deselectAndKeepOpen = false,
     notesOptional = notesOptional,
+  )
+
+fun ReferralStatusReasonEntity.toModel() =
+  ReferralStatusReason(
+    code = code,
+    description = description,
+    referralCategoryCode = referralStatusCategoryCode,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralReferenceDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralReferenceDataService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.r
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusCategory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusReason
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusRefData
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusType
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toModel
 
 @Service
@@ -119,5 +120,10 @@ class ReferralReferenceDataService(
     } else {
       referralStatusTransitionRepository.getPOMTransition(currentStatus, chosenStatus)
     }
+  }
+
+  fun getAllReferralStatusReasonsForType(referralStatusType: ReferralStatusType): List<ReferralStatusReason> {
+    return referralStatusReasonRepository.findReferralStatusReasonsByStatusCode(referralStatusType.name)
+      .map { it.toModel() }
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -128,6 +128,8 @@ services:
     base-url: http://localhost:9098
   case-notes-api:
     base-url: http://localhost:9099
+  manage-users-api:
+    base-url: http://localhost:9100
 
 feature-switch:
   case-notes-enabled: true


### PR DESCRIPTION
## Context

Allow for the retrieval of all referral reasons in one hit based on a type of either DESELECTED or WITHDRAWN

## Changes in this PR

- Add new endpoint to API to retrieve all referral reasons for the provided type
- Added corresponding service implementation and repository code 
- Added Integration tests to validate the correct behaviour
- Minor update to application.yaml to allow for local service startup
- Update to postman collection for new endpoint

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
