### PR TITLE
APG-416 Add handling for "No active sentences" category

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonerSearchApi/model/Prisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonerSearchApi/model/Prisoner.kt
@@ -16,7 +16,6 @@ data class Prisoner(
   var paroleEligibilityDate: LocalDate? = null,
   var prisonName: String?,
   var gender: String?,
-
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryType.kt
@@ -10,6 +10,7 @@ enum class SentenceCategoryType(val description: String) {
   DETERMINATE_INDETERMINATE_RECALL("Determinate and Indeterminate and Recall"),
   UNKNOWN("Unknown"),
   RECALL("Recall"),
+  NO_ACTIVE_SENTENCES("No active sentences"),
   ;
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PersonServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PersonServiceTest.kt
@@ -93,33 +93,7 @@ class PersonServiceTest {
             issuingCourtDate = "firstIssuingCourtDate",
           ),
         ),
-        keyDates = KeyDates(
-          sentenceStartDate = LocalDate.now(),
-          effectiveSentenceEndDate = LocalDate.now().plusDays(1),
-          confirmedReleaseDate = LocalDate.now().plusDays(2),
-          releaseDate = LocalDate.now().plusDays(3),
-          sentenceExpiryDate = LocalDate.now().plusDays(4),
-          automaticReleaseDate = LocalDate.now().plusDays(5),
-          conditionalReleaseDate = LocalDate.now().plusDays(6),
-          nonParoleDate = LocalDate.now().plusDays(7),
-          postRecallReleaseDate = LocalDate.now().plusDays(8),
-          licenceExpiryDate = LocalDate.now().plusDays(9),
-          homeDetentionCurfewEligibilityDate = LocalDate.now().plusDays(10),
-          paroleEligibilityDate = LocalDate.now().plusDays(11),
-          homeDetentionCurfewActualDate = LocalDate.now().plusDays(12),
-          actualParoleDate = LocalDate.now().plusDays(13),
-          releaseOnTemporaryLicenceDate = LocalDate.now().plusDays(14),
-          earlyRemovalSchemeEligibilityDate = LocalDate.now().plusDays(15),
-          earlyTermDate = LocalDate.now().plusDays(16),
-          midTermDate = LocalDate.now().plusDays(17),
-          lateTermDate = LocalDate.now().plusDays(18),
-          topupSupervisionExpiryDate = LocalDate.now().plusDays(19),
-          tariffDate = LocalDate.now().plusDays(20),
-          dtoPostRecallReleaseDate = LocalDate.now().plusDays(21),
-          tariffEarlyRemovalSchemeEligibilityDate = LocalDate.now().plusDays(22),
-          topupSupervisionStartDate = LocalDate.now().plusDays(23),
-          homeDetentionCurfewEndDate = LocalDate.now().plusDays(24),
-        ),
+        keyDates = createKeyDates(),
       ),
     )
     val response = ClientResult.Success(HttpStatus.OK, sentenceInformation)
@@ -274,6 +248,28 @@ class PersonServiceTest {
   }
 
   @Test
+  fun `should set No active sentences category when no sentence information is available`() {
+    // Given
+    val sentenceInformation = SentenceInformation(
+      prisonerNumber = PRISON_NUMBER,
+      latestPrisonTerm = PrisonTerm(
+        courtSentences = emptyList(),
+        keyDates = createKeyDates(),
+      ),
+    )
+    val response = ClientResult.Success(HttpStatus.OK, sentenceInformation)
+    whenever(prisonApiClient.getSentenceInformation(PRISON_NUMBER)).thenReturn(response)
+
+    // When
+    personService.createOrUpdatePerson(PRISON_NUMBER)
+
+    // Then
+    verify(personRepository).save(personEntityCaptor.capture())
+    val personEntity = personEntityCaptor.value
+    personEntity.sentenceType shouldBe "No active sentences"
+  }
+
+  @Test
   fun `should add sentence information when creating a person`() {
     // Given
     whenever(personRepository.findPersonEntityByPrisonNumber(PRISON_NUMBER)).thenReturn(null)
@@ -295,4 +291,32 @@ class PersonServiceTest {
     val personEntity = personEntityCaptor.value
     personEntity.sentenceType shouldBe "Determinate and Indeterminate"
   }
+
+  private fun createKeyDates(): KeyDates = KeyDates(
+    sentenceStartDate = LocalDate.now(),
+    effectiveSentenceEndDate = LocalDate.now().plusDays(1),
+    confirmedReleaseDate = LocalDate.now().plusDays(2),
+    releaseDate = LocalDate.now().plusDays(3),
+    sentenceExpiryDate = LocalDate.now().plusDays(4),
+    automaticReleaseDate = LocalDate.now().plusDays(5),
+    conditionalReleaseDate = LocalDate.now().plusDays(6),
+    nonParoleDate = LocalDate.now().plusDays(7),
+    postRecallReleaseDate = LocalDate.now().plusDays(8),
+    licenceExpiryDate = LocalDate.now().plusDays(9),
+    homeDetentionCurfewEligibilityDate = LocalDate.now().plusDays(10),
+    paroleEligibilityDate = LocalDate.now().plusDays(11),
+    homeDetentionCurfewActualDate = LocalDate.now().plusDays(12),
+    actualParoleDate = LocalDate.now().plusDays(13),
+    releaseOnTemporaryLicenceDate = LocalDate.now().plusDays(14),
+    earlyRemovalSchemeEligibilityDate = LocalDate.now().plusDays(15),
+    earlyTermDate = LocalDate.now().plusDays(16),
+    midTermDate = LocalDate.now().plusDays(17),
+    lateTermDate = LocalDate.now().plusDays(18),
+    topupSupervisionExpiryDate = LocalDate.now().plusDays(19),
+    tariffDate = LocalDate.now().plusDays(20),
+    dtoPostRecallReleaseDate = LocalDate.now().plusDays(21),
+    tariffEarlyRemovalSchemeEligibilityDate = LocalDate.now().plusDays(22),
+    topupSupervisionStartDate = LocalDate.now().plusDays(23),
+    homeDetentionCurfewEndDate = LocalDate.now().plusDays(24),
+  )
 }

--- a/src/test/resources/simulations/__files/prison-search-results_A8610DY.json
+++ b/src/test/resources/simulations/__files/prison-search-results_A8610DY.json
@@ -1,0 +1,51 @@
+[
+  {
+    "prisonerNumber": "A8610DY",
+    "bookingId": "1201102",
+    "bookNumber": "38518A",
+    "firstName": "JOHN",
+    "lastName": "SMITH",
+    "dateOfBirth": "1940-12-20",
+    "gender": "Male",
+    "youthOffender": false,
+    "status": "INACTIVE TRN",
+    "lastMovementTypeCode": "TRN",
+    "lastMovementReasonCode": "MED",
+    "inOutStatus": "TRN",
+    "prisonId": "TRN",
+    "prisonName": "Transfer",
+    "aliases": [
+      {
+        "firstName": "DOUGLAS",
+        "lastName": "ADORNO",
+        "dateOfBirth": "1939-11-19",
+        "gender": "Male",
+        "ethnicity": "Asian/Asian British: Indian"
+      }
+    ],
+    "alerts": [
+      {
+        "alertType": "H",
+        "alertCode": "HA2",
+        "active": true,
+        "expired": false
+      }
+    ],
+    "legalStatus": "RECALL",
+    "imprisonmentStatus": "CUR_ORA",
+    "imprisonmentStatusDescription": "ORA Recalled from Curfew Conditions",
+    "recall": true,
+    "indeterminateSentence": false,
+    "receptionDate": "2021-01-08",
+    "locationDescription": "Transfer",
+    "restrictedPatient": false,
+    "currentIncentive": {
+      "level": {
+        "code": "ENH",
+        "description": "Enhanced"
+      },
+      "dateTime": "2022-06-08T14:41:18",
+      "nextReviewDate": "2023-06-08"
+    }
+  }
+]


### PR DESCRIPTION
## Context

For the case when Nomis does not return sentence information ensure sentence type is appropriately updated 

## Changes in this PR

- Created a new handling mechanism for cases where no active sentence data is returned. 
- Added corresponding unit tests 
- Updated the `SentenceCategoryType` enum to include "No active sentences".

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
