### PR TITLE
APG-461 Add course participation retrieval by status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/CourseParticipationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/CourseParticipationRepository.kt
@@ -5,11 +5,15 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseStatus
 import java.util.UUID
 
 @Repository
 interface CourseParticipationRepository : JpaRepository<CourseParticipationEntity, UUID> {
+
   fun findByPrisonNumber(prisonNumber: String): List<CourseParticipationEntity>
+
+  fun findByPrisonNumberAndOutcomeStatusIn(prisonNumber: String, outcomes: List<CourseStatus>): List<CourseParticipationEntity>
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/CourseParticipationOutcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/CourseParticipationOutcome.kt
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class CourseParticipationOutcome(
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("status", required = true) val status: CourseParticipationOutcome.Status,
+  @get:JsonProperty("status", required = true) val status: Status,
 
   @Schema(example = "null", description = "")
   @get:JsonProperty("yearStarted") val yearStarted: Int? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseParticipationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseParticipationService.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.CourseParticipationUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseParticipationRepository
 import java.util.UUID
@@ -37,6 +38,10 @@ constructor(
 
   fun deleteCourseParticipationById(historicCourseParticipationId: UUID) {
     courseParticipationRepository.deleteById(historicCourseParticipationId)
+  }
+
+  fun getCourseParticipationsByPrisonNumberAndStatus(prisonNumber: String, outcomeStatus: List<CourseStatus>): List<CourseParticipationEntity> {
+    return courseParticipationRepository.findByPrisonNumberAndOutcomeStatusIn(prisonNumber, outcomeStatus)
   }
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PeopleControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PeopleControllerIntegrationTest.kt
@@ -13,17 +13,21 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.PRISONER_1
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CourseParticipation
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CourseParticipationOutcome.Status
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Offence
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.PeopleSearchRequest
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.PeopleSearchResponse
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.SentenceDetails
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.Month
+import java.util.UUID
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @Import(JwtAuthHelper::class)
-class PersonIntegrationTest : IntegrationTestBase() {
+class PeopleControllerIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `get sentences by prison number should return 200 with matching entries`() {
@@ -88,6 +92,25 @@ class PersonIntegrationTest : IntegrationTestBase() {
     )
   }
 
+  @Test
+  fun `should return course participation history with a 200 success code`() {
+    // Given
+    mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
+    persistenceHelper.clearAllTableContent()
+    persistenceHelper.createParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
+    persistenceHelper.createParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
+    persistenceHelper.createParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), "A1234AA", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "COMPLETE", 2023, null, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+
+    // When
+    val courseParticipations = getCourseParticipations("A1234AA", listOf(Status.COMPLETE, Status.INCOMPLETE))
+
+    // Then
+    courseParticipations.shouldNotBeNull()
+    courseParticipations.size shouldBe 3
+    courseParticipations.map { it.courseName } shouldBe listOf("Green Course", "Red Course", "Orange Course")
+  }
+
   fun searchPrisoners(peopleSearchRequest: PeopleSearchRequest) =
     webTestClient
       .post()
@@ -120,5 +143,21 @@ class PersonIntegrationTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isOk
       .expectBody<List<Offence>>()
+      .returnResult().responseBody!!
+
+  private fun getCourseParticipations(prisonNumber: String, outcomeStatus: List<Status>): List<CourseParticipation> =
+    webTestClient
+      .get()
+      .uri { builder ->
+          builder
+              .path("/people/$prisonNumber/course-participation-history")
+              .queryParam("outcomeStatus", outcomeStatus.joinToString(","))
+              .build()
+      }
+        .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<List<CourseParticipation>>()
       .returnResult().responseBody!!
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseParticipationRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseParticipationRepositoryIntegrationTest.kt
@@ -1,0 +1,77 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseStatus
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseParticipationRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.IntegrationTestBase
+import java.time.LocalDateTime
+import java.util.UUID
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+class CourseParticipationRepositoryIntegrationTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var courseParticipationRepository: CourseParticipationRepository
+
+  @BeforeEach
+  fun setUp() {
+    persistenceHelper.clearAllTableContent()
+    persistenceHelper.createParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
+    persistenceHelper.createParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
+    persistenceHelper.createParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), "A1234AA", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "COMPLETE", 2023, null, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+  }
+
+  @Test
+  fun `should retrieve all completed course participations for prison number`() {
+    // Given
+    val prisonNumber = "A1234AA"
+    val outcomes = listOf(CourseStatus.COMPLETE)
+
+    // When
+    val completedCourseParticipations = courseParticipationRepository.findByPrisonNumberAndOutcomeStatusIn(prisonNumber, outcomes)
+
+    // Then
+    assertThat(completedCourseParticipations).hasSize(1)
+    assertThat(completedCourseParticipations[0].courseName).isEqualTo("Orange Course")
+    assertThat(completedCourseParticipations[0].detail).isEqualTo("This participation will be updated")
+  }
+
+  @Test
+  fun `should retrieve all incomplete course participations for prison number`() {
+    // Given
+    val prisonNumber = "A1234AA"
+    val outcomes = listOf(CourseStatus.INCOMPLETE)
+
+    // When
+    val completedCourseParticipations = courseParticipationRepository.findByPrisonNumberAndOutcomeStatusIn(prisonNumber, outcomes)
+
+    // Then
+    assertThat(completedCourseParticipations).hasSize(2)
+    assertThat(completedCourseParticipations[0].courseName).isEqualTo("Green Course")
+    assertThat(completedCourseParticipations[0].detail).isEqualTo("Some detail")
+    assertThat(completedCourseParticipations[1].courseName).isEqualTo("Red Course")
+    assertThat(completedCourseParticipations[1].detail).isEqualTo("Some detail")
+  }
+
+  @Test
+  fun `should retrieve all complete and incomplete course participations for prison number`() {
+    // Given
+    val prisonNumber = "A1234AA"
+    val outcomes = listOf(CourseStatus.INCOMPLETE, CourseStatus.COMPLETE)
+
+    // When
+    val completedCourseParticipations = courseParticipationRepository.findByPrisonNumberAndOutcomeStatusIn(prisonNumber, outcomes)
+
+    // Then
+    assertThat(completedCourseParticipations).hasSize(3)
+    assertThat(completedCourseParticipations.count { it.outcome?.status == CourseStatus.COMPLETE }).isEqualTo(1)
+    assertThat(completedCourseParticipations.count { it.outcome?.status == CourseStatus.INCOMPLETE }).isEqualTo(2)
+  }
+}


### PR DESCRIPTION


## Context

Allow for the retrieval of completed programme History from the API

## Changes in this PR

- Implemented repo method to fetch course participation records by prison number and outcome status within the `CourseParticipationRepository`. 
- New Service method implementation
- Updated `PeopleController` with a new endpoint to support this query and added corresponding integration tests. 
- Deprecated existing similar PeopleController endpoint in Swagger docs


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
