### PR TITLE
Ensure appropriate behaviour for null Sara score 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/type/SaraRisk.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/type/SaraRisk.kt
@@ -11,7 +11,7 @@ enum class SaraRisk(private val score: Int) {
   companion object {
     fun fromString(value: String?): SaraRisk {
       return SaraRisk.entries.find { it.name.equals(value, ignoreCase = true) }
-        ?: throw IllegalArgumentException("Unknown SARA Risk: $value")
+        ?: NOT_APPLICABLE
     }
 
     fun highestRisk(risk1: SaraRisk, risk2: SaraRisk): SaraRisk {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/type/SaraRiskTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/type/SaraRiskTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type
 
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.Test
 
 class SaraRiskTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/type/SaraRiskTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/type/SaraRiskTest.kt
@@ -49,10 +49,24 @@ class SaraRiskTest {
   }
 
   @Test
-  fun `fromString should throw IllegalArgumentException when value is unknown`() {
-    assertThatIllegalArgumentException().isThrownBy {
-      SaraRisk.fromString("UNKNOWN")
-    }.withMessage("Unknown SARA Risk: UNKNOWN")
+  fun `fromString should NOT_APPLICABLE for null risk`() {
+    // Given & When
+    val saraRisk = SaraRisk.fromString(null)
+    // Then
+    assertThat(saraRisk).isSameAs(SaraRisk.NOT_APPLICABLE)
+  }
+
+  @Test
+  fun `should return not applicable when sara risk does not exist`() {
+    // Given
+    val risk1 = SaraRisk.NOT_APPLICABLE
+    val risk2 = SaraRisk.NOT_APPLICABLE
+
+    // When
+    val highestRisk = SaraRisk.highestRisk(risk1, risk2)
+
+    // Then
+    assertThat(highestRisk).isEqualTo(SaraRisk.NOT_APPLICABLE)
   }
 
   @Test


### PR DESCRIPTION
## Changes in this PR

1. Modified the `fromString` method in the `SaraRisk` class to return `NOT_APPLICABLE` instead of throwing an `IllegalArgumentException` when an unknown value is provided. 
2. Updated the unit tests to reflect this change and to ensure that this new behavior is properly validated.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
