### PR TITLE
Make PNI domain scores nullable to accurately represent missing values

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/IndividualNeedsScores.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/IndividualNeedsScores.kt
@@ -57,10 +57,11 @@ data class IndividualSexScores(
 
   @JsonIgnore
   fun overallSexDomainScore(totalScore: Int) = when {
+    totalScore == 0 -> null
     totalScore in 4..6 || (offenceRelatedSexualInterests == 2) -> 2
     totalScore in 0..1 -> 0
     totalScore in 2..3 -> 1
-    else -> 0
+    else -> null
   }
 }
 
@@ -77,13 +78,14 @@ data class IndividualCognitiveScores(
       (hostileOrientation ?: 0)
   }
 
-  fun overallCognitiveDomainScore(): Int {
+  fun overallCognitiveDomainScore(): Int? {
     val totalScore = totalScore()
 
     return when {
+      totalScore == 0 -> null
       totalScore in 3..4 || (proCriminalAttitudes == 2) -> 2
       totalScore in 1..2 -> 1
-      else -> 0
+      else -> null
     }
   }
 }
@@ -110,10 +112,11 @@ data class IndividualSelfManagementScores(
 
   fun overallSelfManagementScore() =
     when (totalScore()) {
+      0 -> null
       in 0..1 -> 0
       in 2..4 -> 1
       in 5..8 -> 2
-      else -> 0
+      else -> null
     }
 }
 
@@ -140,9 +143,10 @@ data class IndividualRelationshipScores(
   }
 
   fun overallRelationshipScore() = when (totalScore()) {
+    0 -> null
     in 0..1 -> 0
     in 2..4 -> 1
     in 5..8 -> 2
-    else -> 0
+    else -> null
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/NeedsScore.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/NeedsScore.kt
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 data class NeedsScore(
   @Schema(example = "5", required = true)
-  @get:JsonProperty("overallNeedsScore") val overallNeedsScore: Int,
+  @get:JsonProperty("overallNeedsScore") val overallNeedsScore: Int?,
   @Schema(example = "6")
   @get:JsonProperty("basicSkillsScore") val basicSkillsScore: Int?,
   @Schema(example = "High Intensity BC", required = true)
@@ -35,12 +35,12 @@ data class DomainScore(
 
 data class SexDomainScore(
   @Schema(example = "2", required = true)
-  @get:JsonProperty("overallSexDomainScore") val overAllSexDomainScore: Int,
+  @get:JsonProperty("overallSexDomainScore") val overAllSexDomainScore: Int?,
   @get:JsonProperty("individualSexScores") val individualSexScores: IndividualSexScores,
 )
 
 data class ThinkingDomainScore(
-  @get:JsonProperty("overallThinkingDomainScore") val overallThinkingDomainScore: Int,
+  @get:JsonProperty("overallThinkingDomainScore") val overallThinkingDomainScore: Int?,
   @get:JsonProperty("individualThinkingScores") val individualThinkingScores: IndividualCognitiveScores,
 ) {
   @JsonIgnore
@@ -56,7 +56,7 @@ data class ThinkingDomainScore(
 }
 
 data class RelationshipDomainScore(
-  @get:JsonProperty("overallRelationshipDomainScore") val overallRelationshipDomainScore: Int,
+  @get:JsonProperty("overallRelationshipDomainScore") val overallRelationshipDomainScore: Int?,
   @get:JsonProperty("individualRelationshipScores") val individualRelationshipScores: IndividualRelationshipScores,
 ) {
   @JsonIgnore
@@ -77,7 +77,7 @@ data class RelationshipDomainScore(
 }
 
 data class SelfManagementDomainScore(
-  @get:JsonProperty("overallSelfManagementDomainScore") val overallSelfManagementDomainScore: Int,
+  @get:JsonProperty("overallSelfManagementDomainScore") val overallSelfManagementDomainScore: Int?,
   @get:JsonProperty("individualSelfManagementScores") val individualSelfManagementScores: IndividualSelfManagementScores,
 ) {
   @JsonIgnore

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualCognitiveScoresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualCognitiveScoresTest.kt
@@ -24,7 +24,7 @@ class IndividualCognitiveScoresTest {
     @JvmStatic
     fun scoresForOverallCognitiveDomainScore(): Stream<Arguments> {
       return Stream.of(
-        Arguments.of(IndividualCognitiveScores(0, 0), 0, 0),
+        Arguments.of(IndividualCognitiveScores(0, 0), 0, null),
         Arguments.of(IndividualCognitiveScores(1, 0), 1, 1),
         Arguments.of(IndividualCognitiveScores(1, 1), 2, 1),
         Arguments.of(IndividualCognitiveScores(2, 1), 3, 2),
@@ -42,7 +42,7 @@ class IndividualCognitiveScoresTest {
 
   @ParameterizedTest
   @MethodSource("scoresForOverallCognitiveDomainScore")
-  fun `overallCognitiveDomainScore returned as expected`(scores: IndividualCognitiveScores, totalScore: Int, expected: Int) {
+  fun `overallCognitiveDomainScore returned as expected`(scores: IndividualCognitiveScores, totalScore: Int, expected: Int?) {
     assertEquals(expected, scores.overallCognitiveDomainScore())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualRelationshipScoresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualRelationshipScoresTest.kt
@@ -26,7 +26,7 @@ class IndividualRelationshipScoresTest {
     @JvmStatic
     fun scoresForOverallRelationshipScore(): Stream<Arguments> {
       return Stream.of(
-        Arguments.of(IndividualRelationshipScores(0, 0, 0, 0), 0),
+        Arguments.of(IndividualRelationshipScores(0, 0, 0, 0), null),
         Arguments.of(IndividualRelationshipScores(1, 0, 0, 0), 0),
         Arguments.of(IndividualRelationshipScores(1, 1, 0, 0), 1),
         Arguments.of(IndividualRelationshipScores(1, 1, 1, 0), 1),
@@ -39,13 +39,13 @@ class IndividualRelationshipScoresTest {
 
   @ParameterizedTest
   @MethodSource("scoresForTotalScore")
-  fun `totalScore returned as expected`(scores: IndividualRelationshipScores, expected: Int) {
+  fun `totalScore returned as expected`(scores: IndividualRelationshipScores, expected: Int?) {
     assertEquals(expected, scores.totalScore())
   }
 
   @ParameterizedTest
   @MethodSource("scoresForOverallRelationshipScore")
-  fun `overall relationship score returned as expected`(scores: IndividualRelationshipScores, expected: Int) {
+  fun `overall relationship score returned as expected`(scores: IndividualRelationshipScores, expected: Int?) {
     assertEquals(expected, scores.overallRelationshipScore())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualSelfManagementScoresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualSelfManagementScoresTest.kt
@@ -26,7 +26,7 @@ class IndividualSelfManagementScoresTest {
     @JvmStatic
     fun scoresForOverallSelfManagementScore(): Stream<Arguments> {
       return Stream.of(
-        Arguments.of(IndividualSelfManagementScores(0, 0, 0, 0), 0),
+        Arguments.of(IndividualSelfManagementScores(0, 0, 0, 0), null),
         Arguments.of(IndividualSelfManagementScores(1, 0, 0, 0), 0),
         Arguments.of(IndividualSelfManagementScores(1, 1, 0, 0), 1),
         Arguments.of(IndividualSelfManagementScores(1, 1, 1, 0), 1),
@@ -45,7 +45,7 @@ class IndividualSelfManagementScoresTest {
 
   @ParameterizedTest
   @MethodSource("scoresForOverallSelfManagementScore")
-  fun `overallSelfManagementScore returned as expected`(scores: IndividualSelfManagementScores, expected: Int) {
+  fun `overallSelfManagementScore returned as expected`(scores: IndividualSelfManagementScores, expected: Int?) {
     assertEquals(expected, scores.overallSelfManagementScore())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualSexScoresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualSexScoresTest.kt
@@ -34,6 +34,7 @@ class IndividualSexScoresTest {
     @JvmStatic
     fun scoresForOverallSexDomainScore(): Stream<Arguments> {
       return Stream.of(
+        Arguments.of(IndividualSexScores(0, 0, 0), 0, null),
         Arguments.of(IndividualSexScores(0, 1, 0), 1, 0),
         Arguments.of(IndividualSexScores(1, 1, 1), 3, 1),
         Arguments.of(IndividualSexScores(2, 2, 2), 6, 2),
@@ -57,7 +58,7 @@ class IndividualSexScoresTest {
 
   @ParameterizedTest
   @MethodSource("scoresForOverallSexDomainScore")
-  fun `test overallSexDomainScore method`(scores: IndividualSexScores, totalScore: Int, expected: Int) {
+  fun `test overallSexDomainScore method`(scores: IndividualSexScores, totalScore: Int, expected: Int?) {
     assertEquals(expected, scores.overallSexDomainScore(totalScore))
   }
 }


### PR DESCRIPTION

## Changes in this PR

- Changed various domain score methods to return `null` instead of `0` when total scores are zero. 
- This ensures `null` values are accurately handled and used in calculations, providing a more precise representation of scores. 
- Updated relevant tests and methods accordingly.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
