### PR TITLE
Refactor score calculations to handle null values in test cases

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/IndividualNeedsScores.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/IndividualNeedsScores.kt
@@ -58,9 +58,8 @@ data class IndividualSexScores(
   @JsonIgnore
   fun overallSexDomainScore(totalScore: Int?) = when {
     !areAllValuesPresent() -> null
-    totalScore == 0 -> null
+    totalScore == 1 -> 0
     totalScore in 4..6 || (offenceRelatedSexualInterests == 2) -> 2
-    totalScore in 0..1 -> 0
     totalScore in 2..3 -> 1
     else -> null
   }
@@ -84,7 +83,6 @@ data class IndividualCognitiveScores(
     val totalScore = totalScore()
 
     return when {
-      totalScore == 0 -> null
       totalScore in 3..4 || (proCriminalAttitudes == 2) -> 2
       totalScore in 1..2 -> 1
       else -> null
@@ -116,8 +114,7 @@ data class IndividualSelfManagementScores(
     if (!areAllValuesPresent()) return null
 
     return when (totalScore()) {
-      0 -> null
-      in 0..1 -> 0
+      1 -> 0
       in 2..4 -> 1
       in 5..8 -> 2
       else -> null
@@ -151,8 +148,7 @@ data class IndividualRelationshipScores(
     if (!areAllValuesPresent()) return null
 
     return when (totalScore()) {
-      0 -> null
-      in 0..1 -> 0
+      1 -> 0
       in 2..4 -> 1
       in 5..8 -> 2
       else -> null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/IndividualNeedsScores.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/IndividualNeedsScores.kt
@@ -3,6 +3,13 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import kotlin.reflect.full.memberProperties
+
+// Extension function to check if all properties of a data class are non-null
+fun <T : Any> T.areAllValuesPresent(): Boolean {
+  return this::class.memberProperties
+    .all { property -> property.call(this) != null }
+}
 
 /**
  *
@@ -41,12 +48,12 @@ data class IndividualSexScores(
     emotionalCongruence,
   ).any { it != null }
 
-  @JsonIgnore
-  fun isAllValuesPresent() = listOf(
-    sexualPreOccupation,
-    offenceRelatedSexualInterests,
-    emotionalCongruence,
-  ).all { it != null }
+//  @JsonIgnore
+//  fun isAllValuesPresent() = listOf(
+//    sexualPreOccupation,
+//    offenceRelatedSexualInterests,
+//    emotionalCongruence,
+//  ).all { it != null }
 
   @JsonIgnore
   fun totalScore(): Int {
@@ -56,7 +63,8 @@ data class IndividualSexScores(
   }
 
   @JsonIgnore
-  fun overallSexDomainScore(totalScore: Int) = when {
+  fun overallSexDomainScore(totalScore: Int?) = when {
+    !areAllValuesPresent() -> null
     totalScore == 0 -> null
     totalScore in 4..6 || (offenceRelatedSexualInterests == 2) -> 2
     totalScore in 0..1 -> 0
@@ -79,6 +87,7 @@ data class IndividualCognitiveScores(
   }
 
   fun overallCognitiveDomainScore(): Int? {
+    if (!areAllValuesPresent()) return null
     val totalScore = totalScore()
 
     return when {
@@ -110,14 +119,25 @@ data class IndividualSelfManagementScores(
       (difficultiesCoping ?: 0)
   }
 
-  fun overallSelfManagementScore() =
-    when (totalScore()) {
+//  @JsonIgnore
+//  fun areAllValuesPresent() = listOf(
+//    impulsivity,
+//    temperControl,
+//    problemSolvingSkills,
+//    difficultiesCoping,
+//  ).all { it != null }
+
+  fun overallSelfManagementScore(): Int? {
+    if (!areAllValuesPresent()) return null
+
+    return when (totalScore()) {
       0 -> null
       in 0..1 -> 0
       in 2..4 -> 1
       in 5..8 -> 2
       else -> null
     }
+  }
 }
 
 data class IndividualRelationshipScores(
@@ -142,11 +162,23 @@ data class IndividualRelationshipScores(
       (aggressiveControllingBehaviour ?: 0)
   }
 
-  fun overallRelationshipScore() = when (totalScore()) {
-    0 -> null
-    in 0..1 -> 0
-    in 2..4 -> 1
-    in 5..8 -> 2
-    else -> null
+//  @JsonIgnore
+//  fun areAllValuesPresent() = listOf(
+//    curRelCloseFamily,
+//    prevExpCloseRel,
+//    easilyInfluenced,
+//    aggressiveControllingBehaviour,
+//  ).all { it != null }
+
+  fun overallRelationshipScore(): Int? {
+    if (!areAllValuesPresent()) return null
+
+    return when (totalScore()) {
+      0 -> null
+      in 0..1 -> 0
+      in 2..4 -> 1
+      in 5..8 -> 2
+      else -> null
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/IndividualNeedsScores.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/IndividualNeedsScores.kt
@@ -57,11 +57,10 @@ data class IndividualSexScores(
 
   @JsonIgnore
   fun overallSexDomainScore(totalScore: Int?) = when {
-    !areAllValuesPresent() -> null
-    totalScore == 1 -> 0
     totalScore in 4..6 || (offenceRelatedSexualInterests == 2) -> 2
+    totalScore in 0..1 -> 0
     totalScore in 2..3 -> 1
-    else -> null
+    else -> 0
   }
 }
 
@@ -79,10 +78,10 @@ data class IndividualCognitiveScores(
   }
 
   fun overallCognitiveDomainScore(): Int? {
-    if (!areAllValuesPresent()) return null
     val totalScore = totalScore()
 
     return when {
+      totalScore == 0 -> 0
       totalScore in 3..4 || (proCriminalAttitudes == 2) -> 2
       totalScore in 1..2 -> 1
       else -> null
@@ -111,10 +110,8 @@ data class IndividualSelfManagementScores(
   }
 
   fun overallSelfManagementScore(): Int? {
-    if (!areAllValuesPresent()) return null
-
     return when (totalScore()) {
-      1 -> 0
+      in 0..1 -> 0
       in 2..4 -> 1
       in 5..8 -> 2
       else -> null
@@ -145,10 +142,8 @@ data class IndividualRelationshipScores(
   }
 
   fun overallRelationshipScore(): Int? {
-    if (!areAllValuesPresent()) return null
-
     return when (totalScore()) {
-      1 -> 0
+      in 0..1 -> 0
       in 2..4 -> 1
       in 5..8 -> 2
       else -> null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/IndividualNeedsScores.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/IndividualNeedsScores.kt
@@ -48,13 +48,6 @@ data class IndividualSexScores(
     emotionalCongruence,
   ).any { it != null }
 
-//  @JsonIgnore
-//  fun isAllValuesPresent() = listOf(
-//    sexualPreOccupation,
-//    offenceRelatedSexualInterests,
-//    emotionalCongruence,
-//  ).all { it != null }
-
   @JsonIgnore
   fun totalScore(): Int {
     return (sexualPreOccupation ?: 0) +
@@ -119,14 +112,6 @@ data class IndividualSelfManagementScores(
       (difficultiesCoping ?: 0)
   }
 
-//  @JsonIgnore
-//  fun areAllValuesPresent() = listOf(
-//    impulsivity,
-//    temperControl,
-//    problemSolvingSkills,
-//    difficultiesCoping,
-//  ).all { it != null }
-
   fun overallSelfManagementScore(): Int? {
     if (!areAllValuesPresent()) return null
 
@@ -161,14 +146,6 @@ data class IndividualRelationshipScores(
       (easilyInfluenced ?: 0) +
       (aggressiveControllingBehaviour ?: 0)
   }
-
-//  @JsonIgnore
-//  fun areAllValuesPresent() = listOf(
-//    curRelCloseFamily,
-//    prevExpCloseRel,
-//    easilyInfluenced,
-//    aggressiveControllingBehaviour,
-//  ).all { it != null }
 
   fun overallRelationshipScore(): Int? {
     if (!areAllValuesPresent()) return null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniNeedsEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniNeedsEngine.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.a
 @Service
 class PniNeedsEngine {
   val validOspLevels = listOf("LOW", "MEDIUM", "HIGH", "VERY_HIGH")
+
   fun getOverallNeedsScore(
     individualNeedsAndRiskScores: IndividualNeedsAndRiskScores,
     prisonNumber: String,
@@ -25,10 +26,8 @@ class PniNeedsEngine {
     val overallThinkingDomainScore = individualNeedsScores.individualCognitiveScores.overallCognitiveDomainScore()
     val overallRelationshipDomainScore = individualNeedsScores.individualRelationshipScores.overallRelationshipScore()
     val overallSelfManagementScore = individualNeedsScores.individualSelfManagementScores.overallSelfManagementScore()
-    val overallNeedsScore =
-      listOf(overallSexDomainScore, overallThinkingDomainScore, overallRelationshipDomainScore, overallSelfManagementScore)
-        .filterNotNull()
-        .sum()
+
+    val overallNeedsScore = calculateOverallNeedScore(individualNeedsAndRiskScores, prisonNumber, gender)
 
     return NeedsScore(
       overallNeedsScore = overallNeedsScore,
@@ -55,6 +54,16 @@ class PniNeedsEngine {
     )
   }
 
+  fun calculateOverallNeedScore(needsAndRiskScores: IndividualNeedsAndRiskScores, prisonNumber: String, gender: String): Int? {
+    val scores = listOf(
+      getSexDomainScore(needsAndRiskScores, prisonNumber, gender),
+      needsAndRiskScores.individualNeedsScores.individualCognitiveScores.overallCognitiveDomainScore(),
+      needsAndRiskScores.individualNeedsScores.individualRelationshipScores.overallRelationshipScore(),
+      needsAndRiskScores.individualNeedsScores.individualSelfManagementScores.overallSelfManagementScore(),
+    )
+    return if (scores.all { it != null }) scores.filterNotNull().sum() else null
+  }
+
   fun getSexDomainScore(individualNeedsAndRiskScores: IndividualNeedsAndRiskScores, prisonNumber: String, gender: String?): Int? {
     val individualSexScores = individualNeedsAndRiskScores.individualNeedsScores.individualSexScores
 
@@ -76,8 +85,9 @@ class PniNeedsEngine {
   }
 }
 
-private fun getClassification(overallNeedsScore: Int): String {
+private fun getClassification(overallNeedsScore: Int?): String {
   return when (overallNeedsScore) {
+    null -> NeedsClassification.INFORMATION_MISSING.name
     in 0..2 -> NeedsClassification.LOW_NEED.name
     in 3..5 -> NeedsClassification.MEDIUM_NEED.name
     in 6..8 -> NeedsClassification.HIGH_NEED.name
@@ -89,4 +99,5 @@ enum class NeedsClassification {
   LOW_NEED,
   MEDIUM_NEED,
   HIGH_NEED,
+  INFORMATION_MISSING,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniNeedsEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniNeedsEngine.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.R
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.SelfManagementDomainScore
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.SexDomainScore
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ThinkingDomainScore
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.areAllValuesPresent
 
 @Service
 class PniNeedsEngine {
@@ -57,7 +58,7 @@ class PniNeedsEngine {
   fun getSexDomainScore(individualNeedsAndRiskScores: IndividualNeedsAndRiskScores, prisonNumber: String, gender: String?): Int? {
     val individualSexScores = individualNeedsAndRiskScores.individualNeedsScores.individualSexScores
 
-    if (individualSexScores.isAllValuesPresent()) {
+    if (individualSexScores.areAllValuesPresent()) {
       return individualSexScores.overallSexDomainScore(individualSexScores.totalScore())
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PniIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PniIntegrationTest.kt
@@ -51,9 +51,9 @@ class PniIntegrationTest :
     assessmentId = 2114584,
     programmePathway = "MISSING_INFORMATION",
     needsScore = NeedsScore(
-      overallNeedsScore = 6,
+      overallNeedsScore = 4,
       basicSkillsScore = 33,
-      classification = "HIGH_NEED",
+      classification = "MEDIUM_NEED",
       domainScore = DomainScore(
         sexDomainScore = SexDomainScore(
           overAllSexDomainScore = 2,
@@ -80,7 +80,7 @@ class PniIntegrationTest :
           ),
         ),
         selfManagementDomainScore = SelfManagementDomainScore(
-          overallSelfManagementDomainScore = 2,
+          overallSelfManagementDomainScore = null,
           individualSelfManagementScores = IndividualSelfManagementScores(
             impulsivity = 1,
             temperControl = 4,
@@ -120,12 +120,13 @@ class PniIntegrationTest :
     // Then
     val pniResults = pniResultEntityRepository.findAllByPrisonNumber(prisonNumber)
     pniResults[0].prisonNumber shouldBe prisonNumber
-    pniResults[0].crn shouldBe buildPniScore(prisonNumber).crn
-    pniResults[0].needsClassification shouldBe buildPniScore(prisonNumber).needsScore.classification
-    pniResults[0].overallNeedsScore shouldBe buildPniScore(prisonNumber).needsScore.overallNeedsScore
-    pniResults[0].programmePathway shouldBe buildPniScore(prisonNumber).programmePathway
-    pniResults[0].riskClassification shouldBe buildPniScore(prisonNumber).riskScore.classification
-    pniResults[0].pniResultJson shouldBe objectMapper.writeValueAsString(buildPniScore(prisonNumber))
+    val pniScore = buildPniScore(prisonNumber)
+    pniResults[0].crn shouldBe pniScore.crn
+    pniResults[0].needsClassification shouldBe pniScore.needsScore.classification
+    pniResults[0].overallNeedsScore shouldBe pniScore.needsScore.overallNeedsScore
+    pniResults[0].programmePathway shouldBe pniScore.programmePathway
+    pniResults[0].riskClassification shouldBe pniScore.riskScore.classification
+    pniResults[0].pniResultJson shouldBe objectMapper.writeValueAsString(pniScore)
     pniResults[0].pniValid shouldBe false
     pniResults[0].basicSkillsScore shouldBe 33
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PniIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PniIntegrationTest.kt
@@ -51,9 +51,9 @@ class PniIntegrationTest :
     assessmentId = 2114584,
     programmePathway = "MISSING_INFORMATION",
     needsScore = NeedsScore(
-      overallNeedsScore = 4,
+      overallNeedsScore = 6,
       basicSkillsScore = 33,
-      classification = "MEDIUM_NEED",
+      classification = "HIGH_NEED",
       domainScore = DomainScore(
         sexDomainScore = SexDomainScore(
           overAllSexDomainScore = 2,
@@ -80,7 +80,7 @@ class PniIntegrationTest :
           ),
         ),
         selfManagementDomainScore = SelfManagementDomainScore(
-          overallSelfManagementDomainScore = null,
+          overallSelfManagementDomainScore = 2,
           individualSelfManagementScores = IndividualSelfManagementScores(
             impulsivity = 1,
             temperControl = 4,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualCognitiveScoresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualCognitiveScoresTest.kt
@@ -24,12 +24,14 @@ class IndividualCognitiveScoresTest {
     @JvmStatic
     fun scoresForOverallCognitiveDomainScore(): Stream<Arguments> {
       return Stream.of(
-        Arguments.of(IndividualCognitiveScores(0, 0), 0, null),
-        Arguments.of(IndividualCognitiveScores(1, 0), 1, 1),
-        Arguments.of(IndividualCognitiveScores(1, 1), 2, 1),
-        Arguments.of(IndividualCognitiveScores(2, 1), 3, 2),
-        Arguments.of(IndividualCognitiveScores(2, 2), 4, 2),
-        Arguments.of(IndividualCognitiveScores(2, 0), 2, 2),
+        Arguments.of(IndividualCognitiveScores(0, 0), null),
+        Arguments.of(IndividualCognitiveScores(1, null), null),
+        Arguments.of(IndividualCognitiveScores(null, 0), null),
+        Arguments.of(IndividualCognitiveScores(1, 0), 1),
+        Arguments.of(IndividualCognitiveScores(1, 1), 1),
+        Arguments.of(IndividualCognitiveScores(2, 1), 2),
+        Arguments.of(IndividualCognitiveScores(2, 2), 2),
+        Arguments.of(IndividualCognitiveScores(2, 0), 2),
       )
     }
   }
@@ -42,7 +44,7 @@ class IndividualCognitiveScoresTest {
 
   @ParameterizedTest
   @MethodSource("scoresForOverallCognitiveDomainScore")
-  fun `overallCognitiveDomainScore returned as expected`(scores: IndividualCognitiveScores, totalScore: Int, expected: Int?) {
+  fun `overallCognitiveDomainScore returned as expected`(scores: IndividualCognitiveScores, expected: Int?) {
     assertEquals(expected, scores.overallCognitiveDomainScore())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualCognitiveScoresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualCognitiveScoresTest.kt
@@ -24,9 +24,9 @@ class IndividualCognitiveScoresTest {
     @JvmStatic
     fun scoresForOverallCognitiveDomainScore(): Stream<Arguments> {
       return Stream.of(
-        Arguments.of(IndividualCognitiveScores(0, 0), null),
-        Arguments.of(IndividualCognitiveScores(1, null), null),
-        Arguments.of(IndividualCognitiveScores(null, 0), null),
+        Arguments.of(IndividualCognitiveScores(0, 0), 0),
+        Arguments.of(IndividualCognitiveScores(1, null), 1),
+        Arguments.of(IndividualCognitiveScores(null, 2), 1),
         Arguments.of(IndividualCognitiveScores(1, 0), 1),
         Arguments.of(IndividualCognitiveScores(1, 1), 1),
         Arguments.of(IndividualCognitiveScores(2, 1), 2),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualRelationshipScoresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualRelationshipScoresTest.kt
@@ -28,6 +28,10 @@ class IndividualRelationshipScoresTest {
       return Stream.of(
         Arguments.of(IndividualRelationshipScores(0, 0, 0, 0), null),
         Arguments.of(IndividualRelationshipScores(1, 0, 0, 0), 0),
+        Arguments.of(IndividualRelationshipScores(null, 2, 3, 4), null),
+        Arguments.of(IndividualRelationshipScores(1, null, 3, 4), null),
+        Arguments.of(IndividualRelationshipScores(1, 2, null, 4), null),
+        Arguments.of(IndividualRelationshipScores(1, 2, 3, null), null),
         Arguments.of(IndividualRelationshipScores(1, 1, 0, 0), 1),
         Arguments.of(IndividualRelationshipScores(1, 1, 1, 0), 1),
         Arguments.of(IndividualRelationshipScores(1, 1, 1, 1), 1),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualRelationshipScoresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualRelationshipScoresTest.kt
@@ -26,12 +26,12 @@ class IndividualRelationshipScoresTest {
     @JvmStatic
     fun scoresForOverallRelationshipScore(): Stream<Arguments> {
       return Stream.of(
-        Arguments.of(IndividualRelationshipScores(0, 0, 0, 0), null),
+        Arguments.of(IndividualRelationshipScores(0, 0, 0, 0), 0),
         Arguments.of(IndividualRelationshipScores(1, 0, 0, 0), 0),
-        Arguments.of(IndividualRelationshipScores(null, 2, 3, 4), null),
-        Arguments.of(IndividualRelationshipScores(1, null, 3, 4), null),
-        Arguments.of(IndividualRelationshipScores(1, 2, null, 4), null),
-        Arguments.of(IndividualRelationshipScores(1, 2, 3, null), null),
+        Arguments.of(IndividualRelationshipScores(null, 1, 2, 3), 2),
+        Arguments.of(IndividualRelationshipScores(1, null, 3, 4), 2),
+        Arguments.of(IndividualRelationshipScores(1, 2, null, 4), 2),
+        Arguments.of(IndividualRelationshipScores(1, 2, 3, null), 2),
         Arguments.of(IndividualRelationshipScores(1, 1, 0, 0), 1),
         Arguments.of(IndividualRelationshipScores(1, 1, 1, 0), 1),
         Arguments.of(IndividualRelationshipScores(1, 1, 1, 1), 1),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualSelfManagementScoresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualSelfManagementScoresTest.kt
@@ -27,6 +27,10 @@ class IndividualSelfManagementScoresTest {
     fun scoresForOverallSelfManagementScore(): Stream<Arguments> {
       return Stream.of(
         Arguments.of(IndividualSelfManagementScores(0, 0, 0, 0), null),
+        Arguments.of(IndividualSelfManagementScores(null, 2, 3, 4), null),
+        Arguments.of(IndividualSelfManagementScores(1, null, 3, 4), null),
+        Arguments.of(IndividualSelfManagementScores(1, 2, null, 4), null),
+        Arguments.of(IndividualSelfManagementScores(1, 2, 3, null), null),
         Arguments.of(IndividualSelfManagementScores(1, 0, 0, 0), 0),
         Arguments.of(IndividualSelfManagementScores(1, 1, 0, 0), 1),
         Arguments.of(IndividualSelfManagementScores(1, 1, 1, 0), 1),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualSelfManagementScoresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualSelfManagementScoresTest.kt
@@ -26,11 +26,11 @@ class IndividualSelfManagementScoresTest {
     @JvmStatic
     fun scoresForOverallSelfManagementScore(): Stream<Arguments> {
       return Stream.of(
-        Arguments.of(IndividualSelfManagementScores(0, 0, 0, 0), null),
-        Arguments.of(IndividualSelfManagementScores(null, 2, 3, 4), null),
-        Arguments.of(IndividualSelfManagementScores(1, null, 3, 4), null),
-        Arguments.of(IndividualSelfManagementScores(1, 2, null, 4), null),
-        Arguments.of(IndividualSelfManagementScores(1, 2, 3, null), null),
+        Arguments.of(IndividualSelfManagementScores(0, 0, 0, 0), 0),
+        Arguments.of(IndividualSelfManagementScores(null, 1, 2, 3), 2),
+        Arguments.of(IndividualSelfManagementScores(1, null, 3, 4), 2),
+        Arguments.of(IndividualSelfManagementScores(1, 2, null, 4), 2),
+        Arguments.of(IndividualSelfManagementScores(1, 2, 3, null), 2),
         Arguments.of(IndividualSelfManagementScores(1, 0, 0, 0), 0),
         Arguments.of(IndividualSelfManagementScores(1, 1, 0, 0), 1),
         Arguments.of(IndividualSelfManagementScores(1, 1, 1, 0), 1),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualSexScoresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualSexScoresTest.kt
@@ -34,7 +34,11 @@ class IndividualSexScoresTest {
     @JvmStatic
     fun scoresForOverallSexDomainScore(): Stream<Arguments> {
       return Stream.of(
-        Arguments.of(IndividualSexScores(0, 0, 0), 0, null),
+        Arguments.of(IndividualSexScores(0, 0, 0), null, null),
+        Arguments.of(IndividualSexScores(null, 1, 2), null, null),
+        Arguments.of(IndividualSexScores(1, null, 3), null, null),
+        Arguments.of(IndividualSexScores(1, 2, null), null, null),
+        Arguments.of(IndividualSexScores(null, null, null), null, null),
         Arguments.of(IndividualSexScores(0, 1, 0), 1, 0),
         Arguments.of(IndividualSexScores(1, 1, 1), 3, 1),
         Arguments.of(IndividualSexScores(2, 2, 2), 6, 2),
@@ -58,7 +62,7 @@ class IndividualSexScoresTest {
 
   @ParameterizedTest
   @MethodSource("scoresForOverallSexDomainScore")
-  fun `test overallSexDomainScore method`(scores: IndividualSexScores, totalScore: Int, expected: Int?) {
+  fun `test overallSexDomainScore method`(scores: IndividualSexScores, totalScore: Int?, expected: Int?) {
     assertEquals(expected, scores.overallSexDomainScore(totalScore))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualSexScoresTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/pni/model/IndividualSexScoresTest.kt
@@ -34,14 +34,15 @@ class IndividualSexScoresTest {
     @JvmStatic
     fun scoresForOverallSexDomainScore(): Stream<Arguments> {
       return Stream.of(
-        Arguments.of(IndividualSexScores(0, 0, 0), null, null),
-        Arguments.of(IndividualSexScores(null, 1, 2), null, null),
-        Arguments.of(IndividualSexScores(1, null, 3), null, null),
-        Arguments.of(IndividualSexScores(1, 2, null), null, null),
-        Arguments.of(IndividualSexScores(null, null, null), null, null),
+        Arguments.of(IndividualSexScores(0, 0, 0), 0, 0),
+        Arguments.of(IndividualSexScores(null, 1, 2), 1, 0),
+        Arguments.of(IndividualSexScores(1, null, 3), 2, 1),
+        Arguments.of(IndividualSexScores(1, 2, null), 2, 2),
+        Arguments.of(IndividualSexScores(null, null, null), 0, 0),
         Arguments.of(IndividualSexScores(0, 1, 0), 1, 0),
         Arguments.of(IndividualSexScores(1, 1, 1), 3, 1),
         Arguments.of(IndividualSexScores(2, 2, 2), 6, 2),
+        Arguments.of(IndividualSexScores(3, 2, 3), 6, 2),
         Arguments.of(IndividualSexScores(1, 2, 1), 4, 2),
         Arguments.of(IndividualSexScores(1, 2, 1), 2, 2),
       )


### PR DESCRIPTION
## Context

Ensure overall scores for PNI constituent scores are null if any of the individual scores are null

NB. This appears to alter the overall PNI risk score.

## Changes in this PR

Updated IndividualNeedsScores calculation logic to integrate a new extension function that checks for null values in data class properties. Adjusted parameterized tests accordingly to ensure robustness in scenarios with partial data, improving the validation of score computations.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
