### PR TITLE
[APG-514] Refactor PniService to ensure only Risk scores use assessment with SARA

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysService.kt
@@ -174,8 +174,7 @@ class OasysService(
   fun getAssessmentIdDate(prisonNumber: String): Pair<Long, LocalDateTime?>? {
     val assessmentTimeline = getAssessments(prisonNumber)
 
-    val assessment =
-      getLatestCompletedLayerThreeAssessment(assessmentTimeline)
+    val assessment = getLatestCompletedLayerThreeAssessment(assessmentTimeline)
 
     return if (assessment == null) {
       log.warn("No completed assessment found for prison number $prisonNumber")
@@ -201,7 +200,7 @@ class OasysService(
     )
   }
 
-  private fun getLatestCompletedLayerThreeAssessment(assessment: OasysAssessmentTimeline): Timeline? {
+  fun getLatestCompletedLayerThreeAssessment(assessment: OasysAssessmentTimeline): Timeline? {
     // get the most recent completed assessment
     return assessment
       .timeline
@@ -217,9 +216,8 @@ class OasysService(
       .sortedByDescending { it.completedAt }
   }
 
-  fun getAssessmentWithCompletedSara(prisonNumber: String): Long? {
-    val assessmentTimeline = getAssessments(prisonNumber)
-    val completedLayerThreeAssessments = getAllCompletedLayerThreeAssessments(assessmentTimeline)
+  fun getAssessmentIdWithCompletedSara(oasysAssessmentTimeline: OasysAssessmentTimeline): Long? {
+    val completedLayerThreeAssessments = getAllCompletedLayerThreeAssessments(oasysAssessmentTimeline)
     val latestAssessmentDate = completedLayerThreeAssessments.first().completedAt
 
     for (assessment in completedLayerThreeAssessments) {
@@ -229,7 +227,7 @@ class OasysService(
         }
       }
     }
-    log.warn("No completed assessment with SARA data found for prison number $prisonNumber")
+    log.warn("No completed assessment with SARA data found for prison number ${oasysAssessmentTimeline.prisNumber}")
     return null
   }
 
@@ -238,7 +236,7 @@ class OasysService(
     return abs(daysBetween) <= 42 // 6 weeks * 7 days/week = 42 days
   }
 
-  private fun getAssessments(prisonNumber: String): OasysAssessmentTimeline {
+  fun getAssessments(prisonNumber: String): OasysAssessmentTimeline {
     val assessments = when (val result = oasysApiClient.getAssessments(prisonNumber)) {
       is ClientResult.Failure -> {
         log.warn("Failure to retrieve Assessment for $prisonNumber reason ${result.toException().cause}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniService.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysAssessmentTimeline
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysAttitude
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysBehaviour
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysLearning
@@ -11,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysPsychiatric
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysRelationships
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysRiskPredictorScores
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Timeline
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.AuditAction
@@ -63,13 +65,12 @@ class PniService(
       auditAction = AuditAction.PNI.name,
     )
 
-    val assessmentIdDate = oasysService.getAssessmentIdDate(prisonNumber)
-      ?: throw NotFoundException("No assessment id found for $prisonNumber")
-    val assessmentId = assessmentIdDate.first
+    val oasysAssessmentTimeline = oasysService.getAssessments(prisonNumber)
+    val completedAssessment = oasysService.getLatestCompletedLayerThreeAssessment(oasysAssessmentTimeline) ?: throw NotFoundException("No completed assessments found for $prisonNumber")
+
+    val assessmentId = completedAssessment.id
 
     // section 6
-    var completedAssessmentIdWithSara = oasysService.getAssessmentWithCompletedSara(prisonNumber)
-    val relationshipsForCompletedAssessmentWithSara = completedAssessmentIdWithSara?.let { oasysService.getRelationships(it) }
     val relationships = oasysService.getRelationships(assessmentId)
     // section 7
     val lifestyle = oasysService.getLifestyle(assessmentId)
@@ -82,13 +83,16 @@ class PniService(
 
     val learning = oasysService.getLearning(assessmentId)
 
+    // SARA result
+    val saraResult = buildSaraResult(oasysAssessmentTimeline, relationships, assessmentId)
+
     // risks
     val oasysOffendingInfo = oasysService.getOffendingInfo(assessmentId)
     val oasysRiskPredictor = oasysService.getRiskPredictors(assessmentId)
 
     val individualNeedsAndRiskScores = IndividualNeedsAndRiskScores(
       individualNeedsScores = buildNeedsScores(behavior, relationships, attitude, lifestyle, psychiatric),
-      individualRiskScores = buildRiskScores(oasysRiskPredictor, relationshipsForCompletedAssessmentWithSara, oasysOffendingInfo, completedAssessmentIdWithSara),
+      individualRiskScores = buildRiskScores(oasysRiskPredictor, oasysOffendingInfo, saraResult),
     )
 
     val genderOfPerson = getGenderOfPerson(prisonNumber, gender)
@@ -119,14 +123,34 @@ class PniService(
     )
 
     if (savePni) {
-      pniResultEntityRepository.save(buildEntity(pniScore, assessmentIdDate, referralId, learning))
+      pniResultEntityRepository.save(buildEntity(pniScore, completedAssessment, referralId, learning))
     }
     return pniScore
   }
 
+  private fun buildSaraResult(timeline: OasysAssessmentTimeline, oasysRelationships: OasysRelationships?, assessmentId: Long): Sara {
+    return if (oasysRelationships?.sara == null) {
+      val completedAssessmentIdWithSara = oasysService.getAssessmentIdWithCompletedSara(timeline)
+      val relationshipsWithSara = completedAssessmentIdWithSara?.let { oasysService.getRelationships(it) }
+      Sara(
+        overallResult = getOverallSARAResult(relationshipsWithSara?.sara),
+        saraRiskOfViolenceTowardsPartner = relationshipsWithSara?.sara?.imminentRiskOfViolenceTowardsPartner,
+        saraRiskOfViolenceTowardsOthers = relationshipsWithSara?.sara?.imminentRiskOfViolenceTowardsOthers,
+        saraAssessmentId = completedAssessmentIdWithSara,
+      )
+    } else {
+      Sara(
+        overallResult = getOverallSARAResult(oasysRelationships.sara),
+        saraRiskOfViolenceTowardsPartner = oasysRelationships.sara.imminentRiskOfViolenceTowardsPartner,
+        saraRiskOfViolenceTowardsOthers = oasysRelationships.sara.imminentRiskOfViolenceTowardsOthers,
+        saraAssessmentId = assessmentId,
+      )
+    }
+  }
+
   private fun buildEntity(
     pniScore: PniScore,
-    assessmentIdDate: Pair<Long, LocalDateTime?>,
+    completedAssessment: Timeline?,
     referralId: UUID?,
     learning: OasysLearning?,
   ): PniResultEntity {
@@ -134,8 +158,8 @@ class PniService(
       crn = pniScore.crn,
       prisonNumber = pniScore.prisonNumber,
       referralId = referralId,
-      oasysAssessmentId = assessmentIdDate.first,
-      oasysAssessmentCompletedDate = assessmentIdDate.second,
+      oasysAssessmentId = completedAssessment?.id,
+      oasysAssessmentCompletedDate = completedAssessment?.completedAt,
       needsClassification = pniScore.needsScore.classification,
       riskClassification = pniScore.riskScore.classification,
       overallNeedsScore = pniScore.needsScore.overallNeedsScore,
@@ -184,22 +208,18 @@ class PniService(
 
   private fun buildRiskScores(
     oasysRiskPredictorScores: OasysRiskPredictorScores?,
-    oasysRelationships: OasysRelationships?,
     oasysOffendingInfo: OasysOffendingInfo?,
-    saraAssessmentId: Long?,
-  ) = IndividualRiskScores(
-    ogrs3 = oasysRiskPredictorScores?.groupReconvictionScore?.twoYears?.round(),
-    ovp = oasysRiskPredictorScores?.violencePredictorScore?.twoYears?.round(),
-    ospIic = oasysOffendingInfo?.ospIICRisk ?: oasysOffendingInfo?.ospIRisk,
-    ospDc = oasysOffendingInfo?.ospDCRisk ?: oasysOffendingInfo?.ospCRisk,
-    rsr = oasysRiskPredictorScores?.riskOfSeriousRecidivismScore?.percentageScore?.round(),
-    sara = Sara(
-      overallResult = getOverallSARAResult(oasysRelationships?.sara),
-      saraRiskOfViolenceTowardsPartner = oasysRelationships?.sara?.imminentRiskOfViolenceTowardsPartner,
-      saraRiskOfViolenceTowardsOthers = oasysRelationships?.sara?.imminentRiskOfViolenceTowardsOthers,
-      saraAssessmentId = saraAssessmentId,
-    ),
-  )
+    sara: Sara,
+  ): IndividualRiskScores {
+    return IndividualRiskScores(
+      ogrs3 = oasysRiskPredictorScores?.groupReconvictionScore?.twoYears?.round(),
+      ovp = oasysRiskPredictorScores?.violencePredictorScore?.twoYears?.round(),
+      ospIic = oasysOffendingInfo?.ospIICRisk ?: oasysOffendingInfo?.ospIRisk,
+      ospDc = oasysOffendingInfo?.ospDCRisk ?: oasysOffendingInfo?.ospCRisk,
+      rsr = oasysRiskPredictorScores?.riskOfSeriousRecidivismScore?.percentageScore?.round(),
+      sara = sara,
+    )
+  }
 
   private fun getOverallSARAResult(sara: uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Sara?): SaraRisk? {
     return SaraRisk.highestRisk(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/OasysApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/OasysApiIntegrationTest.kt
@@ -123,8 +123,8 @@ class OasysApiIntegrationTest : IntegrationTestBase() {
       riskKnownAdultCommunity = LOW,
       riskPublicCommunity = MEDIUM,
       riskChildrenCommunity = LOW,
-      imminentRiskOfViolenceTowardsPartner = HIGH,
-      imminentRiskOfViolenceTowardsOthers = HIGH,
+      imminentRiskOfViolenceTowardsPartner = null,
+      imminentRiskOfViolenceTowardsOthers = null,
       alerts = listOf(
         Alert(
           description = "ACCT Open (HMPS)",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PniIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PniIntegrationTest.kt
@@ -30,9 +30,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type.Sa
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @Import(JwtAuthHelper::class)
-class PniIntegrationTest :
-  IntegrationTestBase() {
-
+class PniIntegrationTest : IntegrationTestBase() {
   @Autowired
   lateinit var pniResultEntityRepository: PNIResultEntityRepository
 
@@ -103,9 +101,8 @@ class PniIntegrationTest :
           overallResult = SaraRisk.HIGH,
           saraRiskOfViolenceTowardsOthers = "High",
           saraRiskOfViolenceTowardsPartner = "High",
-          saraAssessmentId = 2114584,
+          saraAssessmentId = 2114999,
         ),
-
       ),
     ),
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysServiceTest.kt
@@ -311,7 +311,7 @@ class OasysServiceTest {
     every { oasysApiClient.getRelationships(999999) } returns ClientResult.Success(HttpStatus.OK, oasysRelationShips2)
 
     // When
-    val oasysRelationships = service.getAssessmentWithCompletedSara("A9999BB")
+    val oasysRelationships = service.getAssessmentIdWithCompletedSara(oasysAssessmentTimeline)
 
     // Then
     oasysRelationships.shouldBeNull()
@@ -357,7 +357,7 @@ class OasysServiceTest {
     every { oasysApiClient.getRelationships(999999) } returns ClientResult.Success(HttpStatus.OK, oasysRelationShips2)
 
     // When
-    val completedSaraAssessment = service.getAssessmentWithCompletedSara("A9999BB")
+    val completedSaraAssessment = service.getAssessmentIdWithCompletedSara(oasysAssessmentTimeline)
 
     // Then
     completedSaraAssessment.shouldNotBeNull()
@@ -404,7 +404,7 @@ class OasysServiceTest {
     every { oasysApiClient.getRelationships(999999) } returns ClientResult.Success(HttpStatus.OK, oasysRelationShips2)
 
     // When
-    val completedSaraAssessment = service.getAssessmentWithCompletedSara("A9999BB")
+    val completedSaraAssessment = service.getAssessmentIdWithCompletedSara(oasysAssessmentTimeline)
 
     // Then
     completedSaraAssessment.shouldNotBeNull()

--- a/src/test/resources/simulations/__files/assessments.json
+++ b/src/test/resources/simulations/__files/assessments.json
@@ -3,6 +3,12 @@
   "prisNumber": "A9999BB",
   "timeline": [
     {
+      "id": 2114999,
+      "type": "LAYER3",
+      "status": "COMPLETE",
+      "completedAt": "2022-05-23T09:59:22"
+    },
+    {
       "id": 2114584,
       "type": "LAYER3",
       "status": "COMPLETE",

--- a/src/test/resources/simulations/__files/relationships-with-SARA.json
+++ b/src/test/resources/simulations/__files/relationships-with-SARA.json
@@ -1,5 +1,5 @@
 {
-  "assessmentPk": 2114584,
+  "assessmentPk": 2114999,
   "assessmentType": "LAYER3",
   "dateCompleted": "2023-12-19T16:57:25",
   "assessorSignedDate": "2023-12-19T16:55:32",
@@ -33,7 +33,10 @@
   "relationshipWithPartner": "0-No problems",
   "experienceOfChildhood": "0-No problems",
   "emotionalCongruence": "0-No problems",
-  "SARA": null,
+  "SARA": {
+    "imminentRiskOfViolenceTowardsPartner": "High",
+    "imminentRiskOfViolenceTowardsOthers": "High"
+  },
   "assessor": {
     "name": "LevelTwo CentralSupport"
   }

--- a/src/test/resources/simulations/mappings/oasys.json
+++ b/src/test/resources/simulations/mappings/oasys.json
@@ -106,6 +106,19 @@
     },
     {
       "request": {
+        "urlPattern": "/assessments/2114999/section/section6",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "bodyFileName": "relationships-with-SARA.json"
+      }
+    },
+    {
+      "request": {
         "urlPattern": "/assessments/2114584/section/sectionroshfull",
         "method": "GET"
       },


### PR DESCRIPTION
## Context

Ensure only risk score calculation will use the Oasys relationship data from a completed assessment with populated SARA info.

## Changes in this PR

- Refactor PniService to handle completed SARA assessments more accurately by changing variable names and refactoring method calls
- Add and modify JSON test files to include new SARA fields and ensure that integration tests reflect the updated logic.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
