### PR TITLE
APG-535 Add setup-service-pod script for easy service pod management

### DIFF
--- a/script/kubernetes-scripts/README.md
+++ b/script/kubernetes-scripts/README.md
@@ -21,11 +21,11 @@ Change the namespace and local port number (the left-hand one of the pair) as ne
 
 ### Using the Service Pod:
 
-Execute the script for the appropriate k8s namespace by amending the variable on line 2: `namespace=hmpps-accredited-programmes-preprod`:
+Execute the script for the appropriate k8s namespace: 
 ```
-$ ./setup-service-pod.bash
+$ ./setup-service-pod.bash -ns preprod
 ```
-The script will either spin up the service pod, or log you into the existing service pod if it already exists.
+The script will either spin up the service pod, or log you into the existing service pod if it already exists. This can take a few seconds.
 
 The script sets up useful environment variables that are available to the bash session and can be used to invoke aws cli 
 commands as if you were authorised with the IRSA such as:

--- a/script/kubernetes-scripts/README.md
+++ b/script/kubernetes-scripts/README.md
@@ -10,6 +10,7 @@ Every script takes one argument, `-ns <env>` ,that defines the namespace that it
 - `get-courses` Invoke the `GET /courses` end-point and output the response to stdout
 - `start-db-portforward-pod` Starts a pod in the named environment that forwards the Postgresql port for the API 
    instance to the pod. 
+- `setup-servic-pod.bash` starts a service pod in the named namespace with IRSA based authentication, and opens a bash session which then can be used to run authorised commands.
 
 Regarding port forwarding for the database. Once a port forwarding pod has been started for an environment
 the pod port can be forwarded on to the user using a kubectl command like.
@@ -17,3 +18,34 @@ the pod port can be forwarded on to the user using a kubectl command like.
 kubectl port-forward db-port-forward-pod --namespace=hmpps-accredited-programmes-prod 5432:5432
 ```
 Change the namespace and local port number (the left-hand one of the pair) as needed.
+
+### Using the Service Pod:
+
+Execute the script for the appropriate k8s namespace by amending the variable on line 2: `namespace=hmpps-accredited-programmes-preprod`:
+```
+$ ./setup-service-pod.bash
+```
+The script will either spin up the service pod, or log you into the existing service pod if it already exists.
+
+The script sets up useful environment variables that are available to the bash session and can be used to invoke aws cli 
+commands as if you were authorised with the IRSA such as:
+
+#### Retrieve the instance type of an AWS RDS database:
+```
+$ aws rds describe-db-instances --db-instance-identifier $RDS_INSTANCE_IDENTIFIER --query 'DBInstances[0].DBInstanceClass' --output text
+```
+
+#### List the latest RDS snapshot of an AWS RDS database:
+```
+$ aws rds describe-db-snapshots --db-instance-identifier $RDS_INSTANCE_IDENTIFIER --query 'DBSnapshots | sort_by(@, &SnapshotCreateTime)[-1]'
+```
+
+#### Create a manual snapshot of an AWS RDS database:
+```
+$ aws rds create-db-snapshot --db-snapshot-identifier manual-snapshot-09-11-2024 --db-instance-identifier $RDS_INSTANCE_IDENTIFIER
+```
+
+#### Describe a specific snapshot of an AWS RDS database:
+```
+$ aws rds describe-db-snapshots --db-snapshot-identifier manual-snapshot-09-11-2024 --db-instance-identifier $RDS_INSTANCE_IDENTIFIER 
+```

--- a/script/kubernetes-scripts/setup-service-pod.bash
+++ b/script/kubernetes-scripts/setup-service-pod.bash
@@ -1,0 +1,52 @@
+#!/bin/bash
+namespace=hmpps-accredited-programmes-preprod
+
+hostname=$(hostname)
+# Read any named params
+while [ $# -gt 0 ]; do
+
+   if [[ $1 == *"--"* ]]; then
+        param="${1/--/}"
+        declare $param="$2"
+   fi
+
+  shift
+done
+
+set -o history -o histexpand
+set -e
+exit_on_error() {
+    exit_code=$1
+    last_command=${@:2}
+    if [ $exit_code -ne 0 ]; then
+        >&2 echo "💥 Last command:"
+        >&2 echo "    \"${last_command}\""
+        >&2 echo "❌ Failed with exit code ${exit_code}."
+        >&2 echo "🟥 Aborting"
+        exit $exit_code
+    fi
+}
+
+debug_pod_name=service-pod-$namespace
+echo "service pod name: $debug_pod_name"
+service_pod_exists="$(kubectl get pods $debug_pod_name || echo 'NotFound')"
+
+
+if [[ ! $service_pod_exists =~ 'NotFound' ]]; then
+  echo "$debug_pod_name exists signing into shell"
+  kubectl exec -it -n $namespace $debug_pod_name -- sh
+  exit 0
+fi
+
+# Get credentials such as RDS identifiers from namespace secrets
+echo "🔑 Getting RDS instance from secrets ..."
+secret_json=$(cloud-platform decode-secret -s rds-postgresql-instance-output -n $namespace --skip-version-check)
+export RDS_INSTANCE_IDENTIFIER=$(echo "$secret_json" | jq -r .data.rds_instance_address | sed s/[.].*//)
+
+kubectl --namespace=$namespace --request-timeout='120s' run \
+    --env "namespace=$namespace" \
+    --env "RDS_INSTANCE_IDENTIFIER=$RDS_INSTANCE_IDENTIFIER" \
+    -it --rm $debug_pod_name --image=quay.io/hmpps/hmpps-probation-in-court-utils:latest \
+    --restart=Never --overrides='{ "spec": { "serviceAccount": "hmpps-accredited-programmes-service-account" } }'
+
+


### PR DESCRIPTION
## Changes in this PR

- Introduce a new script `setup-service-pod.bash` to automate the creation and management of service pods. This script sets up IRSA-based authentication and allows users to perform authorized AWS commands. 
- Updated the README with usage instructions and examples for interacting with AWS RDS.


