### PR TITLE
APG-515 Update dependencies to address security vulnerability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,9 @@ dependencies {
   val springSecurityVersion = "6.3.4"
 
   implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.0.8")
+  // Override netty-common version to address https://osv.dev/vulnerability/GHSA-xq3w-v528-46rv
+  implementation("io.netty:netty-common:4.1.115.Final")
+
   runtimeOnly("org.postgresql:postgresql:42.7.4")
 
   implementation("org.springframework.boot:spring-boot-starter-webflux")
@@ -46,7 +49,8 @@ dependencies {
   testImplementation("io.jsonwebtoken:jjwt-orgjson:$jsonWebtokenVersion")
   testImplementation("au.com.dius.pact.provider:junit5spring:4.6.15")
   testImplementation("org.springframework.security:spring-security-test:$springSecurityVersion")
-  testImplementation("com.github.tomakehurst:wiremock-standalone:3.0.1")
+  testImplementation("org.wiremock:wiremock-standalone:3.9.2")
+
   testImplementation("org.awaitility:awaitility-kotlin")
 
   testImplementation("org.testcontainers:testcontainers:1.20.3")


### PR DESCRIPTION
## Changes in this PR

- Override netty-common version to address vulnerability GHSA-xq3w-v528-46rv by updating to version 4.1.115.Final. 
- Update wiremock-standalone dependency from 3.0.1 to 3.9.2.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
