### PR TITLE
APG -568 Refactor `getOfferingById` endpoint to improve null handling

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/OfferingController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/OfferingController.kt
@@ -77,12 +77,10 @@ class OfferingController(
     produces = ["application/json"],
   )
   fun getOfferingById(@Parameter(description = "A course offering identifier", required = true) @PathVariable("id") id: UUID): ResponseEntity<CourseOffering> {
-    val offeringById = courseService.getOfferingById(id)
-    val enabledOrg = enabledOrganisationService.getEnabledOrganisation(offeringById?.organisationId.orEmpty()) != null
-    val organisation = organisationService.findOrganisationEntityByCode(offeringById?.organisationId!!)?.gender!!
-
-    return offeringById.toApi(enabledOrg, organisation).let {
-      ResponseEntity.ok(it)
+    return courseService.getOfferingById(id)?.let {
+      val enabledOrg = enabledOrganisationService.getEnabledOrganisation(it.organisationId) != null
+      val genderOfOrganisation = organisationService.findOrganisationEntityByCode(it.organisationId)?.gender!!
+      ResponseEntity.ok(it.toApi(enabledOrg, genderOfOrganisation))
     } ?: throw NotFoundException("No Offering found at /offerings/$id")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
@@ -375,6 +375,26 @@ class CourseIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `Should return 404 with error body when searching for an offering with an unknown id`() {
+    val randomId = UUID.randomUUID()
+
+    webTestClient
+      .get()
+      .uri("/offerings/$randomId")
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isNotFound
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody()
+      .jsonPath("$.status").isEqualTo(404)
+      .jsonPath("$.errorCode").isEmpty
+      .jsonPath("$.userMessage").value(startsWith("Not Found: No Offering found at /offerings/$randomId"))
+      .jsonPath("$.developerMessage").value(startsWith("No Offering found at /offerings/$randomId"))
+      .jsonPath("$.moreInfo").isEmpty
+  }
+
+  @Test
   fun `Get all audiences returns 200 with correct body`() {
     webTestClient
       .get()


### PR DESCRIPTION
## Context

Unknown offering ids were causing spurious 500 errors to be returned from the API. Return 404 instead.

## Changes in this PR

- Streamline the `getOfferingById` endpoint method 
- Added an integration test to verify the 404 response for unknown offering IDs.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
