### PR TITLE
[APG-559] Ensure withdrawn courses are returned from OrganisationController

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/OrganisationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/OrganisationController.kt
@@ -53,8 +53,7 @@ class OrganisationController(
   fun getAllCoursesByOrganisationId(@Parameter(description = "A organisation identifier", required = true) @PathVariable("organisationId") organisationId: String): ResponseEntity<List<Course>> =
     ResponseEntity
       .ok(
-        courseService
-          .getAllOfferingsByOrganisationId(organisationId).filter { !it.withdrawn }
+        courseService.getAllOfferingsByOrganisationId(organisationId)
           .map { it.course }
           .map { it.toApi() },
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/PersistenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/PersistenceHelper.kt
@@ -64,7 +64,7 @@ class PersistenceHelper {
       .executeUpdate()
   }
 
-  fun createdOrganisation(orgId: UUID = UUID.randomUUID(), code: String, name: String, gender: String = "MALE") {
+  fun createOrganisation(orgId: UUID = UUID.randomUUID(), code: String, name: String, gender: String = "MALE") {
     entityManager.createNativeQuery("INSERT INTO organisation (organisation_id, code, name, gender) VALUES (:organisation_id, :code, :name, :gender)")
       .setParameter("organisation_id", orgId)
       .setParameter("code", code)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseIntegrationTest.kt
@@ -92,7 +92,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
       "pr description2",
     )
 
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
 
     persistenceHelper.createOffering(
@@ -104,7 +104,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
       true,
     )
 
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
 
     persistenceHelper.createOffering(
@@ -116,7 +116,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
       true,
     )
 
-    persistenceHelper.createdOrganisation(code = "SKI", name = "SKI org")
+    persistenceHelper.createOrganisation(code = "SKI", name = "SKI org")
     persistenceHelper.createEnabledOrganisation("SKI", "SKI org")
 
     persistenceHelper.createOffering(
@@ -129,7 +129,7 @@ class CourseIntegrationTest : IntegrationTestBase() {
       true,
     )
 
-    persistenceHelper.createdOrganisation(code = "SKN", name = "SKN org")
+    persistenceHelper.createOrganisation(code = "SKN", name = "SKN org")
     persistenceHelper.createEnabledOrganisation("SKN", "SKN org")
     persistenceHelper.createOffering(
       UUID.fromString(UNUSED_OFFERING_ID),
@@ -638,10 +638,10 @@ class CourseIntegrationTest : IntegrationTestBase() {
     val bc1CourseOfferingMainId = UUID.randomUUID()
     val bc1CourseOfferingVariantId = UUID.randomUUID()
 
-    persistenceHelper.createdOrganisation(code = "WSI", name = "WSI org", gender = "MALE")
+    persistenceHelper.createOrganisation(code = "WSI", name = "WSI org", gender = "MALE")
     persistenceHelper.createEnabledOrganisation("WSI", "WSI org")
 
-    persistenceHelper.createdOrganisation(code = "ESI", name = "ESI org", gender = "FEMALE")
+    persistenceHelper.createOrganisation(code = "ESI", name = "ESI org", gender = "FEMALE")
     persistenceHelper.createEnabledOrganisation("ESI", "ESI org")
 
     persistenceHelper.createCourse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationIntegrationTest.kt
@@ -46,8 +46,8 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
   fun setUp() {
     persistenceHelper.clearAllTableContent()
 
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
     persistenceHelper.createParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), null, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
     persistenceHelper.createParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), null, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/DomainEventsListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/DomainEventsListenerTest.kt
@@ -49,10 +49,10 @@ class DomainEventsListenerTest : IntegrationTestBase() {
       "SC++",
       "General offence",
     )
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
 
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
 
     persistenceHelper.createOffering(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/OrganisationControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/OrganisationControllerIntegrationTest.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.expectBody
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseEntity
+import java.util.UUID
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(JwtAuthHelper::class)
+class OrganisationControllerIntegrationTest : IntegrationTestBase() {
+
+  @BeforeEach
+  fun setUp() {
+    persistenceHelper.clearAllTableContent()
+  }
+
+  @Test
+  fun `should return all courses for a given organisation code including withdrawn courses`() {
+    // Given
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
+    val course1Uuid = UUID.randomUUID()
+    persistenceHelper.createCourse(course1Uuid, "SC1", "Course Numero Uno", "Sample description", "SC++", "General offence", withdrawn = false)
+    persistenceHelper.createOffering(UUID.randomUUID(), course1Uuid, "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
+
+    val course2Uuid = UUID.randomUUID()
+    persistenceHelper.createCourse(course2Uuid, "SC2", "Course Numero Dos", "Sample description", "SC++", "General offence", withdrawn = true)
+    persistenceHelper.createOffering(UUID.randomUUID(), course2Uuid, "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", false)
+
+    val course3Uuid = UUID.randomUUID()
+    persistenceHelper.createCourse(course3Uuid, "SC3", "Course Numero Tres", "Sample description", "SC++", "General offence", withdrawn = true)
+    persistenceHelper.createOffering(UUID.randomUUID(), course3Uuid, "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", false)
+
+    // When
+    val offerings = getAllCoursesForOrganisation("BWN")
+
+    // Then
+    assertThat(offerings.size).isEqualTo(3)
+    assertThat(offerings.count { it.withdrawn }).isEqualTo(2)
+  }
+
+  fun getAllCoursesForOrganisation(organisationId: String): List<CourseEntity> =
+    webTestClient
+      .get()
+      .uri("/organisations/$organisationId/courses")
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      .accept(MediaType.APPLICATION_JSON)
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<List<CourseEntity>>()
+      .returnResult().responseBody!!
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PeopleControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PeopleControllerIntegrationTest.kt
@@ -101,7 +101,7 @@ class PeopleControllerIntegrationTest : IntegrationTestBase() {
 
     val referralId = UUID.randomUUID()
     persistenceHelper.clearAllTableContent()
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
 
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
@@ -97,9 +97,9 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
       "SC++",
       "General offence",
     )
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
 
     persistenceHelper.createOffering(
@@ -293,7 +293,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
     val audience = getRandomString(10)
     val offeringId = UUID.randomUUID()
 
-    persistenceHelper.createdOrganisation(code = "XXX", name = "XXX org")
+    persistenceHelper.createOrganisation(code = "XXX", name = "XXX org")
     persistenceHelper.createEnabledOrganisation("XXX", "XXX org")
 
     createCourse(
@@ -1059,7 +1059,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
     val audience = getRandomString(10)
     val offeringId = UUID.randomUUID()
 
-    persistenceHelper.createdOrganisation(code = "XXX", name = "XXX org")
+    persistenceHelper.createOrganisation(code = "XXX", name = "XXX org")
     persistenceHelper.createEnabledOrganisation("XXX", "XXX org")
 
     createCourse(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/StatisticsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/StatisticsIntegrationTest.kt
@@ -50,9 +50,9 @@ class StatisticsIntegrationTest : IntegrationTestBase() {
       "SC++",
       "General offence",
     )
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
 
     persistenceHelper.createOffering(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/StatusHistoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/StatusHistoryIntegrationTest.kt
@@ -68,9 +68,9 @@ class StatusHistoryIntegrationTest : IntegrationTestBase() {
       "SC++",
       "General offence",
     )
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
 
     persistenceHelper.createOffering(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
@@ -44,9 +44,9 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure course d3abc217-75ee-46e9-a010-368f30282367 exists`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
   }
@@ -55,9 +55,9 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure course d3abc217-75ee-46e9-a010-368f30282367 has offerings 790a2dfe-7de5-4504-bb9c-83e6e53a6537 and 7fffcc6a-11f8-4713-be35-cf5ff1aee517`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
   }
@@ -66,9 +66,9 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure courses d3abc217-75ee-46e9-a010-368f30282367, 28e47d30-30bf-4dab-a8eb-9fda3f6400e8, and 1811faa6-d568-4fc4-83ce-41118b90242e and no others exist`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
@@ -80,9 +80,9 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure in order, the names of all the courses are Super Course, Custom Course, and RAPID Course`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
@@ -94,9 +94,9 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure offering 790a2dfe-7de5-4504-bb9c-83e6e53a6537 exists for course d3abc217-75ee-46e9-a010-368f30282367`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
   }
@@ -105,7 +105,7 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure offering 790a2dfe-7de5-4504-bb9c-83e6e53a6537 exists`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
   }
 
@@ -113,7 +113,7 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure offering 7fffcc6a-11f8-4713-be35-cf5ff1aee517 exists`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
   }
 
@@ -142,9 +142,9 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status REFERRAL_STARTED`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
@@ -157,9 +157,9 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
@@ -172,9 +172,9 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure referrals exist for the logged in user`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
@@ -192,9 +192,9 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure referrals exist for logged in user with status REFERRAL_SUBMITTED`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
@@ -210,9 +210,9 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure referrals exist for organisation BWN`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
@@ -230,9 +230,9 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure organisation BWN has courses d3abc217-75ee-46e9-a010-368f30282367, 28e47d30-30bf-4dab-a8eb-9fda3f6400e8, and 1811faa6-d568-4fc4-83ce-41118b90242e and no others`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 
@@ -251,9 +251,9 @@ class PactContractTest : IntegrationTestBase() {
   fun `ensure Super Course referral(s) exist for organisation BWM with status REFERRAL_SUBMITTED to offerings for courses with audience General offence`() {
     persistenceHelper.createCourse(UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "SC", "Super Course", "Sample description", "SC++", "General offence")
     persistenceHelper.createEnabledOrganisation("BWN", "BWN org")
-    persistenceHelper.createdOrganisation(code = "BWN", name = "BWN org")
+    persistenceHelper.createOrganisation(code = "BWN", name = "BWN org")
     persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
-    persistenceHelper.createdOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
     persistenceHelper.createOffering(UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "BWN", "nobody-bwn@digital.justice.gov.uk", "nobody2-bwn@digital.justice.gov.uk", true)
     persistenceHelper.createOffering(UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), UUID.fromString("d3abc217-75ee-46e9-a010-368f30282367"), "MDI", "nobody-mdi@digital.justice.gov.uk", "nobody2-mdi@digital.justice.gov.uk", true)
 


### PR DESCRIPTION
## Changes in this PR

- Refactored getAllCoursesByOrganisationId API endpoint to return withdrawn courses
- Added new integration test for the OrganisationController to verify retrieval of courses by organisation code. 
- Updated existing JUnit tests to reflect refactoring 
- Corrected several instances of a typo in method names from `createdOrganisation` to `createOrganisation` in various test files. 

