### PR TITLE
[APG-559] Refactor course endpoints to handle withdrawn courses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseController.kt
@@ -293,7 +293,7 @@ class CourseController(
     produces = ["application/json"],
   )
   fun getCourseById(@Parameter(description = "A course identifier", required = true) @PathVariable("id") id: UUID): ResponseEntity<Course> =
-    courseService.getNotWithdrawnCourseById(id)?.let {
+    courseService.getCourseById(id)?.let {
       ResponseEntity.ok(it.toApi())
     } ?: throw NotFoundException("No Course found at /courses/$id")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/RecordTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/RecordTransformers.kt
@@ -43,6 +43,7 @@ fun OfferingEntity.toApi(orgEnabled: Boolean, genderForWhichCourseIsOffered: Str
   contactEmail = contactEmail,
   secondaryContactEmail = secondaryContactEmail,
   referable = referable,
+  withdrawn = withdrawn,
   gender = Gender.valueOf(genderForWhichCourseIsOffered),
 )
 
@@ -53,5 +54,6 @@ fun OfferingEntity.toApi(genderForWhichCourseIsOffered: String): CourseOffering 
   contactEmail = contactEmail,
   secondaryContactEmail = secondaryContactEmail,
   referable = referable,
+  withdrawn = withdrawn,
   gender = Gender.valueOf(genderForWhichCourseIsOffered),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
@@ -69,7 +69,7 @@ constructor(
   }
 
   fun getOfferingById(offeringId: UUID): OfferingEntity? =
-    offeringRepository.findByIdOrNull(offeringId)?.takeIf { !it.withdrawn }
+    offeringRepository.findByIdOrNull(offeringId)
 
   fun updateCoursePrerequisites(
     course: CourseEntity,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseControllerTest.kt
@@ -119,7 +119,7 @@ constructor(
         .withPrerequisites(prerequisites)
         .produce()
 
-      every { courseService.getNotWithdrawnCourseById(expectedCourse.id!!) } returns expectedCourse
+      every { courseService.getCourseById(expectedCourse.id!!) } returns expectedCourse
 
       mockMvc.get("/courses/${expectedCourse.id}") {
         accept = MediaType.APPLICATION_JSON
@@ -135,14 +135,14 @@ constructor(
         }
       }
 
-      verify { courseService.getNotWithdrawnCourseById(expectedCourse.id!!) }
+      verify { courseService.getCourseById(expectedCourse.id!!) }
     }
 
     @Test
     fun `getCourseById with random UUID returns 404 with error body`() {
       val randomId = UUID.randomUUID()
 
-      every { courseService.getNotWithdrawnCourseById(any()) } returns null
+      every { courseService.getCourseById(any()) } returns null
 
       mockMvc.get("/courses/$randomId") {
         accept = MediaType.APPLICATION_JSON


### PR DESCRIPTION
## Changes in this PR

- Replaced calls to `getNotWithdrawnCourseById` with `getCourseById` to include withdrawn courses in results.
- Updated and added integration tests to reflect the changes and ensure withdrawn courses are properly returned. 
- Added `withdrawn` property handling in `RecordTransformers`.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
