### PR TITLE
[APG-584] Handle Oasys Not Applicable OSP value

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniRiskEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniRiskEngine.kt
@@ -74,11 +74,14 @@ class PniRiskEngine {
     }
     // osp scores needs to be ignored for females
     return rsrMediumRsr &&
-            (individualRiskScores.ospDc == null ||
-             individualRiskScores.ospDc == RiskClassification.NOT_APPLICABLE.description)
-            &&
-            (individualRiskScores.ospIic == null ||
-             individualRiskScores.ospIic == RiskClassification.NOT_APPLICABLE.description)
+      (
+        individualRiskScores.ospDc == null ||
+          individualRiskScores.ospDc == RiskClassification.NOT_APPLICABLE.description
+        ) &&
+      (
+        individualRiskScores.ospIic == null ||
+          individualRiskScores.ospIic == RiskClassification.NOT_APPLICABLE.description
+        )
   }
 
   private fun isRsrHigh(individualRiskScores: IndividualRiskScores, gender: String): Boolean {
@@ -88,12 +91,15 @@ class PniRiskEngine {
       return isHighRsr
     }
     return isHighRsr &&
-            (individualRiskScores.ospDc == null ||
-             individualRiskScores.ospDc == RiskClassification.NOT_APPLICABLE.description)
-            &&
-            (individualRiskScores.ospIic == null ||
-             individualRiskScores.ospIic == RiskClassification.NOT_APPLICABLE.description)
-   }
+      (
+        individualRiskScores.ospDc == null ||
+          individualRiskScores.ospDc == RiskClassification.NOT_APPLICABLE.description
+        ) &&
+      (
+        individualRiskScores.ospIic == null ||
+          individualRiskScores.ospIic == RiskClassification.NOT_APPLICABLE.description
+        )
+  }
 
   private fun isOgrs3Medium(individualRiskScores: IndividualRiskScores) =
     individualRiskScores.ogrs3?.let { it in BigDecimal("50.00")..BigDecimal("74.00") } == true
@@ -114,8 +120,6 @@ class PniRiskEngine {
   fun isMediumSara(individualRiskScores: IndividualRiskScores) =
     individualRiskScores.sara?.saraRiskOfViolenceTowardsOthers?.equals(RiskClassification.MEDIUM_RISK.description, ignoreCase = true) == true ||
       individualRiskScores.sara?.saraRiskOfViolenceTowardsPartner?.equals(RiskClassification.MEDIUM_RISK.description, ignoreCase = true) == true
-
-
 }
 
 enum class RiskClassification(val description: String) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniRiskEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniRiskEngine.kt
@@ -67,14 +67,33 @@ class PniRiskEngine {
     (individualRiskScores.sara?.saraRiskOfViolenceTowardsOthers?.contains(RiskClassification.HIGH_RISK.description, ignoreCase = true) == true) ||
       (individualRiskScores.sara?.saraRiskOfViolenceTowardsPartner?.contains(RiskClassification.HIGH_RISK.description, ignoreCase = true) == true)
 
+  private fun isRsrMedium(individualRiskScores: IndividualRiskScores, gender: String): Boolean {
+    val rsrMediumRsr = individualRiskScores.rsr?.let { it in BigDecimal("1.00")..BigDecimal("2.99") } == true
+    if (gender.equals("Female", ignoreCase = true)) {
+      return rsrMediumRsr
+    }
+    // osp scores needs to be ignored for females
+    return rsrMediumRsr &&
+            (individualRiskScores.ospDc == null ||
+             individualRiskScores.ospDc == RiskClassification.NOT_APPLICABLE.description)
+            &&
+            (individualRiskScores.ospIic == null ||
+             individualRiskScores.ospIic == RiskClassification.NOT_APPLICABLE.description)
+  }
+
   private fun isRsrHigh(individualRiskScores: IndividualRiskScores, gender: String): Boolean {
     val isHighRsr = individualRiskScores.rsr?.let { it >= BigDecimal("3.00") } == true
 
     if (gender.equals("Female", ignoreCase = true)) {
       return isHighRsr
     }
-    return isHighRsr && (individualRiskScores.ospDc == null && individualRiskScores.ospIic == null)
-  }
+    return isHighRsr &&
+            (individualRiskScores.ospDc == null ||
+             individualRiskScores.ospDc == RiskClassification.NOT_APPLICABLE.description)
+            &&
+            (individualRiskScores.ospIic == null ||
+             individualRiskScores.ospIic == RiskClassification.NOT_APPLICABLE.description)
+   }
 
   private fun isOgrs3Medium(individualRiskScores: IndividualRiskScores) =
     individualRiskScores.ogrs3?.let { it in BigDecimal("50.00")..BigDecimal("74.00") } == true
@@ -96,14 +115,7 @@ class PniRiskEngine {
     individualRiskScores.sara?.saraRiskOfViolenceTowardsOthers?.equals(RiskClassification.MEDIUM_RISK.description, ignoreCase = true) == true ||
       individualRiskScores.sara?.saraRiskOfViolenceTowardsPartner?.equals(RiskClassification.MEDIUM_RISK.description, ignoreCase = true) == true
 
-  private fun isRsrMedium(individualRiskScores: IndividualRiskScores, gender: String): Boolean {
-    val rsrMediumRsr = individualRiskScores.rsr?.let { it in BigDecimal("1.00")..BigDecimal("2.99") } == true
-    if (gender.equals("Female", ignoreCase = true)) {
-      return rsrMediumRsr
-    }
-    // osp scores needs to be ignored for females
-    return rsrMediumRsr && individualRiskScores.ospDc == null && individualRiskScores.ospIic == null
-  }
+
 }
 
 enum class RiskClassification(val description: String) {
@@ -111,4 +123,5 @@ enum class RiskClassification(val description: String) {
   HIGH_RISK("High"),
   MEDIUM_RISK("Medium"),
   LOW_RISK("Low"),
+  NOT_APPLICABLE("Not Applicable"),
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniRiskEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniRiskEngineTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -387,6 +388,57 @@ class PniRiskEngineTest {
       ),
     )
     assertEquals(result, riskEngine.isMediumRisk(riskScores, gender))
+  }
+
+  @Test
+  fun `should NOT return a medium risk when rsr is high and no osp scores are present`() {
+    val riskScores = IndividualRiskScores(
+      ogrs3 = null,
+      ovp = BigDecimal("60.00"),
+      ospDc = null,
+      ospIic = null,
+      rsr = BigDecimal("3.41"), // over 3 is high
+      sara = Sara(
+        saraRiskOfViolenceTowardsPartner = null,
+        saraRiskOfViolenceTowardsOthers = null,
+        overallResult = null,
+      ),
+    )
+    assertThat(riskEngine.isMediumRisk(riskScores, "Male")).isFalse
+  }
+
+  @Test
+  fun `should use RSR score to calculate high risk when OSP scores are set to Not Applicable`() {
+    val riskScores = IndividualRiskScores(
+      ogrs3 = null,
+      ovp = null,
+      ospDc = "Not Applicable",
+      ospIic = "Not Applicable",
+      rsr = BigDecimal("3.41"),
+      sara = Sara(
+        saraRiskOfViolenceTowardsPartner = null,
+        saraRiskOfViolenceTowardsOthers = null,
+        overallResult = null,
+      ),
+    )
+    assertThat(riskEngine.isHighRisk(riskScores, "Male")).isTrue
+  }
+
+  @Test
+  fun `should use RSR score to calculate medium risk when OSP scores are set to Not Applicable`() {
+    val riskScores = IndividualRiskScores(
+      ogrs3 = null,
+      ovp = null,
+      ospDc = "Not Applicable",
+      ospIic = "Not Applicable",
+      rsr = BigDecimal("2.99"),
+      sara = Sara(
+        saraRiskOfViolenceTowardsPartner = null,
+        saraRiskOfViolenceTowardsOthers = null,
+        overallResult = null,
+      ),
+    )
+    assertThat(riskEngine.isMediumRisk(riskScores, "Male")).isTrue
   }
 
   @ParameterizedTest

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniRiskEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniRiskEngineTest.kt
@@ -397,7 +397,7 @@ class PniRiskEngineTest {
       ovp = BigDecimal("60.00"),
       ospDc = null,
       ospIic = null,
-      rsr = BigDecimal("3.41"), // over 3 is high
+      rsr = BigDecimal("3.41"),
       sara = Sara(
         saraRiskOfViolenceTowardsPartner = null,
         saraRiskOfViolenceTowardsOthers = null,


### PR DESCRIPTION
## Context

The Oasys API can return both null and "Not Applicable" for OSP values, which we need to handle appropriately.

## Changes in this PR

- Refactor `isRsrHigh` and `isRsrMedium` methods to handle "Not Applicable" OSP scores. 
- Added corresponding unit tests to ensure risk classification logic is accurately validated.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
