### PR TITLE
[APG-589] Update Offence detail mapping for numberOfOthersInvolved field

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/OasysOffenceDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/OasysOffenceDetail.kt
@@ -7,7 +7,7 @@ data class OasysOffenceDetail(
   val offenceAnalysis: String?,
   val whatOccurred: List<String>?,
   val recognisesImpact: String?,
-  val numberOfOthersInvolved: Int?,
+  val numberOfOthersInvolved: String?,
   val othersInvolved: String?,
   val peerGroupInfluences: String?,
   val offenceMotivation: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/OffenceDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/OffenceDetail.kt
@@ -52,7 +52,7 @@ data class OffenceDetail(
   @get:JsonProperty("recognisesImpact") val recognisesImpact: Boolean? = false,
 
   @Schema(example = "null", description = "")
-  @get:JsonProperty("numberOfOthersInvolved") val numberOfOthersInvolved: Int? = 0,
+  @get:JsonProperty("numberOfOthersInvolved") val numberOfOthersInvolved: String? = null,
 
   @Schema(example = "There were two others involved who absconded at the scene", description = "")
   @get:JsonProperty("othersInvolvedDetail") val othersInvolvedDetail: String? = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/OasysControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/OasysControllerIntegrationTest.kt
@@ -39,10 +39,13 @@ class OasysControllerIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `Get offence details from Oasys`() {
+    // Given
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
     val prisonNumber = "A9999BB"
+    // When
     val offenceDetail = getOffenceDetailsByPrisonNumber(prisonNumber)
 
+    // Then
     offenceDetail.shouldNotBeNull()
     offenceDetail shouldBeEqual OffenceDetail(
       offenceDetails = "An attack took place on christmas eve in Alfreds ex partners house. The children were in bed and the dog was left out side.",
@@ -54,7 +57,7 @@ class OasysControllerIntegrationTest : IntegrationTestBase() {
       victimWasStranger = true,
       stalking = true,
       recognisesImpact = false,
-      numberOfOthersInvolved = null,
+      numberOfOthersInvolved = "6-10",
       othersInvolvedDetail = null,
       peerGroupInfluences = "No",
       motivationAndTriggers = "Mainly due to jealousy and fuelled by drug use",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysServiceTest.kt
@@ -57,11 +57,12 @@ class OasysServiceTest {
 
   @Test
   fun `should return offence detail`() {
+    // Given
     val offenceDetail = OasysOffenceDetail(
       offenceAnalysis = "offence analysis",
       whatOccurred = listOf("Stalking"),
       recognisesImpact = "Yes",
-      numberOfOthersInvolved = 0,
+      numberOfOthersInvolved = "6-10",
       othersInvolved = "No",
       peerGroupInfluences = "influences",
       offenceMotivation = "motivation",
@@ -75,8 +76,10 @@ class OasysServiceTest {
       offenceDetail,
     )
 
+    // When
     val result = service.getOffenceDetail(123123)
 
+    // Then
     assertEquals(offenceDetail, result)
   }
 

--- a/src/test/resources/simulations/__files/offence-detail.json
+++ b/src/test/resources/simulations/__files/offence-detail.json
@@ -21,7 +21,7 @@
   "othersInvolved": null,
   "typeOfWeapon": null,
   "victimInfo": null,
-  "numberOfOthersInvolved": null,
+  "numberOfOthersInvolved": "6-10",
   "thrillSeeking": "No",
   "sexual": "Yes",
   "racial": "No",


### PR DESCRIPTION
## Changes in this PR

- Update Oasys and Model dto data classes to correctly map field as String
- Update JUnit, integration test, and wiremock data file

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
