### PR TITLE
[APG-596] Fix HMP Wymott course offerings withdrawal status.

### DIFF
--- a/src/main/resources/db/migration/V105__fix_hmp_wymott_offerings.sql
+++ b/src/main/resources/db/migration/V105__fix_hmp_wymott_offerings.sql
@@ -1,0 +1,2 @@
+update offering set withdrawn = true
+where organisation_id ='WMI'and course_id in (select c.course_id from course c where c.identifier ='NMS-AO');


### PR DESCRIPTION
## Context

Currently HMP Wymott are able to see the “New Me Strengths” programme as a referable option which should not be the case.

## Changes in this PR

Created a data fix SQL script to set the withdrawn flag to true for the course offerings available at Wymott Prison for the New Me Strengths programme with the course identifier of NMS-AO  

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
