### PR TITLE
[APG-361] Fix table name in data refresh cronjob.

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-api/templates/cronjob-prod-to-preprod-data-refresh.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-api/templates/cronjob-prod-to-preprod-data-refresh.yaml
@@ -31,7 +31,7 @@ data:
       --data-only \
       --no-privileges \
       --verbose \
-      --table public.referrer_users \
+      --table public.referrer_user \
       --file=/tmp/users.dump \
       "$DB_NAME_PREPROD"
 


### PR DESCRIPTION
## Changes in this PR

Fixed typo for referrer_user table in data replication cronjob yaml 

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
