### PR TITLE
[APG-523] Update PNI persistence logic in ReferralService

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
@@ -28,6 +28,16 @@ const val ON_HOLD_REFERRAL_SUBMITTED_DESCRIPTION = "On hold - referral submitted
 const val ON_HOLD_REFERRAL_SUBMITTED_COLOUR = "yellow"
 const val ON_HOLD_REFERRAL_SUBMITTED_HINT = "The referral will be paused until the person is ready to continue."
 
+const val ASSESSED_SUITABLE = "ASSESSED_SUITABLE"
+const val ASSESSED_SUITABLE_DESCRIPTION = "Assessed as suitable"
+const val ASSESSED_SUITABLE_COLOUR = "purple"
+const val ASSESSED_SUITABLE_HINT = "This person meets the suitability criteria. They can now be considered to join this programme."
+
+const val ON_PROGRAMME = "ON_PROGRAMME"
+const val ON_PROGRAMME_DESCRIPTION = "On programme"
+const val ON_PROGRAMME_COLOUR = "pink"
+const val ON_PROGRAMME_HINT = "This person has started the programme."
+
 const val PRISON_NUMBER_1 = "C6666CC"
 const val REFERRER_USERNAME = "TEST_REFERRER_USER_1"
 const val ORGANISATION_ID_MDI = "MDI"


### PR DESCRIPTION

## Changes in this PR

- Refactor the PNI persistence mechanism to save PNI data only when the referral status is updated to "On Programme". 
- Added JUnit and Integration tests to validate this behaviour and ensure PNI is not stored prematurely or inappropriately. 

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
