### PR TITLE
APG 604 add 404 integration test for referral submission

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -705,9 +705,19 @@ class ReferralController(
         return ResponseEntity.status(HttpStatus.CONFLICT).body(duplicateReferrals.first().toApi())
       }
 
-      val submittedReferral = referralService.submitReferralById(id)
-      return ResponseEntity.status(HttpStatus.OK).body(submittedReferral.toApi())
-    } ?: throw NotFoundException("No referral found at /referral/$id")
+        val submittedReferral = referralService.submitReferralById(id)
+        log.info("Referral submitted $submittedReferral")
+
+        log.info("START TO API $submittedReferral")
+        val toApi = submittedReferral.toApi()
+        log.info("FINISH TO API  $toApi")
+        log.info("${ResponseEntity.status(HttpStatus.OK).body(toApi)}")
+        return ResponseEntity.status(HttpStatus.OK).body(toApi)
+      } ?: throw NotFoundException("No referral found at /referral/$id")
+    } catch (ex: Exception) {
+      log.warn("Error submitting referral $id ${ex.stackTrace}", ex)
+      throw ex
+    }
   }
 
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -705,19 +705,9 @@ class ReferralController(
         return ResponseEntity.status(HttpStatus.CONFLICT).body(duplicateReferrals.first().toApi())
       }
 
-        val submittedReferral = referralService.submitReferralById(id)
-        log.info("Referral submitted $submittedReferral")
-
-        log.info("START TO API $submittedReferral")
-        val toApi = submittedReferral.toApi()
-        log.info("FINISH TO API  $toApi")
-        log.info("${ResponseEntity.status(HttpStatus.OK).body(toApi)}")
-        return ResponseEntity.status(HttpStatus.OK).body(toApi)
-      } ?: throw NotFoundException("No referral found at /referral/$id")
-    } catch (ex: Exception) {
-      log.warn("Error submitting referral $id ${ex.stackTrace}", ex)
-      throw ex
-    }
+      val submittedReferral = referralService.submitReferralById(id)
+      return ResponseEntity.status(HttpStatus.OK).body(submittedReferral.toApi())
+    } ?: throw NotFoundException("No referral found at /referral/$id")
   }
 
   @Operation(

--- a/src/test/resources/simulations/mappings/allocation-manager-api.json
+++ b/src/test/resources/simulations/mappings/allocation-manager-api.json
@@ -12,6 +12,19 @@
         },
         "bodyFileName": "pom_details_C6666CC.json"
       }
+    },
+    {
+      "request": {
+        "url": "/api/allocation/NON-EXISTENT",
+        "method": "GET"
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body" : "{}"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Changes in this PR

Add integration test that verifies that referral submission completes successfully in the scenario that the allocation manager API returns a 404 when querying POM details.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
