### PR TITLE
[APG-611] Ensure SARA risk score is calculated correctly

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniRiskEngine.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniRiskEngine.kt
@@ -64,8 +64,7 @@ class PniRiskEngine {
   }
 
   fun isHighSara(individualRiskScores: IndividualRiskScores) =
-    (individualRiskScores.sara?.saraRiskOfViolenceTowardsOthers?.contains(RiskClassification.HIGH_RISK.description, ignoreCase = true) == true) ||
-      (individualRiskScores.sara?.saraRiskOfViolenceTowardsPartner?.contains(RiskClassification.HIGH_RISK.description, ignoreCase = true) == true)
+    individualRiskScores.sara?.saraRiskOfViolenceTowardsPartner?.contains(RiskClassification.HIGH_RISK.description, ignoreCase = true) == true
 
   private fun isRsrMedium(individualRiskScores: IndividualRiskScores, gender: String): Boolean {
     val rsrMediumRsr = individualRiskScores.rsr?.let { it in BigDecimal("1.00")..BigDecimal("2.99") } == true
@@ -118,8 +117,7 @@ class PniRiskEngine {
   }
 
   fun isMediumSara(individualRiskScores: IndividualRiskScores) =
-    individualRiskScores.sara?.saraRiskOfViolenceTowardsOthers?.equals(RiskClassification.MEDIUM_RISK.description, ignoreCase = true) == true ||
-      individualRiskScores.sara?.saraRiskOfViolenceTowardsPartner?.equals(RiskClassification.MEDIUM_RISK.description, ignoreCase = true) == true
+    individualRiskScores.sara?.saraRiskOfViolenceTowardsPartner?.equals(RiskClassification.MEDIUM_RISK.description, ignoreCase = true) == true
 }
 
 enum class RiskClassification(val description: String) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniService.kt
@@ -222,10 +222,7 @@ class PniService(
   }
 
   private fun getOverallSARAResult(sara: uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Sara?): SaraRisk? {
-    return SaraRisk.highestRisk(
-      SaraRisk.fromString(sara?.imminentRiskOfViolenceTowardsPartner),
-      SaraRisk.fromString(sara?.imminentRiskOfViolenceTowardsOthers),
-    )
+    return SaraRisk.fromString(sara?.imminentRiskOfViolenceTowardsPartner)
   }
 
   fun getGenderOfPerson(prisonNumber: String, prisonerGender: String?): String {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniRiskEngineTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniRiskEngineTest.kt
@@ -42,8 +42,8 @@ class PniRiskEngineTest {
       ospIic = null,
       rsr = null,
       sara = Sara(
-        saraRiskOfViolenceTowardsPartner = null,
-        saraRiskOfViolenceTowardsOthers = "High",
+        saraRiskOfViolenceTowardsPartner = "High",
+        saraRiskOfViolenceTowardsOthers = null,
         overallResult = null,
       ),
     )
@@ -193,7 +193,7 @@ class PniRiskEngineTest {
 
   @ParameterizedTest
   @CsvSource(value = ["VERY_HIGH", "VERY HIGH", "Very High", "HIGH", "High"])
-  fun `should return isHighRisk for a person with High or Very High Sara risk of violence towards others`(saraRiskValue: String) {
+  fun `should NOT return isHighRisk for a person with High or Very High Sara risk of violence towards others`(saraRiskValue: String) {
     val riskScores = IndividualRiskScores(
       ogrs3 = null,
       ovp = null,
@@ -206,8 +206,8 @@ class PniRiskEngineTest {
         overallResult = null,
       ),
     )
-    assertTrue(riskEngine.isHighRisk(riskScores, "Male"))
-    assertTrue(riskEngine.isHighRisk(riskScores, "Female"))
+    assertFalse(riskEngine.isHighRisk(riskScores, "Male"))
+    assertFalse(riskEngine.isHighRisk(riskScores, "Female"))
   }
 
   @ParameterizedTest
@@ -487,8 +487,8 @@ class PniRiskEngineTest {
       ospIic = null,
       rsr = null,
       sara = Sara(
-        saraRiskOfViolenceTowardsPartner = "Low",
-        saraRiskOfViolenceTowardsOthers = "Medium",
+        saraRiskOfViolenceTowardsPartner = "Medium",
+        saraRiskOfViolenceTowardsOthers = "Low",
         overallResult = null,
       ),
     )


### PR DESCRIPTION
## Context

Currently the SARA risk score is using both risk values returned from Oasys where as it should only use the risk of violence towards partner risk score for calculation purposes

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
