### PR TITLE
[APG-576] Delete course participations on draft referral delete

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/CourseParticipationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/CourseParticipationRepository.kt
@@ -22,6 +22,8 @@ interface CourseParticipationRepository : JpaRepository<CourseParticipationEntit
   )
   fun updateDraftStatusByReferralId(@Param("referralId") referralId: UUID)
 
+  fun deleteByReferralId(referralId: UUID)
+
   fun findByPrisonNumber(prisonNumber: String): List<CourseParticipationEntity>
 
   fun findByPrisonNumberAndOutcomeStatusIn(prisonNumber: String, outcomes: List<CourseStatus>): List<CourseParticipationEntity>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -40,6 +40,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.R
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toApi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toDomain
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.AuditService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.CourseParticipationService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralReferenceDataService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralStatusHistoryService
@@ -65,6 +66,7 @@ class ReferralController(
   private val referralStatusHistoryService: ReferralStatusHistoryService,
   private val auditService: AuditService,
   private val staffService: StaffService,
+  private val courseParticipationService: CourseParticipationService,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
@@ -209,6 +211,7 @@ class ReferralController(
       throw BusinessException("Only draft referrals can be deleted. Referral with $id has a status of ${status.code}")
     }
 
+    courseParticipationService.deleteAllCourseParticipationsForReferral(id)
     referralService.deleteReferral(id)
     return ResponseEntity.noContent().build()
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseParticipationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseParticipationService.kt
@@ -53,6 +53,10 @@ constructor(
     // longer be marked as draft
     courseParticipationRepository.updateDraftStatusByReferralId(referralId)
   }
+
+  fun deleteAllCourseParticipationsForReferral(referralId: UUID) {
+    courseParticipationRepository.deleteByReferralId(referralId)
+  }
 }
 
 private fun CourseParticipationEntity.applyUpdate(update: CourseParticipationUpdate): CourseParticipationEntity =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/PersistenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/PersistenceHelper.kt
@@ -104,7 +104,7 @@ class PersistenceHelper {
       .executeUpdate()
   }
 
-  fun createParticipation(participationId: UUID, referralId: UUID?, prisonNumber: String, courseName: String, source: String, detail: String, location: String, type: String, outcomeStatus: String, yearStarted: Int?, yearCompleted: Int?, isDraft: Boolean? = false, createdByUsername: String, createdDateTime: LocalDateTime, lastModifiedByUsername: String?, lastModifiedDateTime: LocalDateTime?) {
+  fun createCourseParticipation(participationId: UUID, referralId: UUID?, prisonNumber: String, courseName: String, source: String, detail: String, location: String, type: String, outcomeStatus: String, yearStarted: Int?, yearCompleted: Int?, isDraft: Boolean? = false, createdByUsername: String, createdDateTime: LocalDateTime, lastModifiedByUsername: String?, lastModifiedDateTime: LocalDateTime?) {
     entityManager.createNativeQuery("INSERT INTO course_participation (course_participation_id, referral_id, prison_number, course_name, source, detail, location, type, outcome_status, year_started, year_completed, is_draft, created_by_username, created_date_time, last_modified_by_username, last_modified_date_time) VALUES (:id, :referralId, :prisonNumber, :courseName, :source, :detail, :location, :type, :outcomeStatus, :yearStarted, :yearCompleted, :isDraft, :createdByUsername, :createdDateTime, :lastModifiedByUsername, :lastModifiedDateTime)")
       .setParameter("id", participationId)
       .setParameter("referralId", referralId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationIntegrationTest.kt
@@ -60,10 +60,10 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_1")
     persistenceHelper.createReferral(referralId, offeringId, "B2345BB", "TEST_REFERRER_USER_1", "This referral will be updated", false, false, "REFERRAL_STARTED", null)
 
-    persistenceHelper.createParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), referralId, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), referralId, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), referralId, "C1234CC", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), referralId, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), referralId, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), referralId, "C1234CC", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PeopleControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PeopleControllerIntegrationTest.kt
@@ -108,10 +108,10 @@ class PeopleControllerIntegrationTest : IntegrationTestBase() {
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_1")
     persistenceHelper.createReferral(referralId, UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), "A1234AA", "TEST_REFERRER_USER_1", "This referral will be updated", false, false, "REFERRAL_STARTED", null)
 
-    persistenceHelper.createParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), referralId, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), referralId, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), referralId, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), referralId, "A1234AA", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "COMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), referralId, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), referralId, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), referralId, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), referralId, "A1234AA", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "COMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
 
     // When
     val courseParticipations = getCourseParticipations("A1234AA", listOf(Status.COMPLETE, Status.INCOMPLETE))
@@ -130,10 +130,10 @@ class PeopleControllerIntegrationTest : IntegrationTestBase() {
 
     persistenceHelper.clearAllTableContent()
 
-    persistenceHelper.createParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), null, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), null, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), null, "A1234AA", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "COMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), null, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), null, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), null, "A1234AA", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "COMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
 
     // When
     val courseParticipations = getCourseParticipations("A1234AA", listOf(Status.COMPLETE, Status.INCOMPLETE))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
@@ -119,23 +119,23 @@ class PactContractTest : IntegrationTestBase() {
 
   @State("Participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 exists")
   fun `ensure participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 exists`() {
-    persistenceHelper.createParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
   }
 
   @State("Participation 882a5a16-bcb8-4d8b-9692-a3006dcecffb exists")
   fun `ensure participation 882a5a16-bcb8-4d8b-9692-a3006dcecffb exists`() {
-    persistenceHelper.createParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), null, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), null, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
   }
 
   @State("Participation cc8eb19e-050a-4aa9-92e0-c654e5cfe281 exists")
   fun `ensure participation cc8eb19e-050a-4aa9-92e0-c654e5cfe281 exists`() {
-    persistenceHelper.createParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), null, "C1234CC", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), null, "C1234CC", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
   }
 
   @State("Person A1234AA has participations 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 and eb357e5d-5416-43bf-a8d2-0dc8fd92162e and no others")
   fun `ensure person A1234AA has participations 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 and eb357e5d-5416-43bf-a8d2-0dc8fd92162e and no others`() {
-    persistenceHelper.createParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), null, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), null, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
   }
 
   @State("Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status REFERRAL_STARTED")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralStatusRefDataFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralStatusRefDataFactory.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory
+
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusRefData
+
+class ReferralStatusRefDataFactory {
+
+  private var code: String = "ASSESSMENT_STARTED"
+  private var description: String = "Assessment started"
+  private var colour: String = "blue"
+  private var hintText: String? = "This person is being assessed by the programme team for suitability."
+  private var confirmationText: String? = "You can give more details about this status update."
+  private var hasNotes: Boolean? = false
+  private var hasConfirmation: Boolean? = false
+  private var closed: Boolean? = false
+  private var draft: Boolean? = false
+  private var hold: Boolean? = false
+  private var release: Boolean? = true
+  private var deselectAndKeepOpen: Boolean? = false
+  private var defaultOrder: Int? = 60
+  private var notesOptional: Boolean? = true
+
+  fun withCode(code: String) = apply { this.code = code }
+  fun withDescription(description: String) = apply { this.description = description }
+  fun withColour(colour: String) = apply { this.colour = colour }
+  fun withHintText(hintText: String?) = apply { this.hintText = hintText }
+  fun withConfirmationText(confirmationText: String?) = apply { this.confirmationText = confirmationText }
+  fun withHasNotes(hasNotes: Boolean?) = apply { this.hasNotes = hasNotes }
+  fun withHasConfirmation(hasConfirmation: Boolean?) = apply { this.hasConfirmation = hasConfirmation }
+  fun withClosed(closed: Boolean?) = apply { this.closed = closed }
+  fun withDraft(draft: Boolean?) = apply { this.draft = draft }
+  fun withHold(hold: Boolean?) = apply { this.hold = hold }
+  fun withRelease(release: Boolean?) = apply { this.release = release }
+  fun withDeselectAndKeepOpen(deselectAndKeepOpen: Boolean?) = apply { this.deselectAndKeepOpen = deselectAndKeepOpen }
+  fun withDefaultOrder(defaultOrder: Int?) = apply { this.defaultOrder = defaultOrder }
+  fun withNotesOptional(notesOptional: Boolean?) = apply { this.notesOptional = notesOptional }
+
+  fun produce() = ReferralStatusRefData(
+    code = code,
+    description = description,
+    colour = colour,
+    hintText = hintText,
+    confirmationText = confirmationText,
+    hasNotes = hasNotes,
+    hasConfirmation = hasConfirmation,
+    closed = closed,
+    draft = draft,
+    hold = hold,
+    release = release,
+    deselectAndKeepOpen = deselectAndKeepOpen,
+    defaultOrder = defaultOrder,
+    notesOptional = notesOptional,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseParticipationRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseParticipationRepositoryIntegrationTest.kt
@@ -22,10 +22,10 @@ class CourseParticipationRepositoryIntegrationTest : IntegrationTestBase() {
   @BeforeEach
   fun setUp() {
     persistenceHelper.clearAllTableContent()
-    persistenceHelper.createParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), null, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), null, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
-    persistenceHelper.createParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), null, "A1234AA", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "COMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), null, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), null, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), null, "A1234AA", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "COMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -22,6 +22,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.put
@@ -36,6 +37,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.R
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toApi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.AuditService
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.CourseParticipationService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralReferenceDataService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralStatusHistoryService
@@ -44,6 +46,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.StaffSe
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.CourseEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OfferingEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralStatusRefDataFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferrerUserEntityFactory
 import java.util.UUID
 
@@ -67,7 +70,19 @@ constructor(
   private lateinit var securityService: SecurityService
 
   @MockkBean
+  private lateinit var referralReferenceDataService: ReferralReferenceDataService
+
+  @MockkBean
+  private lateinit var referralStatusHistoryService: ReferralStatusHistoryService
+
+  @MockkBean
   private lateinit var auditService: AuditService
+
+  @MockkBean
+  private lateinit var staffService: StaffService
+
+  @MockkBean
+  private lateinit var courseParticipationService: CourseParticipationService
 
   @Test
   fun `createReferral with JWT, existing user, and valid payload returns 201 with correct body`() {
@@ -358,12 +373,44 @@ constructor(
     val referralStatusHistoryService: ReferralStatusHistoryService = mockk()
     val auditService: AuditService = mockk()
     val staffService: StaffService = mockk()
+    val courseParticipationService: CourseParticipationService = mockk()
 
-    val referralController = ReferralController(referralService, securityService, referenceDataService, referralStatusHistoryService, auditService, staffService)
+    val referralController = ReferralController(referralService, securityService, referenceDataService, referralStatusHistoryService, auditService, staffService, courseParticipationService)
 
     val parseNameOrId = referralController.parseNameOrId(nameSearch)
     parseNameOrId.forename shouldBe "DEL"
     parseNameOrId.surname shouldBe "HATTON"
     parseNameOrId.surnameOnly shouldBe ""
+  }
+
+  @Test
+  fun `deleteReferralById removes referral and associated course participation records`() {
+    // Given
+    every { auditService.audit(any(), any(), org.mockito.kotlin.eq(AuditAction.DELETE_REFERRAL.name)) } returns Unit
+
+    val referralId = UUID.randomUUID()
+    val referral = ReferralEntityFactory()
+      .withId(referralId)
+      .withOffering(OfferingEntityFactory().withId(UUID.randomUUID()).produce())
+      .withPrisonNumber(randomPrisonNumber())
+      .withReferrer(ReferrerUserEntityFactory().withUsername(REFERRER_USERNAME).produce())
+      .produce()
+
+    val draftReferralStatus = ReferralStatusRefDataFactory().withDraft(true).produce()
+    every { referralReferenceDataService.getReferralStatus(any()) } returns draftReferralStatus
+    every { referralService.getReferralById(referralId) } returns referral
+    every { courseParticipationService.deleteAllCourseParticipationsForReferral(referralId) } just Runs
+    every { referralService.deleteReferral(referralId) } just Runs
+
+    // When
+    mockMvc.delete("/referrals/$referralId") {
+      header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+    }.andExpect {
+      status { isNoContent() }
+    }
+
+    // Then
+    verify { courseParticipationService.deleteAllCourseParticipationsForReferral(referralId) }
+    verify { referralService.deleteReferral(referralId) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -12,6 +12,7 @@ import jakarta.validation.ValidationException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.kotlin.any
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -48,6 +49,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.ent
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralStatusRefDataFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferrerUserEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.StaffEntityFactory
 import java.util.UUID
 
 private const val MY_REFERRALS_ENDPOINT = "/referrals/me/dashboard"
@@ -188,6 +190,11 @@ constructor(
       .produce()
 
     every { referralService.getReferralById(any()) } returns referral
+    val referralStatus = ReferralStatusRefDataFactory()
+      .withCode(REFERRAL_STARTED)
+      .produce()
+    every { referralReferenceDataService.getReferralStatus(REFERRAL_STARTED) } returns referralStatus
+    every { staffService.getStaffDetail(any()) } returns StaffEntityFactory().produce()
     every { auditService.audit(any(), any(), org.mockito.kotlin.eq(AuditAction.VIEW_REFERRAL.name)) } returns Unit
 
     mockMvc.get("/referrals/${referral.id}?updatePerson=false") {


### PR DESCRIPTION
## Changes in this PR

- Introduced a method to delete all course participations related to a specific referral. 
- Updated the service, controller, and repository to support this behavior. 
- Added Junit and Integration tests to verify behaviour
- Refactored usage of helper factory methods to ensure consistency.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
