### PR TITLE
[APG-634] Add handling for DETERMINATE_RECALL and INDETERMINATE_RECALL categories

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryType.kt
@@ -19,6 +19,8 @@ enum class SentenceCategoryType(val description: String) {
         sentenceCategoryList.containsAll(listOf(DETERMINATE, INDETERMINATE)) -> DETERMINATE_INDETERMINATE
         sentenceCategoryList.containsAll(listOf(DETERMINATE_RECALL, INDETERMINATE)) -> DETERMINATE_INDETERMINATE_RECALL
         sentenceCategoryList.containsAll(listOf(DETERMINATE, INDETERMINATE_RECALL)) -> DETERMINATE_INDETERMINATE_RECALL
+        sentenceCategoryList.contains(DETERMINATE_RECALL) -> DETERMINATE_RECALL
+        sentenceCategoryList.contains(INDETERMINATE_RECALL) -> INDETERMINATE_RECALL
         sentenceCategoryList.contains(DETERMINATE) -> DETERMINATE
         sentenceCategoryList.contains(INDETERMINATE) -> INDETERMINATE
         sentenceCategoryList.contains(RECALL) -> RECALL

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryTypeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryTypeTest.kt
@@ -84,4 +84,20 @@ class SentenceCategoryTypeTest {
     // When & Then
     assertThat(SentenceCategoryType.determineOverallCategory(list)).isEqualTo(SentenceCategoryType.INDETERMINATE)
   }
+
+  @Test
+  fun `Should return DETERMINATE_RECALL if it's the only category in the list`() {
+    // Given
+    val list = listOf(SentenceCategoryType.DETERMINATE_RECALL)
+    // When & Then
+    assertThat(SentenceCategoryType.determineOverallCategory(list)).isEqualTo(SentenceCategoryType.DETERMINATE_RECALL)
+  }
+
+  @Test
+  fun `Should return INDETERMINATE_RECALL if it's the only category in the list`() {
+    // Given
+    val list = listOf(SentenceCategoryType.INDETERMINATE_RECALL)
+    // When & Then
+    assertThat(SentenceCategoryType.determineOverallCategory(list)).isEqualTo(SentenceCategoryType.INDETERMINATE_RECALL)
+  }
 }


### PR DESCRIPTION

## Changes in this PR

- Fix to ensure that sentence category types of DETERMINATE_RECALL and INDETERMINATE_RECALL are correctly mapped.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
