### PR TITLE
[APG-592] Add projection for course participation with referral status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/CourseParticipationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/CourseParticipationRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseStatus
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.projection.CourseParticipationProjection
 import java.util.UUID
 
 @Repository
@@ -29,6 +30,32 @@ interface CourseParticipationRepository : JpaRepository<CourseParticipationEntit
   fun findByPrisonNumberAndOutcomeStatusIn(prisonNumber: String, outcomes: List<CourseStatus>): List<CourseParticipationEntity>
 
   fun findByReferralId(referralId: UUID): List<CourseParticipationEntity>
+
+  @Query(
+    value = """
+        SELECT 
+            cp.prison_number AS prisonNumber,
+            cp.course_participation_id AS id,
+            cp.referral_id AS referralId,
+            cp.year_started as yearStarted,
+            cp.year_completed as yearCompleted,
+            cp.outcome_status AS outcomeStatus,
+            cp.source AS source,
+            cp.course_name AS courseName,
+            cp.type AS type,
+            cp.detail AS detail,
+            cp.location AS location,
+            cp.is_draft AS isDraft,
+            cp.created_date_time AS createdAt,
+            cp.created_by_username AS addedBy,
+            r.status AS referralStatus
+        FROM course_participation cp
+        INNER JOIN referral r ON cp.referral_id = r.referral_id
+        WHERE cp.referral_id = :referralId
+    """,
+    nativeQuery = true,
+  )
+  fun findCourseParticipationByReferralId(@Param("referralId") referralId: UUID): List<CourseParticipationProjection>
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/projection/CourseParticipationProjection.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/projection/CourseParticipationProjection.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.projection
+
+import java.util.UUID
+
+interface CourseParticipationProjection {
+  fun getPrisonNumber(): String
+  fun getId(): UUID
+  fun getReferralId(): UUID?
+  fun getReferralStatus(): String?
+  fun getAddedBy(): String
+  fun getCreatedAt(): String
+  fun getCourseName(): String?
+  fun getType(): String?
+  fun getYearStarted(): Int?
+  fun getYearCompleted(): Int?
+  fun getLocation(): String?
+  fun getOutcomeStatus(): String?
+  fun getDetail(): String?
+  fun getSource(): String?
+  fun getIsDraft(): Boolean?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseParticipationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseParticipationController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.NotFoundException
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.projection.CourseParticipationProjection
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CourseParticipation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CourseParticipationCreate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CourseParticipationUpdate
@@ -170,7 +170,7 @@ class CourseParticipationController(private val courseParticipationService: Cour
     ResponseEntity.ok(
       courseParticipationService
         .getCourseParticipationHistoryByReferralId(referralId)
-        .map(CourseParticipationEntity::toApi),
+        .map(CourseParticipationProjection::toApi),
     )
 
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/CourseParticipation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/CourseParticipation.kt
@@ -50,4 +50,7 @@ data class CourseParticipation(
 
   @Schema(example = "null", description = "Whether this is a draft record or not.")
   @get:JsonProperty("isDraft") val isDraft: Boolean? = false,
+
+  @Schema(example = "null", description = "The status of the associated referral.")
+  @get:JsonProperty("referralStatus") val referralStatus: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/CourseParticipationOutcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/CourseParticipationOutcome.kt
@@ -35,11 +35,9 @@ data class CourseParticipationOutcome(
   }
 
   companion object {
-    fun from(status: String?, yearStarted: Int?, yearCompleted: Int?): CourseParticipationOutcome? {
-      if (status == null) {
-        return null
+    fun from(status: String?, yearStarted: Int?, yearCompleted: Int?): CourseParticipationOutcome? =
+      status?.let {
+        CourseParticipationOutcome(Status.valueOf(it.uppercase()), yearStarted, yearCompleted)
       }
-      return CourseParticipationOutcome(Status.valueOf(status.uppercase()), yearStarted, yearCompleted)
-    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/CourseParticipationOutcome.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/CourseParticipationOutcome.kt
@@ -33,4 +33,13 @@ data class CourseParticipationOutcome(
     @JsonProperty("complete")
     COMPLETE("complete"),
   }
+
+  companion object {
+    fun from(status: String?, yearStarted: Int?, yearCompleted: Int?): CourseParticipationOutcome? {
+      if (status == null) {
+        return null
+      }
+      return CourseParticipationOutcome(Status.valueOf(status.uppercase()), yearStarted, yearCompleted)
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/CourseParticipationSetting.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/CourseParticipationSetting.kt
@@ -15,4 +15,14 @@ data class CourseParticipationSetting(
 
   @Schema(example = "null", description = "")
   @get:JsonProperty("location") val location: String? = null,
-)
+) {
+
+  companion object {
+    fun from(type: String?, location: String? = null): CourseParticipationSetting? {
+      if (type == null || location == null) {
+        return null
+      }
+      return CourseParticipationSetting(type = CourseParticipationSettingType.valueOf(type), location = location)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/CourseParticipationTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/CourseParticipationTransformers.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.c
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.CourseParticipationUpdate
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.projection.CourseParticipationProjection
 import java.time.Year
 import java.time.format.DateTimeFormatter
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CourseParticipation as ApiCourseParticipation
@@ -100,4 +101,19 @@ fun CourseParticipationEntity.toApi() = ApiCourseParticipation(
   isDraft = isDraft,
   addedBy = createdByUsername,
   createdAt = createdDateTime.format(DateTimeFormatter.ISO_DATE_TIME),
+)
+
+fun CourseParticipationProjection.toApi() = ApiCourseParticipation(
+  courseName = getCourseName(),
+  id = getId(),
+  referralId = getReferralId(),
+  prisonNumber = getPrisonNumber(),
+  setting = ApiCourseParticipationSetting.from(getType(), getLocation()),
+  source = getSource(),
+  detail = getDetail(),
+  outcome = ApiCourseParticipationOutcome.from(getOutcomeStatus(), getYearStarted(), getYearCompleted()),
+  isDraft = getIsDraft(),
+  addedBy = getAddedBy(),
+  createdAt = getCreatedAt().format(DateTimeFormatter.ISO_DATE_TIME),
+  referralStatus = getReferralStatus(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseParticipationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseParticipationService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.c
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.CourseParticipationUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseParticipationRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.projection.CourseParticipationProjection
 import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
 
@@ -44,8 +45,8 @@ constructor(
     return courseParticipationRepository.findByPrisonNumberAndOutcomeStatusIn(prisonNumber, outcomeStatus)
   }
 
-  fun getCourseParticipationHistoryByReferralId(uuid: UUID): List<CourseParticipationEntity> {
-    return courseParticipationRepository.findByReferralId(uuid)
+  fun getCourseParticipationHistoryByReferralId(uuid: UUID): List<CourseParticipationProjection> {
+    return courseParticipationRepository.findCourseParticipationByReferralId(uuid)
   }
 
   fun updateDraftHistoryForSubmittedReferral(referralId: UUID) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryTypeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryTypeTest.kt
@@ -101,3 +101,4 @@ class SentenceCategoryTypeTest {
     assertThat(SentenceCategoryType.determineOverallCategory(list)).isEqualTo(SentenceCategoryType.INDETERMINATE_RECALL)
   }
 }
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryTypeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryTypeTest.kt
@@ -101,4 +101,3 @@ class SentenceCategoryTypeTest {
     assertThat(SentenceCategoryType.determineOverallCategory(list)).isEqualTo(SentenceCategoryType.INDETERMINATE_RECALL)
   }
 }
-

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationControllerIntegrationTest.kt
@@ -38,7 +38,7 @@ import java.util.UUID
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @Import(JwtAuthHelper::class)
-class CourseParticipationIntegrationTest : IntegrationTestBase() {
+class CourseParticipationControllerIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   lateinit var courseParticipationRepository: CourseParticipationRepository
@@ -403,6 +403,7 @@ class CourseParticipationIntegrationTest : IntegrationTestBase() {
     courseParticipationRecords.shouldNotBeNull()
     courseParticipationRecords.size shouldBe 3
     assertThat(courseParticipationRecords).extracting("referralId").containsOnly(referralId)
+    assertThat(courseParticipationRecords).extracting("referralStatus").containsOnly("REFERRAL_STARTED")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseParticipationControllerIntegrationTest.kt
@@ -419,7 +419,7 @@ class CourseParticipationControllerIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `searching for course particpipations by referral id should return http bad request for malformed UUID`() {
+  fun `searching for course participations by referral id should return http bad request for malformed UUID`() {
     // Given
     val badReferralId = "not-a-uuid"
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/pact/PactContractTest.kt
@@ -26,6 +26,7 @@ import java.util.*
 @Provider("Accredited Programmes API")
 @VerificationReports(value = ["markdown", "console"], reportDir = "build/pact")
 class PactContractTest : IntegrationTestBase() {
+
   @BeforeEach
   fun setup() {
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
@@ -33,7 +34,9 @@ class PactContractTest : IntegrationTestBase() {
   }
 
   @State("A participation can be created")
-  fun `ensure a participation can be created`() {}
+  fun `ensure a participation can be created`() {
+    createReferral()
+  }
 
   @State("A course can be created")
   fun `ensure a course can be created`() {
@@ -119,23 +122,56 @@ class PactContractTest : IntegrationTestBase() {
 
   @State("Participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 exists")
   fun `ensure participation 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 exists`() {
-    persistenceHelper.createCourseParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    val referralId = createReferral()
+    persistenceHelper.createCourseParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), referralId, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
   }
 
   @State("Participation 882a5a16-bcb8-4d8b-9692-a3006dcecffb exists")
   fun `ensure participation 882a5a16-bcb8-4d8b-9692-a3006dcecffb exists`() {
-    persistenceHelper.createCourseParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), null, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
+    val referralId = createReferral()
+    persistenceHelper.createCourseParticipation(UUID.fromString("882a5a16-bcb8-4d8b-9692-a3006dcecffb"), referralId, "B2345BB", "Marzipan Course", "Reader's Digest", "This participation will be deleted", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Adele Chiellini", LocalDateTime.parse("2023-11-26T10:20:45"), null, null)
   }
 
   @State("Participation cc8eb19e-050a-4aa9-92e0-c654e5cfe281 exists")
   fun `ensure participation cc8eb19e-050a-4aa9-92e0-c654e5cfe281 exists`() {
-    persistenceHelper.createCourseParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), null, "C1234CC", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    val referralId = createReferral()
+    persistenceHelper.createCourseParticipation(UUID.fromString("cc8eb19e-050a-4aa9-92e0-c654e5cfe281"), referralId, "C1234CC", "Orange Course", "squirrel", "This participation will be updated", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
   }
 
   @State("Person A1234AA has participations 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 and eb357e5d-5416-43bf-a8d2-0dc8fd92162e and no others")
   fun `ensure person A1234AA has participations 0cff5da9-1e90-4ee2-a5cb-94dc49c4b004 and eb357e5d-5416-43bf-a8d2-0dc8fd92162e and no others`() {
-    persistenceHelper.createCourseParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), null, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
-    persistenceHelper.createCourseParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), null, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
+    val referralId = createReferral()
+    persistenceHelper.createCourseParticipation(UUID.fromString("0cff5da9-1e90-4ee2-a5cb-94dc49c4b004"), referralId, "A1234AA", "Green Course", "squirrel", "Some detail", "Schulist End", "COMMUNITY", "INCOMPLETE", 2023, null, false, "Carmelo Conn", LocalDateTime.parse("2023-10-11T13:11:06"), null, null)
+    persistenceHelper.createCourseParticipation(UUID.fromString("eb357e5d-5416-43bf-a8d2-0dc8fd92162e"), referralId, "A1234AA", "Red Course", "deaden", "Some detail", "Schulist End", "CUSTODY", "INCOMPLETE", 2023, null, false, "Joanne Hamill", LocalDateTime.parse("2023-09-21T23:45:12"), null, null)
+  }
+
+  private fun createReferral(): UUID? {
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
+    val offeringId = UUID.randomUUID()
+    val courseId = UUID.randomUUID()
+    val referralId = UUID.fromString("0c46ed09-170b-4c0f-aee8-a24eeaeeddab")
+    persistenceHelper.createCourse(courseId, "C1", "Course 1", "Sample description", "SC++", "General offence")
+    persistenceHelper.createOffering(
+      offeringId,
+      courseId,
+      "MDI",
+      "nobody-mdi@digital.justice.gov.uk",
+      "nobody2-mdi@digital.justice.gov.uk",
+      true,
+    )
+    persistenceHelper.createReferrerUser("TEST_REFERRER_USER_1")
+    persistenceHelper.createReferral(
+      referralId,
+      offeringId,
+      "B2345BB",
+      "TEST_REFERRER_USER_1",
+      "This referral will be updated",
+      false,
+      false,
+      "REFERRAL_STARTED",
+      null,
+    )
+    return referralId
   }
 
   @State("Referral 0c46ed09-170b-4c0f-aee8-a24eeaeeddaa exists with status REFERRAL_STARTED")
@@ -220,6 +256,7 @@ class PactContractTest : IntegrationTestBase() {
     persistenceHelper.createReferrerUser("TEST_REFERRER_USER_2")
 
     persistenceHelper.createReferral(UUID.fromString("0c46ed09-170b-4c0f-aee8-a24eeaeeddaa"), UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), "B2345BB", "TEST_REFERRER_USER_1", "This referral will be updated", false, false, "REFERRAL_STARTED", null)
+    persistenceHelper.createReferral(UUID.fromString("0c46ed09-170b-4c0f-aee8-a24eeaeeddab"), UUID.fromString("7fffcc6a-11f8-4713-be35-cf5ff1aee517"), "B2345BB", "TEST_REFERRER_USER_1", "This referral will be updated", false, false, "REFERRAL_STARTED", null)
     persistenceHelper.createReferral(UUID.fromString("fae2ed00-057e-4179-9e55-f6a4f4874cf0"), UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), "C3456CC", "TEST_REFERRER_USER_2", "more information", true, true, "REFERRAL_SUBMITTED", LocalDateTime.parse("2023-11-12T19:11:00"))
     persistenceHelper.createReferral(UUID.fromString("153383a4-b250-46a8-9950-43eb358c2805"), UUID.fromString("790a2dfe-7de5-4504-bb9c-83e6e53a6537"), "D3456DD", "TEST_REFERRER_USER_2", "more information", true, true, "REFERRAL_SUBMITTED", LocalDateTime.parse("2023-11-13T19:11:00"))
 


### PR DESCRIPTION
## Changes in this PR

- Introduced `CourseParticipationProjection` to support fetching course participation details, including referral status, via repository projection. 
- Updated related components, such as service, transformers, and controller, to utilise this projection. 
- Renamed and enhanced integration tests to validate the new behaviour.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
