### PR TITLE
[APG-545] Add statistics endpoint for referral counts by programme

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/StatisticsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/StatisticsController.kt
@@ -11,7 +11,10 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StatisticsRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReportStatusCount
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.StatisticsService
 import java.time.LocalDate
+import java.util.UUID
 
 @RestController
 @Tag(
@@ -24,8 +27,10 @@ import java.time.LocalDate
 )
 @RequestMapping("statistics")
 class StatisticsController(
+
   private val statisticsRepository: StatisticsRepository,
   private val objectMapper: ObjectMapper,
+  private val statisticsService: StatisticsService,
 ) {
   @GetMapping("/report/countByStatus", produces = ["application/json"])
   fun getReportTypes(
@@ -38,6 +43,21 @@ class StatisticsController(
       endDate!!,
       locationCodes,
     ).orEmpty()
+
+  @GetMapping("/report/count-by-status-for-programme", produces = ["application/json"])
+  fun getReportStatusCountsForProgramme(
+    @RequestParam startDate: LocalDate,
+    @RequestParam endDate: LocalDate? = LocalDate.now().plusDays(1),
+    @RequestParam locationCodes: List<String>? = listOf(),
+    @RequestParam courseId: UUID,
+  ): List<ReportStatusCount> {
+    return statisticsService.getReferralStatusCountByProgramme(
+      startDate,
+      endDate!!,
+      locationCodes,
+      courseId,
+    )
+  }
 
   @GetMapping("/report-types", produces = ["application/json"])
   fun getReportTypes(): ReportTypes {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReportStatusCount.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReportStatusCount.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
+
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StatisticsRepository.ReportStatusCountProjection
+
+data class ReportStatusCount(
+  val count: Long,
+  val status: String,
+  val organisationCode: String,
+) {
+  companion object {
+    fun from(projection: ReportStatusCountProjection) = ReportStatusCount(
+      count = projection.getCount().toLong(),
+      status = projection.getStatus(),
+      organisationCode = projection.getOrgId(),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StatisticsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StatisticsService.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StatisticsRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReportStatusCount
+import java.time.LocalDate
+import java.util.UUID
+
+@Service
+class StatisticsService(
+  val statisticsRepository: StatisticsRepository,
+) {
+  fun getReferralStatusCountByProgramme(
+    startDate: LocalDate,
+    endDate: LocalDate,
+    locations: List<String>?,
+    courseId: UUID,
+  ): List<ReportStatusCount> {
+    return statisticsRepository.findReferralCountByCourseId(startDate, endDate, locations, courseId)
+      ?.map(ReportStatusCount::from) ?: emptyList()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/util/TestConstants.kt
@@ -38,6 +38,9 @@ const val ON_PROGRAMME_DESCRIPTION = "On programme"
 const val ON_PROGRAMME_COLOUR = "pink"
 const val ON_PROGRAMME_HINT = "This person has started the programme."
 
+const val DESELECTED = "DESELECTED"
+const val PROGRAMME_COMPLETE = "PROGRAMME_COMPLETE"
+
 const val PRISON_NUMBER_1 = "C6666CC"
 const val REFERRER_USERNAME = "TEST_REFERRER_USER_1"
 const val ORGANISATION_ID_MDI = "MDI"


### PR DESCRIPTION
## Changes in this PR

Introduce a new endpoint to retrieve referral status counts for a specified programme and location. This includes changes to the repository, service, and controller to handle the query logic, as well as relevant integration tests for validation.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
