### PR TITLE
[APG-622] Add endpoint to retrieve organisation details by code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/Organisation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/Organisation.kt
@@ -15,4 +15,7 @@ data class Organisation(
 
   @Schema(example = "Moorland HMP", description = "")
   @get:JsonProperty("prisonName") val prisonName: String? = null,
+
+  @Schema(example = "MALE", description = "The gender of inmates that a prison will accept")
+  @get:JsonProperty("gender") val gender: String? = null,
 )


### PR DESCRIPTION
## Changes in this PR

- Implemented a new endpoint in OrganisationController to fetch organisation details using an organisation code. 
- Added support for gender information in the Organisation model and handled 404 errors for unknown organisation codes. 
- Updated integration tests to verify the new functionality.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
