### PR TITLE
[APG-665] Delete `course_variant` data during seed reset

### DIFF
--- a/src/main/resources/seed/db/migration/R__Seed_Data.sql
+++ b/src/main/resources/seed/db/migration/R__Seed_Data.sql
@@ -5,6 +5,7 @@ DELETE from referral;
 DELETE from referrer_user;
 DELETE from offering;
 DELETE from prerequisite;
+DELETE from course_variant;
 DELETE from course;
 
 INSERT INTO course(course_id, name, identifier, description, audience, alternate_name)


### PR DESCRIPTION
## Changes in this PR

- Delete `course_variant` table data during seed reset

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
