### PR TITLE
[APG-672] Refactor handling of course participation creation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseParticipationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseParticipationEntity.kt
@@ -29,7 +29,9 @@ data class CourseParticipationEntity(
   @Column(name = "course_participation_id")
   val id: UUID? = null,
 
-  val referralId: UUID? = null,
+  var referralId: UUID? = null,
+
+  var courseId: UUID? = null,
 
   val prisonNumber: String,
   var courseName: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseParticipationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseParticipationService.kt
@@ -38,8 +38,15 @@ constructor(
     val organisationEntity = organisationRepository.findOrganisationEntityByCode(referral.offering.organisationId)
       ?: throw IllegalArgumentException("Organisation not found for code: ${referral.offering.organisationId}")
 
+    // If an existing course participation record exists for a particular referral and course, we should update it.
+    // This should be done by comparing referralId and courseId ideally but the existing data set is incomplete
+    // in this regard, hence the filter below
     val filteredParticipations = courseParticipationRepository.findByPrisonNumber(referral.prisonNumber)
-      .filter { it.courseName == courseName }
+      .filter {
+        it.courseName == courseName &&
+          it.outcome?.yearCompleted == null &&
+          it.outcome?.status != CourseStatus.INCOMPLETE
+      }
 
     when (filteredParticipations.size) {
       1 -> updateExistingParticipation(filteredParticipations.first(), referral, organisationEntity)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseParticipationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseParticipationService.kt
@@ -4,10 +4,19 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationOutcome
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationSetting
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseStatus
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OrganisationEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.CourseParticipationUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseParticipationRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OrganisationRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.projection.CourseParticipationProjection
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type.ReferralStatus
+import java.time.LocalDateTime
+import java.time.Year
 import java.util.UUID
 import kotlin.jvm.optionals.getOrNull
 
@@ -17,11 +26,84 @@ class CourseParticipationService
 @Autowired
 constructor(
   private val courseParticipationRepository: CourseParticipationRepository,
+  private val organisationRepository: OrganisationRepository,
 ) {
   fun createCourseParticipation(courseParticipation: CourseParticipationEntity): CourseParticipationEntity? =
     courseParticipation.let {
       courseParticipationRepository.save(it)
     }
+
+  fun createOrUpdateCourseParticipation(referral: ReferralEntity) {
+    val courseName = referral.offering.course.name
+    val organisationEntity = organisationRepository.findOrganisationEntityByCode(referral.offering.organisationId)
+      ?: throw IllegalArgumentException("Organisation not found for code: ${referral.offering.organisationId}")
+
+    val filteredParticipations = courseParticipationRepository.findByPrisonNumber(referral.prisonNumber)
+      .filter { it.courseName == courseName }
+
+    when (filteredParticipations.size) {
+      1 -> updateExistingParticipation(filteredParticipations.first(), referral, organisationEntity)
+      else -> {
+        // Create a new course participation if none or multiples exist
+        val newParticipation = buildCourseParticipation(referral, organisationEntity)
+        courseParticipationRepository.save(newParticipation)
+      }
+    }
+  }
+
+  private fun updateExistingParticipation(
+    existingParticipation: CourseParticipationEntity,
+    referral: ReferralEntity,
+    organisationEntity: OrganisationEntity,
+  ) {
+    existingParticipation.apply {
+      referralId = referral.id
+      courseId = referral.offering.course.id
+      source = referral.referrer.username
+      detail = referral.additionalInformation
+      lastModifiedDateTime = LocalDateTime.now()
+      setting = CourseParticipationSetting(
+        location = organisationEntity.name,
+        type = CourseSetting.CUSTODY,
+      )
+      outcome = buildCourseParticipationOutcomeByStatus(referral.status)
+        .also {
+          if (existingParticipation.outcome?.yearStarted != null) {
+            it?.yearStarted = existingParticipation.outcome?.yearStarted
+          }
+        }
+    }
+    courseParticipationRepository.save(existingParticipation)
+  }
+
+  private fun buildCourseParticipation(referralEntity: ReferralEntity, organisationEntity: OrganisationEntity): CourseParticipationEntity {
+    return CourseParticipationEntity(
+      referralId = referralEntity.id,
+      prisonNumber = referralEntity.prisonNumber,
+      courseId = referralEntity.offering.course.id,
+      courseName = referralEntity.offering.course.name,
+      source = referralEntity.referrer.username,
+      detail = referralEntity.additionalInformation,
+      createdDateTime = LocalDateTime.now(),
+      setting = CourseParticipationSetting(
+        location = organisationEntity.name,
+        type = CourseSetting.CUSTODY,
+      ),
+      outcome = buildCourseParticipationOutcomeByStatus(referralEntity.status),
+    )
+  }
+
+  private fun buildCourseParticipationOutcomeByStatus(referralStatus: String): CourseParticipationOutcome? {
+    return when (referralStatus) {
+      ReferralStatus.PROGRAMME_COMPLETE.name -> CourseParticipationOutcome(
+        CourseStatus.COMPLETE,
+        yearCompleted = Year.now(),
+      )
+
+      ReferralStatus.DESELECTED.name -> CourseParticipationOutcome(CourseStatus.INCOMPLETE)
+      else -> null
+    }
+  }
 
   fun getCourseParticipationById(historicCourseParticipationId: UUID): CourseParticipationEntity? =
     courseParticipationRepository.findById(historicCourseParticipationId).getOrNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
@@ -404,35 +404,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
     // Given
     val createdReferral = createReferral(PRISON_NUMBER_1)
 
-    val referralStatusUpdate1 = ReferralStatusUpdate(
-      status = ReferralStatus.REFERRAL_SUBMITTED.name,
-      ptUser = true,
-    )
-    updateReferralStatus(createdReferral.id, referralStatusUpdate1)
-
-    val referralStatusUpdate2 = ReferralStatusUpdate(
-      status = ReferralStatus.AWAITING_ASSESSMENT.name,
-      ptUser = true,
-    )
-    updateReferralStatus(createdReferral.id, referralStatusUpdate2)
-
-    val referralStatusUpdate3 = ReferralStatusUpdate(
-      status = ReferralStatus.ASSESSMENT_STARTED.name,
-      ptUser = true,
-    )
-    updateReferralStatus(createdReferral.id, referralStatusUpdate3)
-
-    val referralStatusUpdate4 = ReferralStatusUpdate(
-      status = ReferralStatus.ASSESSED_SUITABLE.name,
-      ptUser = true,
-    )
-    updateReferralStatus(createdReferral.id, referralStatusUpdate4)
-
-    val referralStatusUpdate5 = ReferralStatusUpdate(
-      status = ReferralStatus.ON_PROGRAMME.name,
-      ptUser = true,
-    )
-    updateReferralStatus(createdReferral.id, referralStatusUpdate5)
+    updateReferralStatusToOnProgramme(createdReferral)
 
     // When
     val referralStatusUpdate6 = ReferralStatusUpdate(
@@ -469,35 +441,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
       .produce()
     courseParticipationRepository.save(existCourseParticipation)
 
-    val referralStatusUpdate1 = ReferralStatusUpdate(
-      status = ReferralStatus.REFERRAL_SUBMITTED.name,
-      ptUser = true,
-    )
-    updateReferralStatus(createdReferral.id, referralStatusUpdate1)
-
-    val referralStatusUpdate2 = ReferralStatusUpdate(
-      status = ReferralStatus.AWAITING_ASSESSMENT.name,
-      ptUser = true,
-    )
-    updateReferralStatus(createdReferral.id, referralStatusUpdate2)
-
-    val referralStatusUpdate3 = ReferralStatusUpdate(
-      status = ReferralStatus.ASSESSMENT_STARTED.name,
-      ptUser = true,
-    )
-    updateReferralStatus(createdReferral.id, referralStatusUpdate3)
-
-    val referralStatusUpdate4 = ReferralStatusUpdate(
-      status = ReferralStatus.ASSESSED_SUITABLE.name,
-      ptUser = true,
-    )
-    updateReferralStatus(createdReferral.id, referralStatusUpdate4)
-
-    val referralStatusUpdate5 = ReferralStatusUpdate(
-      status = ReferralStatus.ON_PROGRAMME.name,
-      ptUser = true,
-    )
-    updateReferralStatus(createdReferral.id, referralStatusUpdate5)
+    updateReferralStatusToOnProgramme(createdReferral)
 
     // When
     val referralStatusUpdate6 = ReferralStatusUpdate(
@@ -526,6 +470,26 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
     // Given
     val createdReferral = createReferral(PRISON_NUMBER_1)
 
+    updateReferralStatusToOnProgramme(createdReferral)
+
+    // When
+    val referralStatusUpdate6 = ReferralStatusUpdate(
+      status = ReferralStatus.DESELECTED.name,
+      ptUser = true,
+    )
+    updateReferralStatus(createdReferral.id, referralStatusUpdate6)
+
+    // Then
+    val courseParticipationList = courseParticipationRepository.findByReferralId(createdReferral.id)
+    assertThat(courseParticipationList).hasSize(1)
+    val courseParticipation = courseParticipationList[0]
+    assertThat(courseParticipation.prisonNumber).isEqualTo(PRISON_NUMBER_1)
+    assertThat(courseParticipation.courseName).isEqualTo(COURSE_NAME)
+    assertThat(courseParticipation.outcome?.status).isEqualTo(CourseStatus.INCOMPLETE)
+    assertThat(courseParticipation.outcome?.yearCompleted).isNull()
+  }
+
+  private fun updateReferralStatusToOnProgramme(createdReferral: Referral) {
     val referralStatusUpdate1 = ReferralStatusUpdate(
       status = ReferralStatus.REFERRAL_SUBMITTED.name,
       ptUser = true,
@@ -555,22 +519,6 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
       ptUser = true,
     )
     updateReferralStatus(createdReferral.id, referralStatusUpdate5)
-
-    // When
-    val referralStatusUpdate6 = ReferralStatusUpdate(
-      status = ReferralStatus.DESELECTED.name,
-      ptUser = true,
-    )
-    updateReferralStatus(createdReferral.id, referralStatusUpdate6)
-
-    // Then
-    val courseParticipationList = courseParticipationRepository.findByReferralId(createdReferral.id)
-    assertThat(courseParticipationList).hasSize(1)
-    val courseParticipation = courseParticipationList[0]
-    assertThat(courseParticipation.prisonNumber).isEqualTo(PRISON_NUMBER_1)
-    assertThat(courseParticipation.courseName).isEqualTo(COURSE_NAME)
-    assertThat(courseParticipation.outcome?.status).isEqualTo(CourseStatus.INCOMPLETE)
-    assertThat(courseParticipation.outcome?.yearCompleted).isNull()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -34,7 +34,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REF
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRER_USERNAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.AuditAction
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseStatus
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferrerUserEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusCategoryRepository
@@ -482,11 +481,7 @@ class ReferralServiceTest {
     referralService.updateReferralStatusById(referralId, referralStatusUpdate)
 
     // Then
-    verify { courseParticipationService.createCourseParticipation(capture(courseParticipationEntityCaptor)) }
-    val courseParticipationEntity = courseParticipationEntityCaptor.captured
-    assertThat(courseParticipationEntity.outcome?.status).isEqualTo(CourseStatus.COMPLETE)
-    assertThat(courseParticipationEntity.prisonNumber).isEqualTo(referral.prisonNumber)
-    assertThat(courseParticipationEntity.referralId).isEqualTo(referral.id)
+    verify { courseParticipationService.createOrUpdateCourseParticipation(referral) }
   }
 
   @Test
@@ -527,12 +522,7 @@ class ReferralServiceTest {
     referralService.updateReferralStatusById(referralId, referralStatusUpdate)
 
     // Then
-    verify { courseParticipationService.createCourseParticipation(capture(courseParticipationEntityCaptor)) }
-    val courseParticipationEntity = courseParticipationEntityCaptor.captured
-    assertThat(courseParticipationEntity.outcome?.status).isEqualTo(CourseStatus.INCOMPLETE)
-    assertThat(courseParticipationEntity.outcome?.yearCompleted).isNull()
-    assertThat(courseParticipationEntity.prisonNumber).isEqualTo(referral.prisonNumber)
-    assertThat(courseParticipationEntity.referralId).isEqualTo(referral.id)
+    verify { courseParticipationService.createOrUpdateCourseParticipation(referral) }
   }
 
   @Test


### PR DESCRIPTION
## Changes in this PR

- Replaced duplicate logic with a unified `createOrUpdateCourseParticipation` method. This ensures existing course participation records are updated when applicable, improving code maintainability and consistency.
- Added courseId mapping to CourseParticipationEntity
- Added additional integration tests to verify updated behaviour

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
