### PR TITLE
[APG-732] Deactivate referral status for 'MOVED_TO_BUILDING_CHOICES.'

### DIFF
--- a/src/main/resources/db/migration/V118__update_referral_status_for_building_choices.sql
+++ b/src/main/resources/db/migration/V118__update_referral_status_for_building_choices.sql
@@ -1,0 +1,1 @@
+UPDATE referral_status SET active = false where code = 'MOVED_TO_BUILDING_CHOICES';


### PR DESCRIPTION
## Changes in this PR

This migration updates the `referral_status` table to set `active` to `false` for the status `MOVED_TO_BUILDING_CHOICES`. It ensures the status is no longer flagged as active in the database.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
