### PR TITLE
[APG-732] Remove building choices from referral status transitions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -415,7 +415,6 @@ constructor(
   }
 
   fun transferReferralToBuildingChoices(referral: ReferralEntity, courseId: UUID): ReferralEntity? {
-    validateStatusTransition(referral.id!!, referral.status, ReferralStatus.MOVED_TO_BUILDING_CHOICES.name, true)
     val organisationId = referral.offering.organisationId
     val newOffering = offeringRepository.findByCourseIdAndOrganisationIdAndWithdrawnIsFalse(
       courseId,

--- a/src/main/resources/db/migration/V119__remove_building_choices_from_referral_status_transitions.sql
+++ b/src/main/resources/db/migration/V119__remove_building_choices_from_referral_status_transitions.sql
@@ -1,0 +1,1 @@
+DELETE FROM referral_status_transitions where transition_to_status = 'MOVED_TO_BUILDING_CHOICES';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
@@ -503,7 +503,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should allow referral status updates to status of MOVE_TO_BUILDING_CHOICES`() {
+  fun `should NOT allow referral status updates to status of MOVE_TO_BUILDING_CHOICES`() {
     // Given
     val createdReferral = createReferral(PRISON_NUMBER_1)
 
@@ -513,15 +513,22 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
     )
     updateReferralStatus(createdReferral.id, referralStatusUpdate1)
 
-    // When
     val referralStatusUpdate2 = ReferralStatusUpdate(
       status = ReferralStatus.MOVED_TO_BUILDING_CHOICES.name,
       ptUser = true,
     )
-    updateReferralStatus(createdReferral.id, referralStatusUpdate2)
+
+    // When
+    webTestClient
+      .put()
+      .uri("/referrals/${createdReferral.id}/status")
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(referralStatusUpdate2)
+      .exchange().expectStatus().isBadRequest
 
     // Then
-    referralRepository.findById(createdReferral.id).get().status shouldBeEqual ReferralStatus.MOVED_TO_BUILDING_CHOICES.name
+    referralRepository.findById(createdReferral.id).get().status shouldBeEqual ReferralStatus.REFERRAL_SUBMITTED.name
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
@@ -503,7 +503,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should NOT allow referral status updates to status of MOVE_TO_BUILDING_CHOICES`() {
+  fun `should NOT allow referral status updates to status of MOVED_TO_BUILDING_CHOICES`() {
     // Given
     val createdReferral = createReferral(PRISON_NUMBER_1)
 


### PR DESCRIPTION
## Changes in this PR

- Remove building choices from referral status transitions table in database 
- Update tests to verify the referral transition cannot occur
- Remove status transition check from transfer to building choices

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
