### PR TITLE
[APG-730] Bump up hibernate version and associated refactor

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+@file:OptIn(ExperimentalKotlinGradlePluginApi::class)
+
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -12,7 +15,7 @@ configurations {
   testImplementation { exclude(group = "org.junit.vintage") }
 }
 
- ext["hibernate.version"] = "6.6.9.Final"
+ext["hibernate.version"] = "6.6.9.Final"
 
 dependencies {
   val kotestVersion = "5.9.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ configurations {
   testImplementation { exclude(group = "org.junit.vintage") }
 }
 
-ext["hibernate.version"] = "6.5.3.Final"
+ ext["hibernate.version"] = "6.6.9.Final"
 
 dependencies {
   val kotestVersion = "5.9.1"
@@ -22,7 +22,6 @@ dependencies {
   val springSecurityVersion = "6.4.3"
 
   implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.3.0")
-
   runtimeOnly("org.postgresql:postgresql:42.7.5")
 
   implementation("org.springframework.boot:spring-boot-starter-webflux")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OrganisationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OrganisationEntity.kt
@@ -11,10 +11,11 @@ import java.util.UUID
 @Table(name = "organisation")
 data class OrganisationEntity(
 
+  //  var id: UUID = UUID.randomUUID(),
   @Id
   @GeneratedValue
   @Column(name = "organisation_id")
-  var id: UUID = UUID.randomUUID(),
+  var id: UUID? = null,
 
   @Column
   var code: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/PersonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/PersonEntity.kt
@@ -24,10 +24,11 @@ data class PersonEntity(
   var indeterminateSentence: Boolean?,
   var nonDtoReleaseDateType: String?,
   var sentenceType: String?,
+  //  var id: UUID = UUID.randomUUID(),
   @Id
   @GeneratedValue
   @Column(name = "person_id")
-  var id: UUID = UUID.randomUUID(),
+  var id: UUID? = null,
 
   @Version
   @Column(name = "version", nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/PersonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/PersonEntity.kt
@@ -24,7 +24,7 @@ data class PersonEntity(
   var indeterminateSentence: Boolean?,
   var nonDtoReleaseDateType: String?,
   var sentenceType: String?,
-  //  var id: UUID = UUID.randomUUID(),
+
   @Id
   @GeneratedValue
   @Column(name = "person_id")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/view/CourseVariantEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/view/CourseVariantEntity.kt
@@ -11,7 +11,7 @@ import java.util.*
 class CourseVariantEntity(
 
   @Id
-  val id: UUID = UUID.randomUUID(),
+  val id: UUID? = null,
 
   @Column
   val courseId: UUID,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
@@ -565,6 +565,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
     val createdReferral = createReferral(PRISON_NUMBER_1)
 
     val existCourseParticipation = CourseParticipationEntityFactory()
+      .withId(null)
       .withCourseName(COURSE_NAME)
       .withPrisonNumber(PRISON_NUMBER_1)
       .withSetting(CourseParticipationSettingFactory().withType(CourseSetting.CUSTODY).withLocation("Location").produce())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/StatisticsControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/StatisticsControllerIntegrationTest.kt
@@ -494,7 +494,7 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
 
     val referral = getReferralById(createdReferral.id)
     referral.shouldNotBeNull()
-    referral.status.shouldBe("on_programme") //
+    referral.status.shouldBe("on_programme")
 
     val referralCountByStatus =
       statisticsRepository.referralCountByStatus(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseParticipationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseParticipationRepositoryTest.kt
@@ -45,6 +45,7 @@ class CourseParticipationRepositoryTest {
       .withYearCompleted(Year.parse("2022"))
       .produce()
     var courseParticipation = CourseParticipationEntityFactory()
+      .withId(null)
       .withCourseName("Course name")
       .withPrisonNumber(PRISON_NUMBER_1)
       .withSource("Source of information")
@@ -70,6 +71,7 @@ class CourseParticipationRepositoryTest {
   @Test
   fun `CourseParticipationRepository should save and retrieve CourseParticipationEntity objects, having all nullable fields set to null`() {
     var courseParticipation = CourseParticipationEntityFactory()
+      .withId(null)
       .withCourseName(null)
       .withPrisonNumber(PRISON_NUMBER_1)
       .withSource(null)
@@ -107,6 +109,7 @@ class CourseParticipationRepositoryTest {
       .withYearCompleted(Year.parse("2022"))
       .produce()
     var courseParticipation = CourseParticipationEntityFactory()
+      .withId(null)
       .withCourseName(null)
       .withPrisonNumber(PRISON_NUMBER_1)
       .withSource(null)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseRepositoryTest.kt
@@ -28,7 +28,7 @@ class CourseRepositoryTest {
 
   @Test
   fun `CourseRepository should save and retrieve CourseEntity objects`() {
-    var courseEntity = CourseEntityFactory().produce()
+    var courseEntity = CourseEntityFactory().withId(null).produce()
     courseEntity = entityManager.merge(courseEntity)
 
     val persistedCourse = entityManager.find(CourseEntity::class.java, courseEntity.id)
@@ -43,6 +43,7 @@ class CourseRepositoryTest {
       PrerequisiteEntityFactory().withName("PR2").withDescription("PR2 D1").produce(),
     )
     var course = CourseEntityFactory()
+      .withId(null)
       .withPrerequisites(prerequisites)
       .produce()
     course = entityManager.merge(course)
@@ -53,12 +54,12 @@ class CourseRepositoryTest {
 
   @Test
   fun `CourseRepository should persist multiple OfferingEntity objects for multiple CourseEntity objects and verify ids`() {
-    var course = CourseEntityFactory().produce()
+    var course = CourseEntityFactory().withId(null).produce()
     course = entityManager.merge(course)
 
-    val offering1 = OfferingEntityFactory().withOrganisationId("BWI").withContactEmail("bwi@a.com").produce()
-    val offering2 = OfferingEntityFactory().withOrganisationId("MDI").withContactEmail("mdi@a.com").produce()
-    val offering3 = OfferingEntityFactory().withOrganisationId("BXI").withContactEmail("bxi@a.com").produce()
+    val offering1 = OfferingEntityFactory().withId(null).withOrganisationId("BWI").withContactEmail("bwi@a.com").produce()
+    val offering2 = OfferingEntityFactory().withId(null).withOrganisationId("MDI").withContactEmail("mdi@a.com").produce()
+    val offering3 = OfferingEntityFactory().withId(null).withOrganisationId("BXI").withContactEmail("bxi@a.com").produce()
 
     offering1.course = course
     offering2.course = course
@@ -77,10 +78,10 @@ class CourseRepositoryTest {
 
   @Test
   fun `CourseRepository should retrieve CourseEntity objects by their associated offering id`() {
-    var course = CourseEntityFactory().produce()
+    var course = CourseEntityFactory().withId(null).produce()
     course = entityManager.merge(course)
 
-    var offering = OfferingEntityFactory().withOrganisationId("BWI").withContactEmail("bwi@a.com").produce()
+    var offering = OfferingEntityFactory().withId(null).withOrganisationId("BWI").withContactEmail("bwi@a.com").produce()
     offering.course = course
     offering = entityManager.merge(offering)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/OfferingRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/OfferingRepositoryTest.kt
@@ -25,10 +25,10 @@ class OfferingRepositoryTest {
   @ParameterizedTest
   @ValueSource(booleans = [true, false])
   fun `OfferingRepository should retrieve the correct offering for a CourseEntity object given a valid offeringId`(isWithdrawn: Boolean) {
-    var course = CourseEntityFactory().produce()
+    var course = CourseEntityFactory().withId(null).produce()
     course = entityManager.merge(course)
 
-    var offering = OfferingEntityFactory().withWithdrawn(isWithdrawn).withOrganisationId("MDI").produce()
+    var offering = OfferingEntityFactory().withId(null).withWithdrawn(isWithdrawn).withOrganisationId("MDI").produce()
     offering.course = course
     entityManager.merge(offering)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
@@ -28,10 +28,10 @@ class ReferralRepositoryTest {
 
   @Test
   fun `ReferralRepository should save and retrieve ReferralEntity objects`() {
-    var course = CourseEntityFactory().produce()
+    var course = CourseEntityFactory().withId(null).produce()
     course = entityManager.merge(course)
 
-    var offering = OfferingEntityFactory().produce()
+    var offering = OfferingEntityFactory().withId(null).produce()
     offering.course = course
     offering = entityManager.merge(offering)
 
@@ -41,6 +41,7 @@ class ReferralRepositoryTest {
     referrer = entityManager.merge(referrer)
 
     var referral = ReferralEntityFactory()
+      .withId(null)
       .withReferrer(referrer)
       .withPrisonNumber(PRISON_NUMBER_1)
       .withOffering(offering)
@@ -61,10 +62,10 @@ class ReferralRepositoryTest {
 
   @Test
   fun `ReferralRepository should update and retrieve ReferralEntity objects`() {
-    var course = CourseEntityFactory().produce()
+    var course = CourseEntityFactory().withId(null).produce()
     course = entityManager.merge(course)
 
-    var offering = OfferingEntityFactory().produce()
+    var offering = OfferingEntityFactory().withId(null).produce()
     offering.course = course
     offering = entityManager.merge(offering)
 
@@ -74,6 +75,7 @@ class ReferralRepositoryTest {
     referrer = entityManager.merge(referrer)
 
     var referral = ReferralEntityFactory()
+      .withId(null)
       .withReferrer(referrer)
       .withPrisonNumber(PRISON_NUMBER_1)
       .withOffering(offering)


### PR DESCRIPTION
## Changes in this PR

- Upgraded Hibernate to version 6.6.9.Final which broke 100+ Integration tests as a result of stricter checks when persisting detached entities.
- This was fixed by:
      1.  Ensuring all Entities have a default value of null for their @Id fields
      2. Updating relevant tests and entities to reflect these changes.
