### PR TITLE
[APG-480] Add referral statistics reporting API endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/StatisticsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/StatisticsController.kt
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StatisticsRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatistics
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReportStatusCount
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.StatisticsService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type.ReferralStatus
@@ -56,6 +57,9 @@ class StatisticsController(
     locationCodes,
     courseId,
   )
+
+  @GetMapping("/report/referral-statistics", produces = ["application/json"])
+  fun getReferralStatistics(): ReferralStatistics = statisticsService.getReferralStatistics()
 
   @GetMapping("/report-types", produces = ["application/json"])
   fun getReportTypes(): ReportTypes = ReportTypes(ReportType.entries.map { it.name })

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralStatistics.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralStatistics.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
+
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StatisticsRepository.ReferralStatisticsProjection
+
+data class ReferralStatistics(
+  val submittedReferralCount: Long,
+  val draftReferralCount: Long,
+  val averageDuration: String,
+) {
+  companion object {
+    fun from(referralStatistics: ReferralStatisticsProjection): ReferralStatistics = ReferralStatistics(
+      submittedReferralCount = referralStatistics.getSubmittedReferrals().toLong(),
+      draftReferralCount = referralStatistics.getDraftReferrals().toLong(),
+      averageDuration = referralStatistics.getAverageDuration(),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StatisticsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StatisticsService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StatisticsRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatistics
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReportStatusCount
 import java.time.LocalDate
 import java.util.UUID
@@ -17,4 +18,6 @@ class StatisticsService(
     courseId: UUID,
   ): List<ReportStatusCount> = statisticsRepository.findReferralCountByCourseId(startDate, endDate, locations, courseId)
     ?.map(ReportStatusCount::from) ?: emptyList()
+
+  fun getReferralStatistics(): ReferralStatistics = ReferralStatistics.from(statisticsRepository.getReferralStatistics())
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/IntegrationTestBase.kt
@@ -33,6 +33,8 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.J
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.PersistenceHelper
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Course
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CourseOffering
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Referral
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralUpdate
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.MissingQueueException
 import java.nio.channels.FileChannel
@@ -243,4 +245,24 @@ abstract class IntegrationTestBase {
     .expectStatus().isEqualTo(expectedResponseStatus)
     .expectBody(returnType)
     .returnResult().responseBody!!
+
+  fun performRequestAndExpectStatusWithBody(
+    httpMethod: HttpMethod,
+    uri: String,
+    body: Any,
+    expectedResponseStatus: Int,
+  ): WebTestClient.ResponseSpec? = webTestClient
+    .method(httpMethod)
+    .uri(uri)
+    .contentType(MediaType.APPLICATION_JSON)
+    .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+    .accept(MediaType.APPLICATION_JSON)
+    .bodyValue(body)
+    .exchange()
+    .expectStatus().isEqualTo(expectedResponseStatus)
+
+  fun submitReferral(createdReferralId: UUID) = performRequestAndExpectOk(HttpMethod.POST, "/referrals/$createdReferralId/submit", referralTypeReference())
+  fun updateReferral(referralId: UUID, referralUpdate: ReferralUpdate) = performRequestAndExpectStatusWithBody(HttpMethod.PUT, "/referrals/$referralId", referralUpdate, 204)
+
+  fun referralTypeReference(): ParameterizedTypeReference<Referral> = object : ParameterizedTypeReference<Referral>() {}
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
@@ -1225,15 +1225,6 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
 
   fun getReferralById(createdReferralId: UUID) = performRequestAndExpectOk(HttpMethod.GET, "/referrals/$createdReferralId", referralTypeReference())
 
-  fun updateReferral(referralId: UUID, referralUpdate: ReferralUpdate): Any = webTestClient
-    .put()
-    .uri("/referrals/$referralId")
-    .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
-    .contentType(MediaType.APPLICATION_JSON)
-    .bodyValue(referralUpdate)
-    .exchange()
-    .expectStatus().isNoContent
-
   private fun updateReferralStatus(createdReferralId: UUID, referralStatusUpdate: ReferralStatusUpdate) = webTestClient
     .put()
     .uri("/referrals/$createdReferralId/status")
@@ -1241,8 +1232,6 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
     .contentType(MediaType.APPLICATION_JSON)
     .bodyValue(referralStatusUpdate)
     .exchange().expectStatus().isNoContent
-
-  fun submitReferral(createdReferralId: UUID) = performRequestAndExpectOk(HttpMethod.POST, "/referrals/$createdReferralId/submit", referralTypeReference())
 
   private fun encodeValue(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8.toString())
 
@@ -2130,6 +2119,5 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
   private fun transferReferralToBuildingChoices(referralId: UUID, courseId: UUID): Referral = performRequestAndExpectOk(HttpMethod.POST, "/referrals/$referralId/transfer-to-building-choices/$courseId", referralTypeReference())
 
   private fun paginatedReferralViewTypeReference(): ParameterizedTypeReference<PaginatedReferralView> = object : ParameterizedTypeReference<PaginatedReferralView>() {}
-  private fun referralTypeReference(): ParameterizedTypeReference<Referral> = object : ParameterizedTypeReference<Referral>() {}
   private fun referralListTypeReference(): ParameterizedTypeReference<List<Referral>> = object : ParameterizedTypeReference<List<Referral>>() {}
 }


### PR DESCRIPTION
## Changes in this PR

- Implement functionality to retrieve referral statistics for our show and tell data, including counts for submitted and draft referrals and average processing durations. 
- Update the domain, service, and controller layers with required logic and integrate relevant test coverage.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
