### PR TITLE
[APG-737] Refactor PNI service methods to utilise Oasys returned PNI Score

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/OasysLearning.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/OasysLearning.kt
@@ -11,4 +11,5 @@ data class OasysLearning(
   val qualifications: String?,
   val basicSkillsScore: String?,
   val eTEIssuesDetails: String?,
+  val crn: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/PniCalculation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/PniCalculation.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model
 
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type.SaraRisk
+
 data class PniCalculation(
   val sexDomain: LevelScore,
   val thinkingDomain: LevelScore,
@@ -14,16 +16,50 @@ data class PniCalculation(
 )
 
 data class LevelScore(val level: Level, val score: Int)
-data class SaraRiskLevel(val toPartner: Int, val toOther: Int)
+data class SaraRiskLevel(val toPartner: Int, val toOther: Int) {
+  companion object {
+    private val riskLevelMap = mapOf(
+      1 to SaraRisk.LOW,
+      2 to SaraRisk.MEDIUM,
+      3 to SaraRisk.HIGH,
+    )
+
+    fun getRiskForPartner(toPartner: Int?): SaraRisk = getRiskFromMap(toPartner)
+    fun getRiskToOthers(toOther: Int?): SaraRisk = getRiskFromMap(toOther)
+
+    private fun getRiskFromMap(riskLevel: Int?): SaraRisk = riskLevelMap.getOrDefault(riskLevel, SaraRisk.NOT_APPLICABLE)
+  }
+}
 
 enum class Type {
   H,
   M,
   A,
   O,
+  ;
+
+  companion object {
+    fun toText(type: Type?): String = when (type) {
+      H -> "High Intensity"
+      M -> "Moderate Intensity"
+      A -> "Alternative Pathway"
+      O -> "Other"
+      else -> "MISSING INFORMATION"
+    }
+  }
 }
 enum class Level {
   H,
   M,
   L,
+  ;
+
+  companion object {
+    fun toText(level: Level?): String = when (level) {
+      H -> "High"
+      M -> "Medium"
+      L -> "Low"
+      else -> "Unknown"
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/IndividualRiskScores.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/IndividualRiskScores.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.PniResponse
 import java.math.BigDecimal
 
 /**
@@ -18,6 +19,12 @@ data class IndividualRiskScores(
   @Schema(example = "1", description = "")
   @get:JsonProperty("ogrs3") val ogrs3: BigDecimal? = null,
 
+  @Schema(example = "Medium", description = "The OGRS risk level")
+  @get:JsonProperty("ogrs3Risk") val ogrs3Risk: String? = null,
+
+  @Schema(example = "High", description = "The OVP Risk level")
+  @get:JsonProperty("ovpRisk") val ovpRisk: String? = null,
+
   @Schema(example = "2", description = "")
   @get:JsonProperty("ovp") val ovp: BigDecimal? = null,
 
@@ -32,4 +39,17 @@ data class IndividualRiskScores(
 
   @Schema(description = "SARA related risk score")
   @get:JsonProperty("sara") val sara: Sara? = null,
-)
+) {
+  companion object {
+    fun from(pniResponse: PniResponse) = IndividualRiskScores(
+      ogrs3 = null, // Oasys returns Level rather than numeric value
+      ovp = null, // Oasys returns Level rather than numeric value
+      ogrs3Risk = pniResponse.assessment?.ogrs3Risk?.type,
+      ovpRisk = pniResponse.assessment?.ovpRisk?.type,
+      ospDc = pniResponse.assessment?.osp?.cdc?.type,
+      ospIic = pniResponse.assessment?.osp?.iiic?.type,
+      rsr = pniResponse.assessment?.rsrPercentage?.let { BigDecimal.valueOf(it) },
+      sara = Sara.from(pniResponse),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/NeedsScore.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/NeedsScore.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.PniResponse
 
 data class NeedsScore(
   @Schema(example = "5", required = true)
@@ -30,7 +31,45 @@ data class DomainScore(
   @get:JsonProperty("RelationshipDomainScore") val relationshipDomainScore: RelationshipDomainScore,
   @Schema(example = "1", required = true)
   @get:JsonProperty("SelfManagementDomainScore") val selfManagementDomainScore: SelfManagementDomainScore,
-)
+) {
+  companion object {
+    fun from(pniResponse: PniResponse): DomainScore = DomainScore(
+      sexDomainScore = SexDomainScore(
+        overAllSexDomainScore = pniResponse.pniCalculation?.sexDomain?.score,
+        individualSexScores = IndividualSexScores(
+          sexualPreOccupation = pniResponse.assessment?.questions?.sexualPreOccupation?.score,
+          offenceRelatedSexualInterests = pniResponse.assessment?.questions?.offenceRelatedSexualInterests?.score,
+          emotionalCongruence = pniResponse.assessment?.questions?.emotionalCongruence?.score,
+        ),
+      ),
+      thinkingDomainScore = ThinkingDomainScore(
+        overallThinkingDomainScore = pniResponse.pniCalculation?.thinkingDomain?.score,
+        individualThinkingScores = IndividualCognitiveScores(
+          proCriminalAttitudes = pniResponse.assessment?.questions?.proCriminalAttitudes?.score,
+          hostileOrientation = pniResponse.assessment?.questions?.hostileOrientation?.score,
+        ),
+      ),
+      relationshipDomainScore = RelationshipDomainScore(
+        overallRelationshipDomainScore = pniResponse.pniCalculation?.relationshipDomain?.score,
+        individualRelationshipScores = IndividualRelationshipScores(
+          curRelCloseFamily = pniResponse.assessment?.questions?.relCloseFamily?.score,
+          prevExpCloseRel = pniResponse.assessment?.questions?.prevCloseRelationships?.score,
+          easilyInfluenced = pniResponse.assessment?.questions?.easilyInfluenced?.score,
+          aggressiveControllingBehaviour = pniResponse.assessment?.questions?.aggressiveControllingBehaviour?.score,
+        ),
+      ),
+      selfManagementDomainScore = SelfManagementDomainScore(
+        overallSelfManagementDomainScore = pniResponse.pniCalculation?.selfManagementDomain?.score,
+        individualSelfManagementScores = IndividualSelfManagementScores(
+          impulsivity = pniResponse.assessment?.questions?.impulsivity?.score,
+          temperControl = pniResponse.assessment?.questions?.temperControl?.score,
+          problemSolvingSkills = pniResponse.assessment?.questions?.problemSolvingSkills?.score,
+          difficultiesCoping = pniResponse.assessment?.questions?.difficultiesCoping?.score,
+        ),
+      ),
+    )
+  }
+}
 
 data class SexDomainScore(
   @Schema(example = "2", required = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/Sara.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/Sara.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.PniResponse
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.SaraRiskLevel
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type.SaraRisk
 
 data class Sara(
@@ -16,4 +18,17 @@ data class Sara(
 
   @Schema(example = "2512235167", description = "Assessment ID relevant to the SARA version of the assessment")
   @get:JsonProperty("saraAssessmentId") val saraAssessmentId: Long? = null,
-)
+) {
+  companion object {
+    fun from(pniResponse: PniResponse): Sara {
+      val saraRiskOfViolenceTowardsPartner = SaraRiskLevel.getRiskForPartner(pniResponse.pniCalculation?.saraRiskLevel?.toPartner)
+      val saraRiskOfViolenceTowardsOthers = SaraRiskLevel.getRiskToOthers(pniResponse.pniCalculation?.saraRiskLevel?.toOther)
+      return Sara(
+        overallResult = SaraRisk.highestRisk(saraRiskOfViolenceTowardsPartner, saraRiskOfViolenceTowardsOthers),
+        saraRiskOfViolenceTowardsPartner = saraRiskOfViolenceTowardsPartner.toString(),
+        saraRiskOfViolenceTowardsOthers = saraRiskOfViolenceTowardsOthers.toString(),
+        saraAssessmentId = pniResponse.assessment?.id,
+      )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysServiceTest.kt
@@ -249,6 +249,7 @@ class OasysServiceTest {
       qualifications = "3",
       basicSkillsScore = "4",
       eTEIssuesDetails = "5",
+      crn = "A12345",
     )
     val oasysAccommodation = OasysAccommodation(
       "Yes",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniServiceIntegrationTest.kt
@@ -1,0 +1,185 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.NotFoundException
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PNIResultEntityRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.DomainScore
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualCognitiveScores
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualRelationshipScores
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualRiskScores
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualSelfManagementScores
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualSexScores
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.RelationshipDomainScore
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Sara
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.SelfManagementDomainScore
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.SexDomainScore
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ThinkingDomainScore
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type.SaraRisk
+import java.math.BigDecimal
+import java.util.UUID
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@Import(JwtAuthHelper::class)
+class PniServiceIntegrationTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var pniService: PniService
+
+  @Autowired
+  lateinit var pniResultEntityRepository: PNIResultEntityRepository
+
+  @Test
+  fun `should throw NotFoundException when attempting to calculate PNI score for an unknown prisoner number`() {
+    // Given
+    val prisonNumber = "A99999"
+
+    // When & Then
+    val exception = assertThrows(NotFoundException::class.java) {
+      pniService.getOasysPniScore(prisonNumber)
+    }
+    assertThat(exception.message).isEqualTo("No PNI information found for A99999")
+  }
+
+  @Test
+  fun `should calculate PNI score for known prisoner number`() {
+    // Given
+    val prisonNumber = "A1234AA"
+
+    // When
+    val pniScore = pniService.getOasysPniScore(prisonNumber)
+
+    // Then
+    assertThat(pniScore).isNotNull
+    assertThat(pniScore.prisonNumber).isEqualTo(prisonNumber)
+    assertThat(pniScore.crn).isEqualTo("D006518")
+    assertThat(pniScore.assessmentId).isEqualTo(10082385)
+    assertThat(pniScore.programmePathway).isEqualTo("High Intensity")
+    assertThat(pniScore.needsScore).isNotNull
+    assertThat(pniScore.needsScore.overallNeedsScore).isEqualTo(5)
+    assertThat(pniScore.needsScore.basicSkillsScore).isEqualTo(33)
+    assertThat(pniScore.needsScore.classification).isEqualTo("High")
+    assertThat(pniScore.needsScore.domainScore).isEqualTo(
+      DomainScore(
+        SexDomainScore(
+          overAllSexDomainScore = 10,
+          individualSexScores = IndividualSexScores(
+            sexualPreOccupation = 2,
+            offenceRelatedSexualInterests = 1,
+            emotionalCongruence = 1,
+          ),
+        ),
+        thinkingDomainScore = ThinkingDomainScore(
+          overallThinkingDomainScore = 10,
+          individualThinkingScores = IndividualCognitiveScores(
+            proCriminalAttitudes = 1,
+            hostileOrientation = 1,
+          ),
+        ),
+        relationshipDomainScore = RelationshipDomainScore(
+          overallRelationshipDomainScore = 10,
+          individualRelationshipScores = IndividualRelationshipScores(
+            curRelCloseFamily = 0,
+            prevExpCloseRel = 1,
+            easilyInfluenced = 0,
+            aggressiveControllingBehaviour = 0,
+          ),
+        ),
+        selfManagementDomainScore = SelfManagementDomainScore(
+          overallSelfManagementDomainScore = 10,
+          individualSelfManagementScores = IndividualSelfManagementScores(
+            impulsivity = 0,
+            temperControl = 2,
+            problemSolvingSkills = 0,
+            difficultiesCoping = 0,
+          ),
+        ),
+      ),
+    )
+    assertThat(pniScore.riskScore).isNotNull
+    assertThat(pniScore.riskScore.classification).isEqualTo("High")
+    assertThat(pniScore.riskScore.individualRiskScores).isEqualTo(
+      IndividualRiskScores(
+        ogrs3 = null,
+        ogrs3Risk = "High",
+        ovpRisk = "Medium",
+        ovp = null,
+        ospDc = "Low",
+        ospIic = "Low",
+        rsr = BigDecimal("3.5"),
+        sara = Sara(
+          overallResult = SaraRisk.MEDIUM,
+          saraRiskOfViolenceTowardsPartner = SaraRisk.NOT_APPLICABLE.name,
+          saraRiskOfViolenceTowardsOthers = SaraRisk.MEDIUM.name,
+          saraAssessmentId = 10082385,
+        ),
+      ),
+    )
+    assertThat(pniScore.validationErrors).isEmpty()
+  }
+
+  @Test
+  fun `should persist PNI Score to the database`() {
+    // Given
+    val prisonNumber = "A1234AA"
+    val pniScore = pniService.getOasysPniScore(prisonNumber)
+    val courseId: UUID = UUID.fromString("790a2dfe-8df1-4504-bb9c-83e6e53a6537")
+    val offeringId = "7fffcc6a-11f8-4713-be35-cf5ff1aee517"
+
+    persistenceHelper.clearAllTableContent()
+    persistenceHelper.createCourse(
+      courseId,
+      "SC",
+      "Super Course",
+      "Sample description",
+      "SC++",
+      "General offence",
+    )
+    persistenceHelper.createPrerequisite(courseId, "pr name1", "pr description1")
+    persistenceHelper.createOrganisation(code = "MDI", name = "MDI org")
+    persistenceHelper.createEnabledOrganisation("MDI", "MDI org")
+    persistenceHelper.createOffering(
+      UUID.fromString(offeringId),
+      courseId,
+      "MDI",
+      "nobody-mdi@digital.justice.gov.uk",
+      "nobody2-mdi@digital.justice.gov.uk",
+      true,
+    )
+    persistenceHelper.createReferrerUser("TEST_REFERRER_USER_1")
+    val referralId = UUID.fromString("0c46ed09-170b-4c0f-aee8-a24eeaeeddaa")
+    persistenceHelper.createReferral(
+      referralId,
+      UUID.fromString(offeringId),
+      "B2345BB",
+      "TEST_REFERRER_USER_1",
+      "This referral will be updated",
+      false,
+      false,
+      "REFERRAL_STARTED",
+      null,
+    )
+
+    // When
+    pniService.savePni(pniScore, referralId)
+
+    // Then
+    val pniResults = pniResultEntityRepository.findAllByPrisonNumber(prisonNumber)
+    assertThat(pniResults).hasSize(1)
+    assertThat(pniResults[0].prisonNumber).isEqualTo(prisonNumber)
+    assertThat(pniResults[0].crn).isEqualTo("D006518")
+    assertThat(pniResults[0].referralId).isEqualTo(referralId)
+    assertThat(pniResults[0].programmePathway).isEqualTo("High Intensity")
+    assertThat(pniResults[0].needsClassification).isEqualTo("High")
+    assertThat(pniResults[0].riskClassification).isEqualTo("High")
+    assertThat(pniResults[0].basicSkillsScore).isEqualTo(33)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -2,10 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.service
 
 import io.kotest.matchers.shouldBe
 import io.mockk.CapturingSlot
-import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
@@ -13,6 +13,7 @@ import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Captor
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContext
@@ -73,6 +74,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.ent
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.StaffEntityFactory
 import java.util.*
 
+@ExtendWith(MockKExtension::class)
 class ReferralServiceTest {
 
   @MockK(relaxed = true)
@@ -152,7 +154,6 @@ class ReferralServiceTest {
 
   @BeforeEach
   fun setup() {
-    MockKAnnotations.init(this)
     referralEntityCaptor = slot()
     courseParticipationEntityCaptor = slot()
 

--- a/src/test/resources/simulations/__files/oasys-pni-response-success.json
+++ b/src/test/resources/simulations/__files/oasys-pni-response-success.json
@@ -50,11 +50,11 @@
       "proCriminalAttitudes" : "SOME",
       "hostileOrientation" : "SOME",
       "relCloseFamily" : "NONE",
-      "prevCloseRelationships" : "NONE",
+      "prevCloseRelationships" : "SOME",
       "easilyInfluenced" : "NONE",
       "aggressiveControllingBehaviour" : "NONE",
       "impulsivity" : "NONE",
-      "temperControl" : "NONE",
+      "temperControl" : "SIGNIFICANT",
       "problemSolvingSkills" : "NONE",
       "difficultiesCoping" : "MISSING"
     }

--- a/src/test/resources/simulations/mappings/oasys.json
+++ b/src/test/resources/simulations/mappings/oasys.json
@@ -249,6 +249,19 @@
     },
     {
       "request": {
+        "urlPattern": "/assessments/10082385/section/section4",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "bodyFileName": "learning.json"
+      }
+    },
+    {
+      "request": {
         "urlPattern": "/assessments/2114584/section/sectionroshsumm",
         "method": "GET"
       },


### PR DESCRIPTION
## Changes in this PR

- Introduce mapping logic in PNI related model data classes to correctly map from Oasys returned PniResponse model
- Refactor PniService creating separate methods for PNI score retrieval and persisting of PNI due to separation of concerns
- Added deprecation annotations to existing PniService methods
- Added integration tests to verify PNI score retrieval and persistence

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
