### PR TITLE
[APG-786] Refactor to replace ScoreLevel with RiskScoreLevel

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/PniAssessment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/PniAssessment.kt
@@ -4,16 +4,24 @@ data class PniAssessment(
   val id: Long,
   val ldc: Ldc?,
   val ldcMessage: String?,
-  val ogrs3Risk: ScoreLevel?,
-  val ovpRisk: ScoreLevel?,
+  val ogrs3Risk: RiskScoreLevel?,
+  val ovpRisk: RiskScoreLevel?,
   val osp: Osp,
   val rsrPercentage: Double?,
   val offenderAge: Int,
   val questions: Questions,
 )
 
+enum class RiskScoreLevel(val type: String) {
+  LOW("Low"),
+  MEDIUM("Medium"),
+  HIGH("High"),
+  VERY_HIGH("Very High"),
+  NOT_APPLICABLE("Not Applicable"),
+}
+
 data class Ldc(val score: Int, val subTotal: Int)
-data class Osp(val cdc: ScoreLevel?, val iiic: ScoreLevel?)
+data class Osp(val cdc: RiskScoreLevel?, val iiic: RiskScoreLevel?)
 
 data class Questions(
   val everCommittedSexualOffence: ScoredAnswer.YesNo,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/OasysApiClientIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/OasysApiClientIntegrationTest.kt
@@ -11,7 +11,7 @@ import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.ClientResult
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Level
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.LevelScore
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.ScoreLevel
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.RiskScoreLevel
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Type
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.IntegrationTestBase
@@ -41,7 +41,7 @@ class OasysApiClientIntegrationTest : IntegrationTestBase() {
         assertThat(pniResponse.pniCalculation?.riskLevel).isEqualTo(Level.H)
         assertThat(pniResponse.pniCalculation?.totalDomainScore).isEqualTo(5)
         assertThat(pniResponse.assessment?.id).isEqualTo(10082385)
-        assertThat(pniResponse.assessment?.ovpRisk).isEqualTo(ScoreLevel.MEDIUM)
+        assertThat(pniResponse.assessment?.ovpRisk).isEqualTo(RiskScoreLevel.MEDIUM)
       }
       is ClientResult.Failure.Other<*> -> fail("Unexpected client result: ${response::class.simpleName}")
       is ClientResult.Failure.StatusCode<*> -> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysServiceTest.kt
@@ -37,9 +37,9 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.PniCalculation
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.PniResponse
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Questions
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.RiskScoreLevel
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Sara
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.SaraRiskLevel
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.ScoreLevel
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.ScoredAnswer
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Timeline
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Type
@@ -610,9 +610,9 @@ class OasysServiceTest {
         id = 10082385,
         ldc = Ldc(10, 10),
         ldcMessage = "LDC message",
-        ogrs3Risk = ScoreLevel.HIGH,
-        ovpRisk = ScoreLevel.MEDIUM,
-        osp = Osp(ScoreLevel.LOW, ScoreLevel.LOW),
+        ogrs3Risk = RiskScoreLevel.HIGH,
+        ovpRisk = RiskScoreLevel.MEDIUM,
+        osp = Osp(RiskScoreLevel.LOW, RiskScoreLevel.LOW),
         rsrPercentage = 3.5,
         offenderAge = 32,
         questions = Questions(

--- a/src/test/resources/simulations/__files/oasys-pni-response-success.json
+++ b/src/test/resources/simulations/__files/oasys-pni-response-success.json
@@ -33,11 +33,11 @@
       "subTotal" : 10
     },
     "ldcMessage" : "LDC message",
-    "ogrs3Risk" : "High",
-    "ovpRisk" : "Medium",
+    "ogrs3Risk" : "HIGH",
+    "ovpRisk" : "MEDIUM",
     "osp" : {
-      "cdc" : "Low",
-      "iiic" : "Low"
+      "cdc" : "LOW",
+      "iiic" : "LOW"
     },
     "rsrPercentage" : 3.5,
     "offenderAge" : 32,


### PR DESCRIPTION
## Changes in this PR

- Fix prod defect where incorrect enum was used to map Risk score level
- Renamed Oasys model enum to guarantee proper mapping

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
