### PR TITLE
[APG-768] Refactor referral statistics to use course name instead of ID

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/StatisticsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/StatisticsController.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
@@ -12,7 +11,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StatisticsRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatistics
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReportStatusCount
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.StatusCountByProgramme
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.StatisticsService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type.ReferralStatus
 import java.time.LocalDate
@@ -50,12 +49,12 @@ class StatisticsController(
     @RequestParam startDate: LocalDate,
     @RequestParam endDate: LocalDate? = LocalDate.now().plusDays(1),
     @RequestParam locationCodes: List<String>? = listOf(),
-    @RequestParam courseId: UUID,
-  ): List<ReportStatusCount> = statisticsService.getReferralStatusCountByProgramme(
+    @RequestParam courseName: String? = null,
+  ): List<StatusCountByProgramme> = statisticsService.getReferralStatusCountByProgramme(
     startDate,
     endDate!!,
     locationCodes,
-    courseId,
+    courseName,
   )
 
   @GetMapping("/report/referral-statistics", produces = ["application/json"])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/StatusCountByProgramme.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/StatusCountByProgramme.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
+
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StatisticsRepository.StatusCountByProgrammeProjection
+import java.math.BigInteger
+
+data class StatusCountByProgramme(
+  val courseName: String,
+  val audience: String,
+  val count: BigInteger,
+  val status: String,
+  val organisationCode: String,
+) {
+  companion object {
+    fun from(projection: StatusCountByProgrammeProjection): StatusCountByProgramme = StatusCountByProgramme(
+      courseName = projection.getCourseName(),
+      audience = projection.getAudience(),
+      count = projection.getCount(),
+      status = projection.getStatus(),
+      organisationCode = projection.getOrgId(),
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StatisticsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StatisticsService.kt
@@ -3,9 +3,8 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StatisticsRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatistics
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReportStatusCount
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.StatusCountByProgramme
 import java.time.LocalDate
-import java.util.UUID
 
 @Service
 class StatisticsService(
@@ -15,9 +14,9 @@ class StatisticsService(
     startDate: LocalDate,
     endDate: LocalDate,
     locations: List<String>?,
-    courseId: UUID,
-  ): List<ReportStatusCount> = statisticsRepository.findReferralCountByCourseId(startDate, endDate, locations, courseId)
-    ?.map(ReportStatusCount::from) ?: emptyList()
+    courseName: String?,
+  ): List<StatusCountByProgramme> = statisticsRepository.findReferralCountByCourseName(startDate, endDate, locations, courseName)
+    ?.map(StatusCountByProgramme::from) ?: emptyList()
 
   fun getReferralStatistics(): ReferralStatistics = ReferralStatistics.from(statisticsRepository.getReferralStatistics())
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/StatisticsControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/StatisticsControllerIntegrationTest.kt
@@ -34,7 +34,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.R
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatistics
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralUpdate
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReportStatusCount
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.StatusCountByProgramme
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type.ReferralStatus
 import java.math.BigInteger
 import java.time.LocalDate
@@ -51,10 +51,13 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
   @Autowired
   lateinit var statisticsRepository: StatisticsRepository
 
+  val courseName1 = "Super Course"
   val courseId1 = UUID.randomUUID()
   val courseId2 = UUID.randomUUID()
+  val courseId3 = UUID.randomUUID()
   val offeringId1 = UUID.randomUUID()
   val offeringId2 = UUID.randomUUID()
+  val offeringId3 = UUID.randomUUID()
 
   @BeforeEach
   fun setUp() {
@@ -67,7 +70,7 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
     persistenceHelper.createCourse(
       courseId1,
       "SC",
-      "Super Course",
+      courseName1,
       "Sample description",
       "SC++",
       "General offence",
@@ -82,12 +85,12 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
       "Custom offence",
     )
     persistenceHelper.createCourse(
-      UUID.fromString("1811faa6-d568-4fc4-83ce-41118b90242e"),
+      courseId3,
       "RC",
-      "RAPID Course",
+      courseName1,
       "Sample description",
       "RC",
-      "General offence",
+      "Sexual offence",
     )
 
     persistenceHelper.createOffering(
@@ -101,6 +104,14 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
     persistenceHelper.createOffering(
       offeringId2,
       courseId2,
+      "MDI",
+      "nobody-bwn@digital.justice.gov.uk",
+      "nobody2-bwn@digital.justice.gov.uk",
+      true,
+    )
+    persistenceHelper.createOffering(
+      offeringId3,
+      courseId3,
       "MDI",
       "nobody-bwn@digital.justice.gov.uk",
       "nobody2-bwn@digital.justice.gov.uk",
@@ -193,7 +204,7 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
     // Then
     reportContent.reportType shouldBe ReportType.ON_PROGRAMME_COUNT.toString()
     reportContent.content.count shouldBe 1
-    reportContent.content.courseCounts?.get(0)?.name shouldBe "Super Course"
+    reportContent.content.courseCounts?.get(0)?.name shouldBe courseName1
     reportContent.content.courseCounts?.get(0)?.audience shouldBe "General offence"
     reportContent.content.courseCounts?.get(0)?.count shouldBe 1
     reportContent.parameters.courseId shouldBe courseId1
@@ -217,7 +228,7 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
 
     // Then
     reportContent.content.count shouldBe 1
-    reportContent.content.courseCounts?.first()?.name shouldBe "Super Course"
+    reportContent.content.courseCounts?.first()?.name shouldBe courseName1
     reportContent.content.courseCounts?.first()?.audience shouldBe "General offence"
     reportContent.parameters.courseId shouldBe null
     reportContent.reportType shouldBe ReportType.PROGRAMME_COMPLETE_COUNT.toString()
@@ -275,7 +286,7 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
     reportContent.content.courseCounts?.get(0)?.name shouldBe "Custom Course"
     reportContent.content.courseCounts?.get(0)?.audience shouldBe "Custom offence"
     reportContent.content.courseCounts?.get(0)?.count shouldBe 1
-    reportContent.content.courseCounts?.get(1)?.name shouldBe "Super Course"
+    reportContent.content.courseCounts?.get(1)?.name shouldBe courseName1
     reportContent.content.courseCounts?.get(1)?.audience shouldBe "General offence"
     reportContent.content.courseCounts?.get(1)?.count shouldBe 1
     reportContent.parameters.courseId shouldBe null
@@ -331,7 +342,7 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
     reportContent.content.courseCounts?.get(0)?.name shouldBe "Custom Course"
     reportContent.content.courseCounts?.get(0)?.audience shouldBe "Custom offence"
     reportContent.content.courseCounts?.get(0)?.count shouldBe 1
-    reportContent.content.courseCounts?.get(1)?.name shouldBe "Super Course"
+    reportContent.content.courseCounts?.get(1)?.name shouldBe courseName1
     reportContent.content.courseCounts?.get(1)?.audience shouldBe "General offence"
     reportContent.content.courseCounts?.get(1)?.count shouldBe 1
     reportContent.parameters.courseId shouldBe null
@@ -392,7 +403,7 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
     reportContent.content.courseCounts?.get(0)?.name shouldBe "Custom Course"
     reportContent.content.courseCounts?.get(0)?.audience shouldBe "Custom offence"
     reportContent.content.courseCounts?.get(0)?.count shouldBe 1
-    reportContent.content.courseCounts?.get(1)?.name shouldBe "Super Course"
+    reportContent.content.courseCounts?.get(1)?.name shouldBe courseName1
     reportContent.content.courseCounts?.get(1)?.audience shouldBe "General offence"
     reportContent.content.courseCounts?.get(1)?.count shouldBe 1
     reportContent.parameters.courseId shouldBe null
@@ -480,7 +491,7 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
     reportContent.content.courseCounts?.get(0)?.name shouldBe "Custom Course"
     reportContent.content.courseCounts?.get(0)?.audience shouldBe "Custom offence"
     reportContent.content.courseCounts?.get(0)?.count shouldBe 1
-    reportContent.content.courseCounts?.get(1)?.name shouldBe "Super Course"
+    reportContent.content.courseCounts?.get(1)?.name shouldBe courseName1
     reportContent.content.courseCounts?.get(1)?.audience shouldBe "General offence"
     reportContent.content.courseCounts?.get(1)?.count shouldBe 1
     reportContent.parameters.courseId shouldBe null
@@ -539,48 +550,56 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should return referral status statistics for a given course id and location`() {
+  fun `should return referral status statistics for a given course name and location`() {
     // Given
-    val createdReferral = createReferral(prisonNumber = PRISON_NUMBER_1)
-    progressReferralStatusToOnProgramme(createdReferral.id)
+    val createdReferral1 = createReferral(offeringId1, PRISON_NUMBER_1)
+    progressReferralStatusToOnProgramme(createdReferral1.id)
+    val createdReferral2 = createReferral(offeringId3, PRISON_NUMBER_1)
+    progressReferralStatusToOnProgramme(createdReferral2.id)
 
     // When
-    val reportStatusesByProgrammeType = getReportStatusesByProgrammeType(courseId1, startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), locations = listOf(ORGANISATION_ID_MDI))
+    val reportStatusesByProgrammeType = getReportStatusesByProgrammeType(courseName1, startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), locations = listOf(ORGANISATION_ID_MDI))
 
     // Then
     assertThat(reportStatusesByProgrammeType).isNotNull
-      .hasSize(6)
-      .extracting("count", "status", "organisationCode")
+      .hasSize(12)
+      .extracting("courseName", "audience", "count", "status", "organisationCode")
       .containsExactly(
-        tuple(1L, "ASSESSED_SUITABLE", ORGANISATION_ID_MDI),
-        tuple(1L, "ASSESSMENT_STARTED", ORGANISATION_ID_MDI),
-        tuple(1L, "AWAITING_ASSESSMENT", ORGANISATION_ID_MDI),
-        tuple(1L, "ON_PROGRAMME", ORGANISATION_ID_MDI),
-        tuple(1L, "REFERRAL_STARTED", ORGANISATION_ID_MDI),
-        tuple(1L, "REFERRAL_SUBMITTED", ORGANISATION_ID_MDI),
+        tuple(courseName1, "General offence", BigInteger.ONE, "ASSESSED_SUITABLE", ORGANISATION_ID_MDI),
+        tuple(courseName1, "Sexual offence", BigInteger.ONE, "ASSESSED_SUITABLE", ORGANISATION_ID_MDI),
+        tuple(courseName1, "General offence", BigInteger.ONE, "ASSESSMENT_STARTED", ORGANISATION_ID_MDI),
+        tuple(courseName1, "Sexual offence", BigInteger.ONE, "ASSESSMENT_STARTED", ORGANISATION_ID_MDI),
+        tuple(courseName1, "General offence", BigInteger.ONE, "AWAITING_ASSESSMENT", ORGANISATION_ID_MDI),
+        tuple(courseName1, "Sexual offence", BigInteger.ONE, "AWAITING_ASSESSMENT", ORGANISATION_ID_MDI),
+        tuple(courseName1, "General offence", BigInteger.ONE, "ON_PROGRAMME", ORGANISATION_ID_MDI),
+        tuple(courseName1, "Sexual offence", BigInteger.ONE, "ON_PROGRAMME", ORGANISATION_ID_MDI),
+        tuple(courseName1, "General offence", BigInteger.ONE, "REFERRAL_STARTED", ORGANISATION_ID_MDI),
+        tuple(courseName1, "Sexual offence", BigInteger.ONE, "REFERRAL_STARTED", ORGANISATION_ID_MDI),
+        tuple(courseName1, "General offence", BigInteger.ONE, "REFERRAL_SUBMITTED", ORGANISATION_ID_MDI),
+        tuple(courseName1, "Sexual offence", BigInteger.ONE, "REFERRAL_SUBMITTED", ORGANISATION_ID_MDI),
       )
   }
 
   @Test
-  fun `should return referral status statistics for a given course id and ALL locations`() {
+  fun `should return referral status statistics for a given course name and ALL locations`() {
     // Given
     val createdReferral = createReferral(prisonNumber = PRISON_NUMBER_1)
     progressReferralStatusToOnProgramme(createdReferral.id)
 
     // When
-    val reportStatusesByProgrammeType = getReportStatusesByProgrammeType(courseId1, startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), locations = null)
+    val reportStatusesByProgrammeType = getReportStatusesByProgrammeType(courseName1, startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), locations = null)
 
     // Then
     assertThat(reportStatusesByProgrammeType).isNotNull
       .hasSize(6)
-      .extracting("count", "status", "organisationCode")
+      .extracting("courseName", "audience", "count", "status", "organisationCode")
       .containsExactly(
-        tuple(1L, "ASSESSED_SUITABLE", ORGANISATION_ID_MDI),
-        tuple(1L, "ASSESSMENT_STARTED", ORGANISATION_ID_MDI),
-        tuple(1L, "AWAITING_ASSESSMENT", ORGANISATION_ID_MDI),
-        tuple(1L, "ON_PROGRAMME", ORGANISATION_ID_MDI),
-        tuple(1L, "REFERRAL_STARTED", ORGANISATION_ID_MDI),
-        tuple(1L, "REFERRAL_SUBMITTED", ORGANISATION_ID_MDI),
+        tuple(courseName1, "General offence", BigInteger.ONE, "ASSESSED_SUITABLE", ORGANISATION_ID_MDI),
+        tuple(courseName1, "General offence", BigInteger.ONE, "ASSESSMENT_STARTED", ORGANISATION_ID_MDI),
+        tuple(courseName1, "General offence", BigInteger.ONE, "AWAITING_ASSESSMENT", ORGANISATION_ID_MDI),
+        tuple(courseName1, "General offence", BigInteger.ONE, "ON_PROGRAMME", ORGANISATION_ID_MDI),
+        tuple(courseName1, "General offence", BigInteger.ONE, "REFERRAL_STARTED", ORGANISATION_ID_MDI),
+        tuple(courseName1, "General offence", BigInteger.ONE, "REFERRAL_SUBMITTED", ORGANISATION_ID_MDI),
       )
   }
 
@@ -592,30 +611,30 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
     progressReferralStatusToStatus(createdReferral.id, DESELECTED)
 
     // When
-    val reportStatusesByProgrammeType = getReportStatusesByProgrammeType(courseId1, startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), locations = listOf(ORGANISATION_ID_MDI))
+    val reportStatusesByProgrammeType = getReportStatusesByProgrammeType(courseName1, startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), locations = listOf(ORGANISATION_ID_MDI))
 
     // Then
     assertThat(reportStatusesByProgrammeType)
       .hasSize(7)
-      .extracting("count", "status", "organisationCode")
-      .contains(tuple(1L, DESELECTED, ORGANISATION_ID_MDI))
+      .extracting("courseName", "audience", "count", "status", "organisationCode")
+      .contains(tuple(courseName1, "General offence", BigInteger.ONE, DESELECTED, ORGANISATION_ID_MDI))
   }
 
   @Test
-  fun `should return PROGRAMME_COMPLETE referral count for a given course id`() {
+  fun `should return PROGRAMME_COMPLETE referral count for a given course name and location`() {
     // Given
     val createdReferral = createReferral(prisonNumber = PRISON_NUMBER_1)
     progressReferralStatusToOnProgramme(createdReferral.id)
     progressReferralStatusToStatus(createdReferral.id, PROGRAMME_COMPLETE)
 
     // When
-    val reportStatusesByProgrammeType = getReportStatusesByProgrammeType(courseId1, startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), locations = listOf(ORGANISATION_ID_MDI))
+    val reportStatusesByProgrammeType = getReportStatusesByProgrammeType(courseName1, startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), locations = listOf(ORGANISATION_ID_MDI))
 
     // Then
     assertThat(reportStatusesByProgrammeType)
       .hasSize(7)
-      .extracting("count", "status", "organisationCode")
-      .contains(tuple(1L, PROGRAMME_COMPLETE, ORGANISATION_ID_MDI))
+      .extracting("courseName", "audience", "count", "status", "organisationCode")
+      .contains(tuple(courseName1, "General offence", BigInteger.ONE, PROGRAMME_COMPLETE, ORGANISATION_ID_MDI))
   }
 
   @Test
@@ -629,25 +648,24 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
     progressReferralStatusToStatus(createdReferral.id, REFERRAL_WITHDRAWN)
 
     // When
-    val reportStatusesByProgrammeType = getReportStatusesByProgrammeType(courseId1, startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), locations = listOf(ORGANISATION_ID_MDI))
+    val reportStatusesByProgrammeType = getReportStatusesByProgrammeType(courseName1, startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), locations = listOf(ORGANISATION_ID_MDI))
 
     // Then
     assertThat(reportStatusesByProgrammeType)
       .hasSize(3)
-      .extracting("count", "status", "organisationCode")
-      .contains(tuple(1L, REFERRAL_WITHDRAWN, ORGANISATION_ID_MDI))
+      .extracting("courseName", "audience", "count", "status", "organisationCode")
+      .contains(tuple(courseName1, "General offence", BigInteger.ONE, REFERRAL_WITHDRAWN, ORGANISATION_ID_MDI))
   }
 
   @Test
-  fun `should return an empty list of referral statistics for an unknown course id`() {
+  fun `should return an empty list of referral statistics for an unknown course name`() {
     // Given
     val createdReferral = createReferral(prisonNumber = PRISON_NUMBER_1)
 
     progressReferralStatusToOnProgramme(createdReferral.id)
-    val courseId = UUID.randomUUID()
 
     // When
-    val reportStatusesByProgrammeType = getReportStatusesByProgrammeType(courseId, startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), locations = listOf(ORGANISATION_ID_MDI))
+    val reportStatusesByProgrammeType = getReportStatusesByProgrammeType("unknown course", startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), locations = listOf(ORGANISATION_ID_MDI))
 
     // Then
     assertThat(reportStatusesByProgrammeType).isEmpty()
@@ -695,7 +713,7 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
 
   fun createReferral(prisonNumber: String = PRISON_NUMBER_1): Referral = createReferral(offeringId1, prisonNumber)
 
-  fun getReportStatusesByProgrammeType(courseId: UUID, startDate: LocalDate, endDate: LocalDate, locations: List<String>?) = performRequestAndExpectOk(HttpMethod.GET, "/statistics/report/count-by-status-for-programme?startDate=$startDate&endDate=$endDate&" + locations?.joinToString("&") { "locationCodes=$it" } + "&courseId=$courseId", listReportStatusCountTypeReference())
+  fun getReportStatusesByProgrammeType(courseName: String?, startDate: LocalDate, endDate: LocalDate, locations: List<String>?) = performRequestAndExpectOk(HttpMethod.GET, "/statistics/report/count-by-status-for-programme?startDate=$startDate&endDate=$endDate&" + locations?.joinToString("&") { "locationCodes=$it" } + if (courseName != null) "&courseName=$courseName" else "", listStatusCountByProgrammeTypeReference())
 
   fun getReferralById(createdReferralId: UUID) = performRequestAndExpectOk(HttpMethod.GET, "/referrals/$createdReferralId", referralTypeReference())
 
@@ -707,5 +725,5 @@ class StatisticsControllerIntegrationTest : IntegrationTestBase() {
 
   fun referralStatisticsTypeReference(): ParameterizedTypeReference<ReferralStatistics> = object : ParameterizedTypeReference<ReferralStatistics>() {}
   fun reportContentTypeReference(): ParameterizedTypeReference<ReportContent> = object : ParameterizedTypeReference<ReportContent>() {}
-  fun listReportStatusCountTypeReference(): ParameterizedTypeReference<List<ReportStatusCount>> = object : ParameterizedTypeReference<List<ReportStatusCount>>() {}
+  fun listStatusCountByProgrammeTypeReference(): ParameterizedTypeReference<List<StatusCountByProgramme>> = object : ParameterizedTypeReference<List<StatusCountByProgramme>>() {}
 }


### PR DESCRIPTION
## Changes in this PR

- Replaced `courseId` with `courseName` across the referral statistics API and related logic. 
- Added `StatusCountByProgramme` model to support this change. 
- Updated tests, services, and repository queries to reflect the updated logic.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
