### PR TITLE
[APG-807] Refactor course handling logic and optimize test data setup.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
@@ -43,8 +43,6 @@ class CourseEntity(
   var prerequisites: MutableSet<PrerequisiteEntity> = mutableSetOf(),
 
   @OneToMany(mappedBy = "course", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-  @Column(name = "offerings")
-  @Fetch(SUBSELECT)
   var offerings: MutableSet<OfferingEntity> = mutableSetOf(),
 
   var audience: String,
@@ -54,10 +52,14 @@ class CourseEntity(
   var displayOnProgrammeDirectory: Boolean? = true,
   var intensity: String? = null,
 ) {
-  fun addOffering(offering: OfferingEntity) {
-    offering.course = this
-    offerings += offering
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || this::class != other::class) return false
+    other as CourseEntity
+    return this.id == other.id
   }
+
+  override fun hashCode(): Int = id.hashCode()
 }
 
 @Embeddable

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OfferingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OfferingEntity.kt
@@ -32,4 +32,13 @@ class OfferingEntity(
   @ManyToOne(fetch = FetchType.EAGER, optional = false)
   @JoinColumn(name = "course_id")
   var course: CourseEntity,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || this::class != other::class) return false
+    other as OfferingEntity
+    return this.id == other.id
+  }
+
+  override fun hashCode(): Int = id.hashCode()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
@@ -59,4 +59,13 @@ class ReferralEntity(
   var originalReferralId: UUID? = null,
   var hasLdc: Boolean? = null,
   var hasLdcBeenOverriddenByProgrammeTeam: Boolean = false,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || this::class != other::class) return false
+    other as ReferralEntity
+    return this.id == other.id
+  }
+
+  override fun hashCode(): Int = id.hashCode()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseController.kt
@@ -38,7 +38,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.Enabled
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.OrganisationService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.PniService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.ReferralService
-import java.util.UUID
+import java.util.*
 import kotlin.random.Random
 
 @RestController
@@ -512,22 +512,7 @@ class CourseController(
   fun updateCourse(
     @Parameter(description = "A course identifier", required = true) @PathVariable("id") id: UUID,
     @Parameter(description = "", required = true) @RequestBody courseUpdateRequest: CourseUpdateRequest,
-  ): ResponseEntity<Course> {
-    var existingCourse = courseService.getCourseById(id)
-      ?: throw NotFoundException("No Course found at /courses/$id")
-
-    existingCourse.name = courseUpdateRequest.name ?: existingCourse.name
-    existingCourse.description = courseUpdateRequest.description ?: existingCourse.description
-    existingCourse.alternateName = courseUpdateRequest.alternateName ?: existingCourse.alternateName
-    existingCourse.listDisplayName = courseUpdateRequest.displayName ?: existingCourse.listDisplayName
-    existingCourse.audience = courseUpdateRequest.audience ?: existingCourse.audience
-    existingCourse.audienceColour = courseUpdateRequest.audienceColour ?: existingCourse.audienceColour
-    existingCourse.withdrawn = courseUpdateRequest.withdrawn ?: existingCourse.withdrawn
-
-    val savedCourse = courseService.save(existingCourse)
-
-    return ResponseEntity.ok(savedCourse.toApi())
-  }
+  ): ResponseEntity<Course> = ResponseEntity.ok(courseService.updateCourse(id, courseUpdateRequest))
 
   @Operation(
     tags = ["Course Offerings"],
@@ -550,13 +535,9 @@ class CourseController(
     consumes = ["application/json"],
   )
   fun updateCourseOffering(
-    @Parameter(description = "A course identifier", required = true) @PathVariable("id") id: UUID,
+    @Parameter(description = "A course identifier", required = true) @PathVariable("id") courseId: UUID,
     @Parameter(description = "", required = true) @RequestBody courseOffering: CourseOffering,
-  ): ResponseEntity<CourseOffering> {
-    val course = courseService.getCourseById(id)
-      ?: throw NotFoundException("No Course found at /courses/$id")
-    return ResponseEntity.ok(courseService.updateOffering(course, courseOffering))
-  }
+  ): ResponseEntity<CourseOffering> = ResponseEntity.ok(courseService.updateOffering(courseId, courseOffering))
 
   @Operation(
     tags = ["Courses"],
@@ -684,22 +665,12 @@ class CourseController(
     @Parameter(
       description = "The id (UUID) of a referral",
       required = true,
-    ) @PathVariable("id") id: UUID,
+    ) @PathVariable("id") referralId: UUID,
     @Parameter(description = "result of PNI calculation") @RequestParam(
       value = "programmePathway",
       required = false,
     ) programmePathway: String?,
-  ): ResponseEntity<Course> {
-    val referral = referralService.getReferralById(id) ?: throw NotFoundException("No Referral found at /referrals/$id")
-
-    val pniResult = programmePathway
-      ?: pniService.getPniScore(
-        prisonNumber = referral.prisonNumber,
-        referralId = referral.id,
-      ).programmePathway
-
-    return ResponseEntity.ok(courseService.getBuildingChoicesCourseForTransferringReferral(referral, pniResult))
-  }
+  ): ResponseEntity<Course> = ResponseEntity.ok(courseService.getBuildingChoicesCourseForTransferringReferral(referralId, programmePathway))
 
   fun generateRandom10AlphaString(): String {
     val chars = ('A'..'Z')

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/IntegrationTestBase.kt
@@ -246,6 +246,24 @@ abstract class IntegrationTestBase {
     .expectBody(returnType)
     .returnResult().responseBody!!
 
+  fun <T> performRequestAndExpectStatusWithBody(
+    httpMethod: HttpMethod,
+    uri: String,
+    returnType: ParameterizedTypeReference<T>,
+    body: Any,
+    expectedResponseStatus: Int,
+  ): T = webTestClient
+    .method(httpMethod)
+    .uri(uri)
+    .contentType(MediaType.APPLICATION_JSON)
+    .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+    .accept(MediaType.APPLICATION_JSON)
+    .bodyValue(body)
+    .exchange()
+    .expectStatus().isEqualTo(expectedResponseStatus)
+    .expectBody(returnType)
+    .returnResult().responseBody!!
+
   fun performRequestAndExpectStatusWithBody(
     httpMethod: HttpMethod,
     uri: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
@@ -223,7 +223,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
 
     // When
     val unknownOfferingId = UUID.randomUUID()
-    val errorResponse = performRequestAndExpectStatusWithBody(
+    performRequestAndExpectStatusWithBody(
       httpMethod = HttpMethod.POST,
       uri = "/referrals/transfer-to-building-choices",
       body = TransferReferralRequest(createdReferral.id, unknownOfferingId, "Transfer reason"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseRepositoryTest.kt
@@ -69,11 +69,11 @@ class CourseRepositoryTest {
     offering1.course = course
     offering2.course = course
     offering3.course = course
-    entityManager.merge(offering1)
-    entityManager.merge(offering2)
-    entityManager.merge(offering3)
+    val persistedOffering1 = entityManager.merge(offering1)
+    val persistedOffering2 = entityManager.merge(offering2)
+    val persistedOffering3 = entityManager.merge(offering3)
 
-    course.offerings.addAll(listOf(offering1, offering2, offering3))
+    course.offerings.addAll(listOf(persistedOffering1, persistedOffering2, persistedOffering3))
     course = entityManager.merge(course)
 
     val persistedCourse = entityManager.find(CourseEntity::class.java, course.id)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/CourseControllerTest.kt
@@ -16,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.CourseService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.OrganisationService
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.PniService
@@ -246,7 +247,7 @@ constructor(
       fun `for a non existent referral returns not found error`() {
         val randomId = UUID.randomUUID()
 
-        every { referralService.getReferralById(randomId) } returns null
+        every { courseService.getBuildingChoicesCourseForTransferringReferral(randomId, null) } throws NotFoundException("No referral found for id: $randomId")
 
         mockMvc.get("/courses/building-choices/referral/$randomId") {
           accept = MediaType.APPLICATION_JSON
@@ -256,7 +257,7 @@ constructor(
           content {
             contentType(MediaType.APPLICATION_JSON)
             jsonPath("$.status") { value(404) }
-            jsonPath("$.developerMessage") { prefix("No Referral found at /referrals/$randomId") }
+            jsonPath("$.developerMessage") { prefix("No referral found for id: $randomId") }
           }
         }
       }


### PR DESCRIPTION
## Context

We are seeing some optimistic locking exceptions in the API logs which may have resulted from refactoring JPA entities to non data classes.

## Changes in this PR

- Isolated service tier code that performs updates on entities to ensure both fetching of entities and updating of persistent entites occurs within a single transactional boundary
- Added missing integration test for updating a course offering
- Belt and braces : added equals and hashcode methods to course, offering and referral entities
- Corresponding Junit & Integration test updates


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
