### PR TITLE
[APG-807] Remove spurious @GeneratedValue annotation from JPA Entities

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/AudienceEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/AudienceEntity.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.util.UUID
@@ -11,7 +10,6 @@ import java.util.UUID
 @Table(name = "audience")
 class AudienceEntity(
   @Id
-  @GeneratedValue
   @Column(name = "audience_id")
   val id: UUID? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.ElementCollection
 import jakarta.persistence.Embeddable
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
@@ -23,7 +22,6 @@ import java.util.UUID
 @Table(name = "course")
 class CourseEntity(
   @Id
-  @GeneratedValue
   @Column(name = "course_id")
   val id: UUID? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OfferingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OfferingEntity.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
@@ -15,7 +14,6 @@ import java.util.UUID
 @Table(name = "offering")
 class OfferingEntity(
   @Id
-  @GeneratedValue
   @Column(name = "offering_id")
   val id: UUID? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OrganisationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OrganisationEntity.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import java.util.UUID
@@ -12,7 +11,6 @@ import java.util.UUID
 class OrganisationEntity(
 
   @Id
-  @GeneratedValue
   @Column(name = "organisation_id")
   var id: UUID? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseController.kt
@@ -143,6 +143,7 @@ class CourseController(
       ?: throw BusinessException("Audience with id ${courseCreateRequest.audienceId} does not exist")
 
     val course = CourseEntity(
+      id = UUID.randomUUID(),
       name = courseCreateRequest.name,
       identifier = identifier,
       description = courseCreateRequest.description,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OrganisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OrganisationService.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonRe
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OrganisationEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OrganisationRepository
+import java.util.UUID
 
 @Service
 @Transactional
@@ -38,6 +39,7 @@ class OrganisationService(
 
           return organisationRepository.save(
             OrganisationEntity(
+              id = UUID.randomUUID(),
               code = it.prisonId,
               name = it.prisonName,
               gender = gender,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseControllerIntegrationTest.kt
@@ -740,7 +740,7 @@ class CourseControllerIntegrationTest : IntegrationTestBase() {
       .accept(MediaType.APPLICATION_JSON)
       .bodyValue(
         CourseOffering(
-          id = null,
+          id = UUID.randomUUID(),
           organisationId = "AWI",
           contactEmail = "awi1@whatton.com",
           secondaryContactEmail = "awi2@whatton.com",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
@@ -306,6 +306,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `Creating a referral which already exists results in conflict 409 response`() {
+    // Given
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
 
     val course = getAllCourses().first()
@@ -322,8 +323,10 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
         overrideReason = "Scored higher in OSP, should go onto Kaizen",
       ),
     )
+    // When
     submitReferral(referralCreated.id)
 
+    // Then
     val staffEntity = staffRepository.findAll()
     staffEntity.shouldNotBeEmpty()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/CourseRepositoryTest.kt
@@ -28,7 +28,7 @@ class CourseRepositoryTest {
 
   @Test
   fun `CourseRepository should save and retrieve CourseEntity objects`() {
-    var courseEntity = CourseEntityFactory().withId(null).produce()
+    var courseEntity = CourseEntityFactory().produce()
     courseEntity = entityManager.merge(courseEntity)
 
     val persistedCourse = entityManager.find(CourseEntity::class.java, courseEntity.id)
@@ -44,7 +44,6 @@ class CourseRepositoryTest {
       PrerequisiteEntityFactory().withName("PR3").withDescription("PR1 D3").produce(),
     )
     var course = CourseEntityFactory()
-      .withId(null)
       .withPrerequisites(prerequisites)
       .produce()
     // When
@@ -59,12 +58,12 @@ class CourseRepositoryTest {
 
   @Test
   fun `CourseRepository should persist multiple OfferingEntity objects for multiple CourseEntity objects and verify ids`() {
-    var course = CourseEntityFactory().withId(null).produce()
+    var course = CourseEntityFactory().produce()
     course = entityManager.merge(course)
 
-    val offering1 = OfferingEntityFactory().withId(null).withOrganisationId("BWI").withContactEmail("bwi@a.com").produce()
-    val offering2 = OfferingEntityFactory().withId(null).withOrganisationId("MDI").withContactEmail("mdi@a.com").produce()
-    val offering3 = OfferingEntityFactory().withId(null).withOrganisationId("BXI").withContactEmail("bxi@a.com").produce()
+    val offering1 = OfferingEntityFactory().withOrganisationId("BWI").withContactEmail("bwi@a.com").produce()
+    val offering2 = OfferingEntityFactory().withOrganisationId("MDI").withContactEmail("mdi@a.com").produce()
+    val offering3 = OfferingEntityFactory().withOrganisationId("BXI").withContactEmail("bxi@a.com").produce()
 
     offering1.course = course
     offering2.course = course
@@ -83,10 +82,10 @@ class CourseRepositoryTest {
 
   @Test
   fun `CourseRepository should retrieve CourseEntity objects by their associated offering id`() {
-    var course = CourseEntityFactory().withId(null).produce()
+    var course = CourseEntityFactory().produce()
     course = entityManager.merge(course)
 
-    var offering = OfferingEntityFactory().withId(null).withOrganisationId("BWI").withContactEmail("bwi@a.com").produce()
+    var offering = OfferingEntityFactory().withOrganisationId("BWI").withContactEmail("bwi@a.com").produce()
     offering.course = course
     offering = entityManager.merge(offering)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/OfferingRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/OfferingRepositoryTest.kt
@@ -25,10 +25,10 @@ class OfferingRepositoryTest {
   @ParameterizedTest
   @ValueSource(booleans = [true, false])
   fun `OfferingRepository should retrieve the correct offering for a CourseEntity object given a valid offeringId`(isWithdrawn: Boolean) {
-    var course = CourseEntityFactory().withId(null).produce()
+    var course = CourseEntityFactory().produce()
     course = entityManager.merge(course)
 
-    var offering = OfferingEntityFactory().withId(null).withWithdrawn(isWithdrawn).withOrganisationId("MDI").produce()
+    var offering = OfferingEntityFactory().withWithdrawn(isWithdrawn).withOrganisationId("MDI").produce()
     offering.course = course
     entityManager.merge(offering)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
@@ -62,11 +62,9 @@ class ReferralRepositoryTest {
 
   @Test
   fun `ReferralRepository should update and retrieve ReferralEntity objects`() {
-//    var course = CourseEntityFactory().withId(null).produce()
     var course = CourseEntityFactory().produce()
     course = entityManager.merge(course)
 
-//    var offering = OfferingEntityFactory().withId(null).produce()
     var offering = OfferingEntityFactory().produce()
     offering.course = course
     offering = entityManager.merge(offering)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
@@ -28,10 +28,10 @@ class ReferralRepositoryTest {
 
   @Test
   fun `ReferralRepository should save and retrieve ReferralEntity objects`() {
-    var course = CourseEntityFactory().withId(null).produce()
+    var course = CourseEntityFactory().produce()
     course = entityManager.merge(course)
 
-    var offering = OfferingEntityFactory().withId(null).produce()
+    var offering = OfferingEntityFactory().produce()
     offering.course = course
     offering = entityManager.merge(offering)
 
@@ -62,10 +62,12 @@ class ReferralRepositoryTest {
 
   @Test
   fun `ReferralRepository should update and retrieve ReferralEntity objects`() {
-    var course = CourseEntityFactory().withId(null).produce()
+//    var course = CourseEntityFactory().withId(null).produce()
+    var course = CourseEntityFactory().produce()
     course = entityManager.merge(course)
 
-    var offering = OfferingEntityFactory().withId(null).produce()
+//    var offering = OfferingEntityFactory().withId(null).produce()
+    var offering = OfferingEntityFactory().produce()
     offering.course = course
     offering = entityManager.merge(offering)
 


### PR DESCRIPTION
## Changes in this PR

- Removed `@GeneratedValue` annotation from JPA Entities where Id field is set manually
- Updated corresponding service code
- Updated affected Integration tests

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
