### PR TITLE
[APG-808] Encapsulate referral fetching logic in ReferralService

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -372,18 +372,7 @@ class ReferralController(
       description = "The id (UUID) of a referral",
       required = true,
     ) @PathVariable("id") id: UUID,
-  ): ResponseEntity<Referral> = referralService
-    .getReferralById(referralId = id)
-    ?.let {
-      auditService.audit(referralEntity = it, auditAction = AuditAction.VIEW_REFERRAL.name)
-      val status = referenceDataService.getReferralStatus(it.status)
-      val staffDetail = staffService.getStaffDetail(it.primaryPomStaffId)?.toApi()
-      if (!it.hasLdcBeenOverriddenByProgrammeTeam) {
-        it.hasLdc = referralService.getLdc(it.prisonNumber)
-      }
-      ResponseEntity.ok(it.toApi(status, staffDetail))
-    }
-    ?: throw NotFoundException("No Referral found at /referrals/$id")
+  ): ResponseEntity<Referral> = ResponseEntity.ok(referralService.fetchCompleteReferralDataSetForId(id))
 
   @Operation(
     tags = ["Referrals"],

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
@@ -12,7 +12,7 @@ import java.time.ZoneOffset
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Referral as ApiReferral
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralUpdate as ApiReferralUpdate
 
-fun ReferralEntity.toApi(status: ReferralStatusRefData, staffDetail: StaffDetail?): ApiReferral = ApiReferral(
+fun ReferralEntity.toApi(status: ReferralStatusRefData, staffDetail: StaffDetail?, hasLearningDifficulties: Boolean?): ApiReferral = ApiReferral(
   id = id!!,
   offeringId = offering.id!!,
   prisonNumber = prisonNumber,
@@ -28,7 +28,7 @@ fun ReferralEntity.toApi(status: ReferralStatusRefData, staffDetail: StaffDetail
   primaryPrisonOffenderManager = staffDetail,
   overrideReason = overrideReason,
   originalReferralId = originalReferralId,
-  hasLdc = hasLdc,
+  hasLdc = hasLearningDifficulties,
   hasLdcBeenOverriddenByProgrammeTeam = hasLdcBeenOverriddenByProgrammeTeam,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.test.web.servlet.put
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRAL_STARTED
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRAL_SUBMITTED
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRER_USERNAME
@@ -48,8 +49,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.ent
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralStatusRefDataFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferrerUserEntityFactory
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.StaffEntityFactory
-import java.util.UUID
+import java.util.*
 
 private const val MY_REFERRALS_ENDPOINT = "/referrals/me/dashboard"
 
@@ -187,15 +187,17 @@ constructor(
       .withOasysConfirmed(true)
       .withHasReviewedProgrammeHistory(true)
       .produce()
+//    val referral =
 
-    every { referralService.getReferralById(any()) } returns referral
-    every { referralService.getLdc(any()) } returns true
-    val referralStatus = ReferralStatusRefDataFactory()
-      .withCode(REFERRAL_STARTED)
-      .produce()
-    every { referralReferenceDataService.getReferralStatus(REFERRAL_STARTED) } returns referralStatus
-    every { staffService.getStaffDetail(any()) } returns StaffEntityFactory().produce()
-    every { auditService.audit(any(), any(), org.mockito.kotlin.eq(AuditAction.VIEW_REFERRAL.name)) } returns Unit
+    every { referralService.fetchCompleteReferralDataSetForId(any()) } returns referral.toApi()
+//    every { referralService.getReferralById(any()) } returns referral
+//    every { referralService.getLdc(any()) } returns true
+//    val referralStatus = ReferralStatusRefDataFactory()
+//      .withCode(REFERRAL_STARTED)
+//      .produce()
+//    every { referralReferenceDataService.getReferralStatus(REFERRAL_STARTED) } returns referralStatus
+//    every { staffService.getStaffDetail(any()) } returns StaffEntityFactory().produce()
+//    every { auditService.audit(any(), any(), org.mockito.kotlin.eq(AuditAction.VIEW_REFERRAL.name)) } returns Unit
 
     mockMvc.get("/referrals/${referral.id}?updatePerson=false") {
       accept = MediaType.APPLICATION_JSON
@@ -214,8 +216,8 @@ constructor(
       }
     }
 
-    verify { referralService.getReferralById(any()) }
-    verify { auditService.audit(any(), any(), org.mockito.kotlin.eq(AuditAction.VIEW_REFERRAL.name)) }
+    verify { referralService.fetchCompleteReferralDataSetForId(any()) }
+//    verify { auditService.audit(any(), any(), org.mockito.kotlin.eq(AuditAction.VIEW_REFERRAL.name)) }
   }
 
   @Test
@@ -231,9 +233,9 @@ constructor(
   fun `getReferralById with random UUID returns 404 with error body`() {
     val referralId = UUID.randomUUID()
 
-    every { referralService.getReferralById(any()) } returns null
+    every { referralService.fetchCompleteReferralDataSetForId(referralId) } throws NotFoundException("No referral found with id $referralId")
 
-    mockMvc.get("/referrals/$referralId?updatePerson=false") {
+    mockMvc.get("/referrals/$referralId") {
       accept = MediaType.APPLICATION_JSON
       header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
     }.andExpect {
@@ -242,13 +244,12 @@ constructor(
         contentType(MediaType.APPLICATION_JSON)
         jsonPath("$.status") { value(404) }
         jsonPath("$.errorCode") { isEmpty() }
-        jsonPath("$.userMessage") { prefix("Not Found: No Referral found at /referrals/$referralId") }
-        jsonPath("$.developerMessage") { prefix("No referral found at /courses/$referralId") }
+        jsonPath("$.userMessage") { prefix("Not Found: No referral found with id $referralId") }
         jsonPath("$.moreInfo") { isEmpty() }
       }
     }
 
-    verify { referralService.getReferralById(referralId) }
+    verify { referralService.fetchCompleteReferralDataSetForId(referralId) }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -187,17 +187,8 @@ constructor(
       .withOasysConfirmed(true)
       .withHasReviewedProgrammeHistory(true)
       .produce()
-//    val referral =
 
     every { referralService.fetchCompleteReferralDataSetForId(any()) } returns referral.toApi()
-//    every { referralService.getReferralById(any()) } returns referral
-//    every { referralService.getLdc(any()) } returns true
-//    val referralStatus = ReferralStatusRefDataFactory()
-//      .withCode(REFERRAL_STARTED)
-//      .produce()
-//    every { referralReferenceDataService.getReferralStatus(REFERRAL_STARTED) } returns referralStatus
-//    every { staffService.getStaffDetail(any()) } returns StaffEntityFactory().produce()
-//    every { auditService.audit(any(), any(), org.mockito.kotlin.eq(AuditAction.VIEW_REFERRAL.name)) } returns Unit
 
     mockMvc.get("/referrals/${referral.id}?updatePerson=false") {
       accept = MediaType.APPLICATION_JSON
@@ -217,7 +208,6 @@ constructor(
     }
 
     verify { referralService.fetchCompleteReferralDataSetForId(any()) }
-//    verify { auditService.audit(any(), any(), org.mockito.kotlin.eq(AuditAction.VIEW_REFERRAL.name)) }
   }
 
   @Test


### PR DESCRIPTION
## Changes in this PR

- Move referral retrieval logic from controller to referral service
- Prevent referral ldc flag persistent update during GET operation

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
