### PR TITLE
[APG-808] Remove Version annotation from course and offering entities

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/CourseEntity.kt
@@ -12,7 +12,6 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OrderBy
 import jakarta.persistence.Table
-import jakarta.persistence.Version
 import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode.SUBSELECT
 import org.hibernate.annotations.Immutable
@@ -24,10 +23,6 @@ class CourseEntity(
   @Id
   @Column(name = "course_id")
   val id: UUID? = null,
-
-  @Version
-  @Column(name = "version", nullable = false)
-  val version: Long = 0,
 
   var name: String,
   var identifier: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OfferingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OfferingEntity.kt
@@ -7,7 +7,6 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
-import jakarta.persistence.Version
 import java.util.UUID
 
 @Entity
@@ -16,10 +15,6 @@ class OfferingEntity(
   @Id
   @Column(name = "offering_id")
   val id: UUID? = null,
-
-  @Version
-  @Column(name = "version", nullable = false)
-  val version: Long = 0,
 
   var organisationId: String,
   var contactEmail: String,


### PR DESCRIPTION
## Changes in this PR

- Remove `@Version` annotation from Course and Offering entities

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
