### PR TITLE
[APG-808] Generate offering ID automatically if not provided

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OfferingEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OfferingEntity.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.PrePersist
 import jakarta.persistence.Table
 import java.util.UUID
 
@@ -14,7 +15,7 @@ import java.util.UUID
 class OfferingEntity(
   @Id
   @Column(name = "offering_id")
-  val id: UUID? = null,
+  var id: UUID? = null,
 
   var organisationId: String,
   var contactEmail: String,
@@ -25,4 +26,12 @@ class OfferingEntity(
   @ManyToOne(fetch = FetchType.EAGER, optional = false)
   @JoinColumn(name = "course_id")
   var course: CourseEntity,
-)
+){
+  @PrePersist
+  fun generateId() {
+    if (id == null) {
+      id = UUID.randomUUID()
+    }
+  }
+}
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseControllerIntegrationTest.kt
@@ -757,6 +757,32 @@ class CourseControllerIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should create offering when offering id is not provided`() {
+    webTestClient
+      .post()
+      .uri("/courses/$COURSE_ID2/offerings")
+      .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
+      .contentType(MediaType.APPLICATION_JSON)
+      .accept(MediaType.APPLICATION_JSON)
+      .bodyValue(
+        CourseOffering(
+          id = null,
+          organisationId = "AWI",
+          contactEmail = "awi1@whatton.com",
+          secondaryContactEmail = "awi2@whatton.com",
+          referable = true,
+          withdrawn = false,
+          organisationEnabled = true,
+          gender = Gender.MALE,
+        ),
+      )
+      .exchange()
+      .expectStatus().isCreated
+      .expectBody<CourseOffering>()
+      .returnResult().responseBody!!
+  }
+
+  @Test
   fun `Building choices courses are returned as expected`() {
     val bc1MainCourseId = UUID.randomUUID()
     val bc1VariantCourseId = UUID.randomUUID()


### PR DESCRIPTION
## Changes in this PR

- Introduced logic in `OfferingEntity` to auto-generate a UUID when the ID is null. 
- Added a corresponding integration test to ensure offering creation works without explicitly providing an ID.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
