### PR TITLE
[APG-818] Small refactor for returning Building Choices courses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/CourseController.kt
@@ -296,7 +296,7 @@ class CourseController(
     ) buildingChoicesOnly: Boolean?,
   ): ResponseEntity<List<Course>> {
     if (buildingChoicesOnly == true) {
-      courseService.getBuildingChoicesCourses().let { courseEntities ->
+      courseService.getAllBuildingChoicesCourses().let { courseEntities ->
         return ResponseEntity.ok(courseEntities.map { it.toApi() })
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
@@ -174,7 +174,7 @@ constructor(
 
   fun getCoursesByName(name: String): List<CourseEntity> = courseRepository.findAllByName(name)
   fun getCourses(courseIds: List<UUID>): List<CourseEntity> = courseRepository.findAllById(courseIds)
-  fun getBuildingChoicesCourses(): List<CourseEntity> {
+  fun getAllBuildingChoicesCourses(): List<CourseEntity> {
     val findAllByCourseId = courseVariantRepository.findAll()
 
     val bcParentCourseIds = findAllByCourseId.map { it.courseId }
@@ -195,7 +195,7 @@ constructor(
     val referral = referralRepository.findById(referralId).getOrNull() ?: throw NotFoundException("No referral found for id: $referralId")
     val pniResult = programmePathway ?: pniService.getPniScore(prisonNumber = referral.prisonNumber, referralId = referral.id).programmePathway
 
-    val buildingChoicesCourses = getBuildingChoicesCourses()
+    val buildingChoicesCourses = getAllBuildingChoicesCourses()
     val audience = referral.offering.course.audience.takeIf { it == "Sexual offence" } ?: "General offence"
     val buildingChoicesIntensity = getIntensityOfBuildingChoicesCourse(pniResult)
     val recommendedBuildingChoicesCourse =
@@ -209,7 +209,7 @@ constructor(
     val bcOfferingMatchingWithReferralOrg: OfferingEntity =
       (
         recommendedBuildingChoicesCourse.offerings.firstOrNull { (it.organisationId == referral.offering.organisationId) && it.referable && !it.withdrawn }
-          ?: throw BusinessException("Building choices course ${recommendedBuildingChoicesCourse.name} not offered at ${organisation.name}")
+          ?: throw NotFoundException("Building choices course ${recommendedBuildingChoicesCourse.name} not offered at ${organisation.name} for audience $audience")
         )
 
     val recommendedBuildingChoicesCourseModel = recommendedBuildingChoicesCourse.toApi()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/CourseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/CourseServiceTest.kt
@@ -13,8 +13,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.any
-import org.springframework.test.web.servlet.get
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.view.CourseVariantEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseRepository
@@ -222,7 +220,7 @@ class CourseServiceTest {
     every { courseVariantRepository.findAll() } returns courseVariantEntities
     every { courseRepository.findAllById(any()) } returns courseEntities
 
-    val result = courseService.getBuildingChoicesCourses()
+    val result = courseService.getAllBuildingChoicesCourses()
 
     result.size shouldBe 4
     result.map { it.id } shouldContainOnly listOf(courseId1, courseId2, variantCourseId1, variantCourseId2)
@@ -271,7 +269,7 @@ class CourseServiceTest {
   }
 
   @Test
-  fun `should return building choices course with general offence as audience when offence is differnt to sexual offence`() {
+  fun `should return building choices course with general offence as audience when offence is different to sexual offence`() {
     val courseId1 = UUID.randomUUID()
     val courseId2 = UUID.randomUUID()
     val variantCourseId1 = UUID.randomUUID()


### PR DESCRIPTION
## Changes in this PR

- Updated logic to return 404 responses when no matching BC courses are found. 
- Additional test to ensure correct behaviour for new scenarios.
- Renamed `getBuildingChoicesCourses` to `getAllBuildingChoicesCourses` for clarity and consistency. 

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
