### PR TITLE
APG-780 add has reviewed additional info flag to referral

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
@@ -31,32 +31,50 @@ class ReferralEntity(
   @JoinColumn(name = "offering_id", referencedColumnName = "offering_id")
   var offering: OfferingEntity,
 
+  @Column(name = "prison_number")
   var prisonNumber: String,
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "referrer_username", referencedColumnName = "referrer_username")
   var referrer: ReferrerUserEntity,
 
+  @Column(name = "additional_information")
   var additionalInformation: String? = null,
 
+  @Column(name = "oasys_confirmed")
   var oasysConfirmed: Boolean = false,
 
+  @Column(name = "has_reviewed_programme_history")
   var hasReviewedProgrammeHistory: Boolean = false,
 
+  @Column(name = "has_reviewed_additional_information")
+  var hasReviewedAdditionalInformation: Boolean? = null,
+
+  @Column(name = "status")
   var status: String = "REFERRAL_STARTED",
 
+  @Column(name = "submitted_on")
   var submittedOn: LocalDateTime? = null,
 
+  @Column(name = "deleted")
   var deleted: Boolean = false,
 
   @Column(name = "primary_pom_staff_id")
   var primaryPomStaffId: BigInteger? = null,
+
   @Column(name = "secondary_pom_staff_id")
   var secondaryPomStaffId: BigInteger? = null,
 
+  @Column(name = "referrer_override_reason")
   var referrerOverrideReason: String? = null,
+
+  @Column(name = "original_referral_id")
   var originalReferralId: UUID? = null,
+
+  @Column(name = "has_ldc")
   var hasLdc: Boolean? = null,
+
+  @Column(name = "has_ldc_been_overridden_by_programme_team")
   var hasLdcBeenOverriddenByProgrammeTeam: Boolean = false,
 ) {
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/ReferralUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/update/ReferralUpdate.kt
@@ -4,6 +4,7 @@ data class ReferralUpdate(
   val additionalInformation: String?,
   val oasysConfirmed: Boolean,
   val hasReviewedProgrammeHistory: Boolean,
+  val hasReviewedAdditionalInformation: Boolean? = null,
   val referrerOverrideReason: String? = null,
   val hasLdc: Boolean? = null,
   val hasLdcBeenOverriddenByProgrammeTeam: Boolean? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/Referral.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/Referral.kt
@@ -75,4 +75,7 @@ data class Referral(
 
   @Schema(example = "null", description = "")
   @get:JsonProperty("primaryPrisonOffenderManager") val primaryPrisonOffenderManager: PrisonOffenderManager? = null,
+
+  @Schema(example = "true", description = "Flag to indicate if the user had reviewed the additional information")
+  @get:JsonProperty("hasReviewedAdditionalInformation") val hasReviewedAdditionalInformation: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralUpdate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralUpdate.kt
@@ -30,4 +30,6 @@ data class ReferralUpdate(
   @Schema(example = "true", description = "Flag to indicate if the ldc field was overriden by the programme team")
   @get:JsonProperty("hasLdcBeenOverriddenByProgrammeTeam") val hasLdcBeenOverriddenByProgrammeTeam: Boolean? = null,
 
+  @Schema(example = "true", description = "Flag to indicate if the user has reviewed the additional information")
+  @get:JsonProperty("hasReviewedAdditionalInformation") val hasReviewedAdditionalInformation: Boolean? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferralTransformers.kt
@@ -30,6 +30,7 @@ fun ReferralEntity.toApi(status: ReferralStatusRefData, staffDetail: StaffDetail
   originalReferralId = originalReferralId,
   hasLdc = hasLdc,
   hasLdcBeenOverriddenByProgrammeTeam = hasLdcBeenOverriddenByProgrammeTeam,
+  hasReviewedAdditionalInformation = hasReviewedAdditionalInformation,
 )
 
 fun ReferralEntity.toApi(): ApiReferral = ApiReferral(
@@ -63,6 +64,7 @@ fun ApiReferralUpdate.toDomain() = ReferralUpdate(
   referrerOverrideReason = referrerOverrideReason,
   hasLdc = hasLdc,
   hasLdcBeenOverriddenByProgrammeTeam = hasLdcBeenOverriddenByProgrammeTeam ?: false,
+  hasReviewedAdditionalInformation = hasReviewedAdditionalInformation,
 )
 
 fun ReferralUpdate.toApi() = ApiReferralUpdate(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -131,6 +131,7 @@ constructor(
     referral.referrerOverrideReason = update.referrerOverrideReason
     referral.hasLdc = update.hasLdc
     referral.hasLdcBeenOverriddenByProgrammeTeam = update.hasLdcBeenOverriddenByProgrammeTeam ?: false
+    referral.hasReviewedAdditionalInformation = update.hasReviewedAdditionalInformation
   }
 
   fun updateReferralStatusById(referralId: UUID, referralStatusUpdate: ReferralStatusUpdate) {

--- a/src/main/resources/db/migration/V127__add_has_reviewed_info_flag_to_referral.sql
+++ b/src/main/resources/db/migration/V127__add_has_reviewed_info_flag_to_referral.sql
@@ -1,1 +1,0 @@
-ALTER table referral add column has_reviewed_additional_information boolean null;

--- a/src/main/resources/db/migration/V127__add_has_reviewed_info_flag_to_referral.sql
+++ b/src/main/resources/db/migration/V127__add_has_reviewed_info_flag_to_referral.sql
@@ -1,0 +1,1 @@
+ALTER table referral add column has_reviewed_additional_information boolean null;

--- a/src/main/resources/db/migration/V128__add_has_reviewed_info_flag_to_referral.sql
+++ b/src/main/resources/db/migration/V128__add_has_reviewed_info_flag_to_referral.sql
@@ -1,0 +1,4 @@
+ALTER table referral add column has_reviewed_additional_information boolean null;
+
+UPDATE referral set has_reviewed_additional_information = true
+WHERE additional_information is not null and status = 'REFERRAL_STARTED';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
@@ -439,6 +439,47 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should return 204 when updating a referral without additional information present`() {
+    mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
+    val course = getAllCourses().first()
+    val offering = getAllOfferingsForCourse(course.id).first()
+    val referralCreated = createReferral(offering.id!!)
+
+    val referralUpdate = ReferralUpdate(
+      additionalInformation = null,
+      oasysConfirmed = true,
+      hasReviewedProgrammeHistory = true,
+      hasReviewedAdditionalInformation = true,
+      referrerOverrideReason = "Override reason",
+      hasLdcBeenOverriddenByProgrammeTeam = true,
+    )
+
+    updateReferral(referralCreated.id, referralUpdate)
+
+    val referralById = getReferralById(referralCreated.id)
+
+    referralById shouldBeEqual Referral(
+      id = referralCreated.id,
+      offeringId = offering.id!!,
+      referrerUsername = REFERRER_USERNAME,
+      prisonNumber = PRISON_NUMBER_1,
+      status = REFERRAL_STARTED.lowercase(),
+      statusDescription = REFERRAL_STARTED_DESCRIPTION,
+      statusColour = REFERRAL_STARTED_COLOUR,
+      closed = false,
+      additionalInformation = null,
+      oasysConfirmed = true,
+      hasReviewedProgrammeHistory = true,
+      submittedOn = null,
+      referrerOverrideReason = "Override reason",
+      hasLdc = null,
+      hasLdcBeenOverriddenByProgrammeTeam = true,
+      primaryPrisonOffenderManager = null,
+      hasReviewedAdditionalInformation = true,
+    )
+  }
+
+  @Test
   fun `Updating a nonexistent referral should return 404 with error body`() {
     webTestClient
       .put()


### PR DESCRIPTION
## Changes in this PR

- Added new flag to store whether a user has reviewed the additional information for a referral on the referral JPA entity
- Created corresponding column on referral table via flyway script
- Added SQL to update existing draft referrals with appropriate flag value
- Added an integration test to verify new scenario where additional information can be null

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
