### PR TITLE
[APG-804] Handle null OSP value from Oasys

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/PniAssessment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/PniAssessment.kt
@@ -6,7 +6,7 @@ data class PniAssessment(
   val ldcMessage: String?,
   val ogrs3Risk: RiskScoreLevel?,
   val ovpRisk: RiskScoreLevel?,
-  val osp: Osp,
+  val osp: Osp?,
   val rsrPercentage: Double?,
   val offenderAge: Int,
   val questions: Questions,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniServiceIntegrationTest.kt
@@ -50,6 +50,21 @@ class PniServiceIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should handle PNI Response when no OSP score is present`() {
+    // Given
+    val prisonNumber = "A4321AA"
+
+    // When
+    val pniScore = pniService.getOasysPniScore(prisonNumber)
+
+    // Then
+    assertThat(pniScore).isNotNull
+    assertThat(pniScore.needsScore.classification).isEqualTo("High")
+    assertThat(pniScore.riskScore.individualRiskScores.ospDc).isNull()
+    assertThat(pniScore.riskScore.individualRiskScores.ospIic).isNull()
+  }
+
+  @Test
   fun `should calculate PNI score for known prisoner number`() {
     // Given
     val prisonNumber = "A1234AA"

--- a/src/test/resources/simulations/__files/oasys-pni-response-no-osp-success.json
+++ b/src/test/resources/simulations/__files/oasys-pni-response-no-osp-success.json
@@ -1,0 +1,58 @@
+{
+  "pniCalculation" : {
+    "sexDomain" : {
+      "level" : "H",
+      "score" : 10
+    },
+    "thinkingDomain" : {
+      "level" : "H",
+      "score" : 10
+    },
+    "relationshipDomain" : {
+      "level" : "H",
+      "score" : 10
+    },
+    "selfManagementDomain" : {
+      "level" : "H",
+      "score" : 10
+    },
+    "riskLevel" : "H",
+    "needLevel" : "H",
+    "totalDomainScore" : 5,
+    "pni" : "H",
+    "saraRiskLevel" : {
+      "toPartner" : 10,
+      "toOther" : 2
+    },
+    "missingFields" : [ ]
+  },
+  "assessment" : {
+    "id" : 10082385,
+    "ldc" : {
+      "score" : 10,
+      "subTotal" : 10
+    },
+    "ldcMessage" : "LDC message",
+    "ogrs3Risk" : "HIGH",
+    "ovpRisk" : "MEDIUM",
+    "rsrPercentage" : 3.5,
+    "offenderAge" : 32,
+    "questions" : {
+      "everCommittedSexualOffence" : "Unknown",
+      "openSexualOffendingQuestions" : "NO",
+      "sexualPreOccupation" : "SIGNIFICANT",
+      "offenceRelatedSexualInterests" : "SOME",
+      "emotionalCongruence" : "SOME",
+      "proCriminalAttitudes" : "SOME",
+      "hostileOrientation" : "SOME",
+      "relCloseFamily" : "NONE",
+      "prevCloseRelationships" : "SOME",
+      "easilyInfluenced" : "NONE",
+      "aggressiveControllingBehaviour" : "NONE",
+      "impulsivity" : "NONE",
+      "temperControl" : "SIGNIFICANT",
+      "problemSolvingSkills" : "NONE",
+      "difficultiesCoping" : "MISSING"
+    }
+  }
+}

--- a/src/test/resources/simulations/mappings/oasys.json
+++ b/src/test/resources/simulations/mappings/oasys.json
@@ -301,6 +301,19 @@
     },
     {
       "request": {
+        "url": "/assessments/pni/A4321AA?community=false",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "bodyFileName": "oasys-pni-response-no-osp-success.json"
+      }
+    },
+    {
+      "request": {
         "url": "/assessments/pni/A9876BB?community=false",
         "method": "GET"
       },


### PR DESCRIPTION
## Changes in this PR

- Updated model objects for Oasys PniResponse to allow for null OSP values
- Added integration test to verify 

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
