### PR TITLE
APG-791 Add new referral status categories for ASSESSED_SUITABLE status type

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferenceDataController.kt
@@ -62,7 +62,7 @@ class ReferenceDataController(
     .getReferralStatusReason(code)
 
   @Operation(
-    summary = "Gets a full list of Referral Status Reasons for a status type (WITHDRAWN or DESELECTED)",
+    summary = "Gets a full list of Referral Status Reasons for a status type (WITHDRAWN, DESELECTED or ASSESSED_SUITABLE)",
     operationId = "getReferralStatusReasonsForReferralStatusType",
     description = """Get all Referral Status Reasons (code, description, referralCategoryCode) for the provided type""",
     responses = [
@@ -74,6 +74,6 @@ class ReferenceDataController(
   )
   @GetMapping("/referral-statuses/{referralStatusType}/categories/reasons", produces = ["application/json"])
   fun getReferralStatusReasonsForReferralStatusType(
-    @Parameter(description = "The referral status type (WITHDRAWN or DESELECTED)", required = true) @PathVariable referralStatusType: ReferralStatusType,
+    @Parameter(description = "The referral status type (WITHDRAWN, DESELECTED or ASSESSED_SUITABLE)", required = true) @PathVariable referralStatusType: ReferralStatusType,
   ): List<ReferralStatusReason> = referenceDataService.getAllReferralStatusReasonsForType(referralStatusType)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralStatusType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralStatusType.kt
@@ -3,4 +3,5 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
 enum class ReferralStatusType {
   WITHDRAWN,
   DESELECTED,
+  ASSESSED_SUITABLE,
 }

--- a/src/main/resources/db/migration/V129__add_assessed_as_suitable_categories.sql
+++ b/src/main/resources/db/migration/V129__add_assessed_as_suitable_categories.sql
@@ -1,0 +1,26 @@
+insert into referral_status_category values ('AS_RISK', 'ASSESSED_SUITABLE', 'Risk and need', true);
+insert into referral_status_category values ('AS_INCOMPLETE', 'ASSESSED_SUITABLE', 'Incomplete assessment', true);
+insert into referral_status_category values ('AS_SENTENCE', 'ASSESSED_SUITABLE', 'Sentence type', true);
+insert into referral_status_category values ('AS_OPERATIONAL', 'ASSESSED_SUITABLE', 'Operational', true);
+
+insert into referral_status_reason (code, referral_status_category_code, description, active, deselect_open)
+values ('AS_SEXUAL_KILLING', 'AS_RISK', 'The person is low risk but has been convicted of a sexual killing', true, true);
+insert into referral_status_reason (code, referral_status_category_code, description, active, deselect_open)
+values ('AS_EXTREMIST_OFFENDING', 'AS_RISK', 'The person is low risk but has been convicted of extremist offending, for example terrorism', true, true);
+insert into referral_status_reason (code, referral_status_category_code, description, active, deselect_open)
+values ('AS_REOFFENDING_RISK', 'AS_RISK', 'The person''s psychological risk assessment shows high risk of reoffending', true, true);
+insert into referral_status_reason (code, referral_status_category_code, description, active, deselect_open)
+values ('AS_NEED_HIGH_INTENSITY', 'AS_RISK', 'The person is substantially different to others on the moderate intensity pathway. They need a high intensity programme', true, true);
+insert into referral_status_reason (code, referral_status_category_code, description, active, deselect_open)
+values ('AS_NEED_MODERATE_INTENSITY', 'AS_RISK', 'The person is substantially different to others on the high intensity pathway. They need a moderate intensity programme', true, true);
+
+insert into referral_status_reason (code, referral_status_category_code, description, active, deselect_open)
+values ('AS_MISSING_INFORMATION', 'AS_INCOMPLETE', 'Information is missing from the risk and need assessment but the person''s risks and needs do match the recommendations for the programme', true, true);
+insert into referral_status_reason (code, referral_status_category_code, description, active, deselect_open)
+values ('AS_OUTDATED', 'AS_INCOMPLETE', 'The risk and need assessment is outdated', true, true);
+
+insert into referral_status_reason (code, referral_status_category_code, description, active, deselect_open)
+values ('AS_HIGH_ROSH', 'AS_SENTENCE', 'The person has an Indefinite Sentence for the Public Protection and high ROSH (Risk of Serious Harm)', true, true);
+
+insert into referral_status_reason (code, referral_status_category_code, description, active, deselect_open)
+values ('AS_NOT_ENOUGH_TIME', 'AS_OPERATIONAL', 'There is not enough time to complete a high intensity programme so the person should complete a moderate intensity programme', true, true);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
@@ -182,19 +182,19 @@ class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
     response.size.shouldBeEqual(9)
     response.filter { it.referralCategoryCode == "AS_RISK" }.size.shouldBeEqual(5)
     response.filter { it.referralCategoryCode == "AS_RISK" && it.code == "AS_REOFFENDING_RISK" }.getOrNull(0)?.description?.shouldBeEqual(
-      "The person's psychological risk assessment shows high risk of reoffending"
+      "The person's psychological risk assessment shows high risk of reoffending",
     )
     response.filter { it.referralCategoryCode == "AS_INCOMPLETE" }.size.shouldBeEqual(2)
     response.filter { it.referralCategoryCode == "AS_INCOMPLETE" && it.code == "AS_OUTDATED" }.getOrNull(0)?.description?.shouldBeEqual(
-      "The risk and need assessment is outdated"
+      "The risk and need assessment is outdated",
     )
     response.filter { it.referralCategoryCode == "AS_SENTENCE" }.size.shouldBeEqual(1)
     response.filter { it.referralCategoryCode == "AS_SENTENCE" && it.code == "AS_HIGH_ROSH" }.getOrNull(0)?.description?.shouldBeEqual(
-      "The person has an Indefinite Sentence for the Public Protection and high ROSH (Risk of Serious Harm)"
+      "The person has an Indefinite Sentence for the Public Protection and high ROSH (Risk of Serious Harm)",
     )
     response.filter { it.referralCategoryCode == "AS_OPERATIONAL" }.size.shouldBeEqual(1)
     response.filter { it.referralCategoryCode == "AS_OPERATIONAL" && it.code == "AS_NOT_ENOUGH_TIME" }.getOrNull(0)?.description?.shouldBeEqual(
-      "There is not enough time to complete a high intensity programme so the person should complete a moderate intensity programme"
+      "There is not enough time to complete a high intensity programme so the person should complete a moderate intensity programme",
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
@@ -172,7 +172,34 @@ class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should return bad request and error response when referral status type is not WITHDRAWN or DESELECTED`() {
+  fun `should return all assessed suitable referral status reasons`() {
+    // Given
+    mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
+    // When
+    val response = getAllReferralStatusReasonsForType(ReferralStatusType.ASSESSED_SUITABLE.name)
+    // Then
+    response.shouldNotBeNull()
+    response.size.shouldBeEqual(9)
+    response.filter { it.referralCategoryCode == "AS_RISK" }.size.shouldBeEqual(5)
+    response.filter { it.referralCategoryCode == "AS_RISK" && it.code == "AS_REOFFENDING_RISK" }.getOrNull(0)?.description?.shouldBeEqual(
+      "The person's psychological risk assessment shows high risk of reoffending"
+    )
+    response.filter { it.referralCategoryCode == "AS_INCOMPLETE" }.size.shouldBeEqual(2)
+    response.filter { it.referralCategoryCode == "AS_INCOMPLETE" && it.code == "AS_OUTDATED" }.getOrNull(0)?.description?.shouldBeEqual(
+      "The risk and need assessment is outdated"
+    )
+    response.filter { it.referralCategoryCode == "AS_SENTENCE" }.size.shouldBeEqual(1)
+    response.filter { it.referralCategoryCode == "AS_SENTENCE" && it.code == "AS_HIGH_ROSH" }.getOrNull(0)?.description?.shouldBeEqual(
+      "The person has an Indefinite Sentence for the Public Protection and high ROSH (Risk of Serious Harm)"
+    )
+    response.filter { it.referralCategoryCode == "AS_OPERATIONAL" }.size.shouldBeEqual(1)
+    response.filter { it.referralCategoryCode == "AS_OPERATIONAL" && it.code == "AS_NOT_ENOUGH_TIME" }.getOrNull(0)?.description?.shouldBeEqual(
+      "There is not enough time to complete a high intensity programme so the person should complete a moderate intensity programme"
+    )
+  }
+
+  @Test
+  fun `should return bad request and error response when referral status type is not a permitted ReferralStatusType`() {
     // Given
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
 


### PR DESCRIPTION
## Changes in this PR

- Introduced a new referral status type 'ASSESSED_SUITABLE' with associated categories and reasons in the database. 
- Updated API endpoints, documentation, and tests to support fetching and validating this new status type and its reasons.

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
