### PR TITLE
[APG-829] Add category description to referral status reasons

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusEntity.kt
@@ -98,7 +98,10 @@ interface ReferralStatusReasonRepository : JpaRepository<ReferralStatusReasonEnt
 
   @Query(
     """
-    SELECT r.*
+    SELECT r.code as code,
+     r.description as description, 
+     r.referral_status_category_code as referralCategoryCode, 
+     c.description as categoryDescription
     FROM referral_status_reason r
     JOIN referral_status_category c 
     ON r.referral_status_category_code = c.code
@@ -107,7 +110,14 @@ interface ReferralStatusReasonRepository : JpaRepository<ReferralStatusReasonEnt
   """,
     nativeQuery = true,
   )
-  fun findReferralStatusReasonsByStatusCode(statusCode: String): List<ReferralStatusReasonEntity>
+  fun findReferralStatusReasonsByStatusCode(statusCode: String): List<ReferralStatusReasonProjection>
+}
+
+interface ReferralStatusReasonProjection {
+  fun getCode(): String
+  fun getDescription(): String
+  fun getReferralCategoryCode(): String
+  fun getCategoryDescription(): String
 }
 
 fun ReferralStatusReasonRepository.getByCode(code: String) = findByCode(code) ?: throw NotFoundException("No Referral status reason found with id=$code")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralStatusReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralStatusReason.kt
@@ -19,4 +19,7 @@ data class ReferralStatusReason(
 
   @Schema(example = "ADMIN", required = true, description = "")
   @get:JsonProperty("referralCategoryCode", required = true) val referralCategoryCode: String,
+
+  @Schema(example = "Risk and need", required = true, description = "")
+  @get:JsonProperty("categoryDescription", required = false) val categoryDescription: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferenceDataTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/ReferenceDataTransformer.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer
 
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusReasonEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusReasonProjection
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusReason
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusRefData
 
@@ -21,8 +21,9 @@ fun ReferralStatusEntity.toModel(altDescription: String?, altHintText: String?) 
   notesOptional = notesOptional,
 )
 
-fun ReferralStatusReasonEntity.toModel() = ReferralStatusReason(
-  code = code,
-  description = description,
-  referralCategoryCode = referralStatusCategoryCode,
+fun ReferralStatusReasonProjection.toModel() = ReferralStatusReason(
+  code = getCode(),
+  description = getDescription(),
+  referralCategoryCode = getReferralCategoryCode(),
+  categoryDescription = getCategoryDescription(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralReferenceDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralReferenceDataService.kt
@@ -83,6 +83,7 @@ class ReferralReferenceDataService(
       code = it.code,
       description = it.description,
       referralCategoryCode = it.referralStatusCategoryCode,
+      categoryDescription = null,
     )
   }
 
@@ -91,6 +92,7 @@ class ReferralReferenceDataService(
       code = it.code,
       description = it.description,
       referralCategoryCode = it.referralStatusCategoryCode,
+      categoryDescription = null,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.context.annotation.Import
@@ -53,6 +54,7 @@ class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
     code = REASON_DUPLICATE,
     description = "Duplicate referral",
     referralCategoryCode = CATEGORY_ADMIN,
+    categoryDescription = null,
   )
 
   @Test
@@ -181,18 +183,25 @@ class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
     response.shouldNotBeNull()
     response.size.shouldBeEqual(9)
     response.filter { it.referralCategoryCode == "AS_RISK" }.size.shouldBeEqual(5)
+    assertThat(response.filter { it.referralCategoryCode == "AS_RISK" }).allMatch { it.categoryDescription == "Risk and need" }
     response.filter { it.referralCategoryCode == "AS_RISK" && it.code == "AS_REOFFENDING_RISK" }.getOrNull(0)?.description?.shouldBeEqual(
       "The person's psychological risk assessment shows high risk of reoffending",
     )
+
     response.filter { it.referralCategoryCode == "AS_INCOMPLETE" }.size.shouldBeEqual(2)
+    assertThat(response.filter { it.referralCategoryCode == "AS_INCOMPLETE" }).allMatch { it.categoryDescription == "Incomplete assessment" }
     response.filter { it.referralCategoryCode == "AS_INCOMPLETE" && it.code == "AS_OUTDATED" }.getOrNull(0)?.description?.shouldBeEqual(
       "The risk and need assessment is outdated",
     )
+
     response.filter { it.referralCategoryCode == "AS_SENTENCE" }.size.shouldBeEqual(1)
+    assertThat(response.filter { it.referralCategoryCode == "AS_SENTENCE" }).allMatch { it.categoryDescription == "Sentence type" }
     response.filter { it.referralCategoryCode == "AS_SENTENCE" && it.code == "AS_HIGH_ROSH" }.getOrNull(0)?.description?.shouldBeEqual(
       "The person has an Indefinite Sentence for the Public Protection and high ROSH (Risk of Serious Harm)",
     )
+
     response.filter { it.referralCategoryCode == "AS_OPERATIONAL" }.size.shouldBeEqual(1)
+    assertThat(response.filter { it.referralCategoryCode == "AS_OPERATIONAL" }).allMatch { it.categoryDescription == "Operational" }
     response.filter { it.referralCategoryCode == "AS_OPERATIONAL" && it.code == "AS_NOT_ENOUGH_TIME" }.getOrNull(0)?.description?.shouldBeEqual(
       "There is not enough time to complete a high intensity programme so the person should complete a moderate intensity programme",
     )


### PR DESCRIPTION
## Changes in this PR

- Introduce `categoryDescription` field to referral status reasons, aligning database queries, projections, and transformations accordingly. 
- Updated tests to validate the new field and ensure correct integration into the referral response. 


## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
