### PR TITLE
[APG-838] Return LDC score with PNI details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysService.kt
@@ -44,7 +44,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.R
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.RoshAnalysis
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.buildRisks
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toModel
-import java.math.BigDecimal
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import kotlin.math.abs
@@ -326,7 +325,7 @@ class OasysService(
 
   fun getAlcoholDetail(assessmentId: Long): OasysAlcoholDetail? = fetchDetail(assessmentId, oasysApiClient::getAlcoholDetail, "AlcoholDetail")
 
-  fun getLDCScore(prisonNumber: String): BigDecimal? = getPniCalculation(prisonNumber)?.assessment?.ldc?.subTotal?.toBigDecimal()
+  fun getLDCScore(prisonNumber: String): Int? = getPniCalculation(prisonNumber)?.assessment?.ldc?.subTotal
 
   fun getOasysPniProgrammePathway(prisonId: String): String = when (getPniCalculation(prisonId)?.pniCalculation?.pni) {
     Type.H -> "HIGH_INTENSITY_BC"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PNIControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PNIControllerIntegrationTest.kt
@@ -30,16 +30,18 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type.Sa
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @Import(JwtAuthHelper::class)
-class PniIntegrationTest : IntegrationTestBase() {
+class PNIControllerIntegrationTest : IntegrationTestBase() {
   @Autowired
   lateinit var pniResultEntityRepository: PNIResultEntityRepository
 
   @Test
   fun `Get pni info for prisoner successful`() {
+    // Given
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
     val prisonNumber = "A9999BB"
+    // When
     val pniScore = getPniInfoByPrisonNumber(prisonNumber)
-
+    // Then
     pniScore shouldBe buildPniScore(prisonNumber)
   }
 
@@ -50,7 +52,7 @@ class PniIntegrationTest : IntegrationTestBase() {
     programmePathway = "MISSING_INFORMATION",
     needsScore = NeedsScore(
       overallNeedsScore = 6,
-      basicSkillsScore = 33,
+      basicSkillsScore = 10,
       classification = "HIGH_NEED",
       domainScore = DomainScore(
         sexDomainScore = SexDomainScore(
@@ -125,7 +127,7 @@ class PniIntegrationTest : IntegrationTestBase() {
     pniResults[0].riskClassification shouldBe pniScore.riskScore.classification
     pniResults[0].pniResultJson shouldBe objectMapper.writeValueAsString(pniScore)
     pniResults[0].pniValid shouldBe false
-    pniResults[0].basicSkillsScore shouldBe 33
+    pniResults[0].basicSkillsScore shouldBe 10
   }
 
   fun getPniInfoByPrisonNumber(prisonNumber: String) = webTestClient

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysServiceTest.kt
@@ -48,7 +48,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisoner
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.AlertFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.PniCalculationFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.PniResponseFactory
-import java.math.BigDecimal
 import java.time.LocalDateTime
 
 class OasysServiceTest {
@@ -754,6 +753,6 @@ class OasysServiceTest {
     val result = service.getLDCScore(prisonNumber)
 
     // Then
-    assertThat(result).isEqualTo(BigDecimal(ldcSubTotal))
+    assertThat(result).isEqualTo(ldcSubTotal)
   }
 }

--- a/src/test/resources/simulations/__files/oasys-pni-response-no-osp-success.json
+++ b/src/test/resources/simulations/__files/oasys-pni-response-no-osp-success.json
@@ -1,4 +1,4 @@
-{
+ {
   "pniCalculation" : {
     "sexDomain" : {
       "level" : "H",
@@ -29,8 +29,8 @@
   "assessment" : {
     "id" : 10082385,
     "ldc" : {
-      "score" : 10,
-      "subTotal" : 10
+      "score" : 2,
+      "subTotal" : 2
     },
     "ldcMessage" : "LDC message",
     "ogrs3Risk" : "HIGH",

--- a/src/test/resources/simulations/mappings/oasys.json
+++ b/src/test/resources/simulations/mappings/oasys.json
@@ -314,6 +314,19 @@
     },
     {
       "request": {
+        "url": "/assessments/pni/A9999BB?community=false",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "bodyFileName": "oasys-pni-response-success.json"
+      }
+    },
+    {
+      "request": {
         "url": "/assessments/pni/A9876BB?community=false",
         "method": "GET"
       },


### PR DESCRIPTION
## Changes in this PR

- Updates to return LDC score as part of Learning and Needs basic skills score as part of PNI details
- Refactor LDC score to use integers instead of BigDecimal to reduce unnecessary conversion (API returns an Int)
- Updated LDC score processing to use integer types for consistency and simplified threshold comparison logic. 
- Adjusted and added integration tests and mock data to align with the changes

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
