### PR TITLE
[APG-844] Remove commented-out ModSecurity settings from Helm values.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,12 +7,6 @@ generic-service:
   ingress:
     host: accredited-programmes-api-dev.hmpps.service.justice.gov.uk
     tlsSecretName: hmpps-accredited-programmes-api-dev-cert
-#    modsecurity_enabled: true
-#    modsecurity_snippet: |
-#      SecRuleEngine DetectionOnly
-#      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-#      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-#      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -5,12 +5,6 @@ generic-service:
   ingress:
     host: accredited-programmes-api-preprod.hmpps.service.justice.gov.uk
     tlsSecretName: hmpps-accredited-programmes-api-preprod-cert
-#    modsecurity_enabled: true
-#    modsecurity_snippet: |
-#      SecRuleEngine DetectionOnly
-#      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-#      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-#      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     JAVA_OPTS: "-Xmx2048m"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -5,12 +5,6 @@ generic-service:
   ingress:
     host: accredited-programmes-api.hmpps.service.justice.gov.uk
     tlsSecretName: hmpps-accredited-programmes-api-prod-cert
-#    modsecurity_enabled: true
-#    modsecurity_snippet: |
-#      SecRuleEngine DetectionOnly
-#      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-#      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-#      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     JAVA_OPTS: "-Xmx2048m"


### PR DESCRIPTION
## Changes in this PR

- Commented ModSecurity-related lines have been removed from the production, development, and pre-production Helm values files. 

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
