### PR TITLE
[APG-536] Update PostgreSQL version in IntegrationTestBase

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/IntegrationTestBase.kt
@@ -93,7 +93,7 @@ abstract class IntegrationTestBase {
   companion object {
 
     @JvmStatic
-    private val postgresContainer = PostgreSQLContainer<Nothing>("postgres:15.1")
+    private val postgresContainer = PostgreSQLContainer<Nothing>("postgres:16.4")
       .apply {
         withReuse(true)
       }


### PR DESCRIPTION
## Changes in this PR

- Upgraded PostgreSQL container from version 15.1 to 16.4 for our integration tests, to align with desired version in production environment

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
