### PR TITLE
Refactor: Add documentation to the getNextStatusTransitions endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -72,9 +72,9 @@ class ReferralController(
 
   @Operation(
     tags = ["Referral"],
-    summary = "Get the status transitions for a referral",
+    summary = "Get the status transitions for a Referral",
     operationId = "getStatusTransitions",
-    description = "Returns a status transition for a referral",
+    description = "Returns a list of status transitions for a Referral",
     security = [SecurityRequirement(name = "bearerAuth")],
     responses = [
       ApiResponse(
@@ -93,7 +93,6 @@ class ReferralController(
     method = [RequestMethod.GET],
     value = ["/referrals/{id}/status-transitions"],
     produces = ["application/json"],
-    consumes = ["application/json"],
   )
   fun getNextStatusTransitions(
     @PathVariable id: UUID,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -12,12 +12,10 @@ import jakarta.transaction.Transactional
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
-import org.springframework.data.jpa.domain.AbstractPersistable_.id
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -72,25 +70,51 @@ class ReferralController(
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
 
-  @GetMapping("/referrals/{id}/status-transitions", produces = ["application/json"])
+  @Operation(
+    tags = ["Referral"],
+    summary = "Get the status transitions for a referral",
+    operationId = "getStatusTransitions",
+    description = "Returns a status transition for a referral",
+    security = [SecurityRequirement(name = "bearerAuth")],
+    responses = [
+      ApiResponse(
+        responseCode = "404",
+        description = "No Referral with ID",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "200",
+        description = "Status transitions for a referral",
+        content = [Content(schema = Schema(implementation = ReferralStatusRefData::class))],
+      ),
+    ],
+  )
+  @RequestMapping(
+    method = [RequestMethod.GET],
+    value = ["/referrals/{id}/status-transitions"],
+    produces = ["application/json"],
+    consumes = ["application/json"],
+  )
   fun getNextStatusTransitions(
     @PathVariable id: UUID,
     @RequestParam(defaultValue = "false") ptUser: Boolean = false,
     @RequestParam(defaultValue = "false") deselectAndKeepOpen: Boolean = false,
   ): ResponseEntity<List<ReferralStatusRefData>> {
-    val referral = referralService.getReferralById(id)
-    var statuses = referenceDataService.getNextStatusTransitions(referral!!.status, ptUser)
-    // bespoke logic for deselect and keep open
-    if (statuses.any { it.code == "DESELECTED" } && !deselectAndKeepOpen) {
+    val referral = referralService.getReferralById(id) ?: throw NotFoundException("Referral with id $id not found")
+
+    var statuses = referenceDataService.getNextStatusTransitions(referral.status, ptUser)
+    val deselectedStatus = statuses.find { it.code == "DESELECTED" }
+
+    if (deselectedStatus != null && !deselectAndKeepOpen) {
       // rebuild the status list with a bespoke set of statuses
       val newStatusList = mutableListOf<ReferralStatusRefData>()
       newStatusList.addAll(statuses.filter { it.code == "PROGRAMME_COMPLETE" })
       newStatusList.add(
-        statuses.first { it.code == "DESELECTED" }
+        deselectedStatus
           .copy(description = "Deselect and close referral", deselectAndKeepOpen = false),
       )
       newStatusList.add(
-        statuses.first { it.code == "DESELECTED" }
+        deselectedStatus
           .copy(
             description = "Deselect and keep referral open",
             hintText = "This person cannot continue the programme now but may be able to in future.",
@@ -98,8 +122,7 @@ class ReferralController(
           ),
       )
       statuses = newStatusList
-    }
-    if (deselectAndKeepOpen) {
+    } else if (deselectAndKeepOpen) {
       // rebuild the status list with a bespoke set of statuses
       val newStatusList = mutableListOf<ReferralStatusRefData>()
       newStatusList.addAll(statuses.filter { it.code != "DESELECTED" && it.code != "PROGRAMME_COMPLETE" })

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferralController.kt
@@ -121,7 +121,9 @@ class ReferralController(
           ),
       )
       statuses = newStatusList
-    } else if (deselectAndKeepOpen) {
+    }
+
+    if (deselectAndKeepOpen) {
       // rebuild the status list with a bespoke set of statuses
       val newStatusList = mutableListOf<ReferralStatusRefData>()
       newStatusList.addAll(statuses.filter { it.code != "DESELECTED" && it.code != "PROGRAMME_COMPLETE" })


### PR DESCRIPTION
**WHAT**

This is a pure-refactor commit, i.e. it introduces no new functionality.

Made the following changes to the getNextStatusTransitions endpoint (i.e. `GET /referrals/{id}/status-transitions`):

- Added the `@Operation` annotation
- Replaced the `@GetMapping` annotation with the `@RequestMapping`
- Return a 404 if the Referral isn't found (don't coerce non-null)
- Refactored the logic to stop re-finding of the same status (i.e. the DESELECTED code)

**WHY**

As part of getting more familiar with Kotlin and the AcP codebase(s), I have been getting familiar with the patterns used.

While looking around, it appeared that this endpoint was broadly inconsistent with the others.
