### PR TITLE
Marks stats/reporting endpoints that are not in use by the UI as deprecated

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/StatisticsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/StatisticsController.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.contro
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -33,6 +34,10 @@ class StatisticsController(
   private val objectMapper: ObjectMapper,
   private val statisticsService: StatisticsService,
 ) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
   @GetMapping("/report/countByStatus", produces = ["application/json"])
   fun getReportTypes(
     @RequestParam startDate: LocalDate,
@@ -57,11 +62,19 @@ class StatisticsController(
     courseName,
   )
 
+  @Deprecated("This endpoint is deprecated and may be removed in the future")
   @GetMapping("/report/referral-statistics", produces = ["application/json"])
-  fun getReferralStatistics(): ReferralStatistics = statisticsService.getReferralStatistics()
+  fun getReferralStatistics(): ReferralStatistics {
+    log.warn("Deprecated endpoint /report/referral-statistics was called")
+    return statisticsService.getReferralStatistics()
+  }
 
+  @Deprecated("This endpoint is deprecated and may be removed in the future")
   @GetMapping("/report-types", produces = ["application/json"])
-  fun getReportTypes(): ReportTypes = ReportTypes(ReportType.entries.map { it.name })
+  fun getReportTypes(): ReportTypes {
+    log.warn("Deprecated endpoint /report-types was called")
+    return ReportTypes(ReportType.entries.map { it.name })
+  }
 
   @GetMapping("/report/{reportType}")
   fun getStatistics(
@@ -152,16 +165,19 @@ class StatisticsController(
    * supplied status.
    *
    */
+  @Deprecated("This endpoint is deprecated and may be removed in the future")
   @GetMapping("/current/status-counts")
   fun getCurrentStatusCounts(
     @RequestParam statuses: List<String> = listOf(),
     @RequestParam locationCodes: List<String>? = listOf(),
   ): CurrentCount {
+    log.warn("Deprecated endpoint /current/status-counts was called")
     val content = statisticsRepository.currentCountsByStatus(statuses, locationCodes)
 
     return objectMapper.readValue(content, CurrentCount::class.java)
   }
 
+  @Deprecated("This endpoint is deprecated and may be removed in the future")
   @GetMapping("/performance/status-duration")
   fun getAverageTimeSpentAtStatus(
     @RequestParam startDate: LocalDate,
@@ -172,6 +188,7 @@ class StatisticsController(
     if (statuses.isEmpty()) {
       throw BusinessException("This end point requires at least one status")
     }
+    log.warn("Deprecated endpoint /performance/status-duration was called")
     val content = statisticsRepository.averageTime(startDate, endDate!!, statuses, locationCodes)
     return objectMapper.readValue(content, Performance::class.java)
   }


### PR DESCRIPTION
Marks stats/reporting endpoints that are not in use by the UI as deprecated

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
