### PR TITLE
Marks People and Prison Search endpoints that are not in use by the U…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PeopleController.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -47,6 +48,9 @@ class PeopleController(
   private val peopleSearchApiService: PeopleSearchApiService,
   private val auditService: AuditService,
 ) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
 
   @Deprecated(
     "This endpoint is deprecated",
@@ -134,6 +138,7 @@ class PeopleController(
     )
   }
 
+  @Deprecated("This endpoint is deprecated and may be removed in the future")
   @Operation(
     tags = ["Person"],
     summary = "Get details of an offence by prison number",
@@ -170,6 +175,7 @@ class PeopleController(
       prisonNumber = prisonNumber,
       auditAction = AuditAction.OFFENCE_DETAILS.name,
     )
+    log.warn("Deprecated endpoint /people/offences/prisonNumber was called")
     val offenceMap = personService.getOffenceDetails(prisonNumber).associateBy({ it.first }, { it.second })
     val offences = manageOffencesService.getOffences(offenceMap.keys.toList())
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PrisonSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PrisonSearchController.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
@@ -26,38 +27,76 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.PrisonR
   name = "Prison Search",
 )
 class PrisonSearchController(private val prisonRegisterApiService: PrisonRegisterApiService) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Deprecated("This endpoint is deprecated and may be removed in the future")
   @Operation(
     tags = ["Prison"],
     summary = "Details for a single prison",
     operationId = "getPrisonById",
     description = """""",
     responses = [
-      ApiResponse(responseCode = "200", description = "successful operation", content = [Content(schema = Schema(implementation = PrisonSearchResponse::class))]),
-      ApiResponse(responseCode = "400", description = "Bad input", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
-      ApiResponse(responseCode = "401", description = "The client is not authorized to perform this operation.", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
+      ApiResponse(
+        responseCode = "200",
+        description = "successful operation",
+        content = [Content(schema = Schema(implementation = PrisonSearchResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad input",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "The client is not authorized to perform this operation.",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
     ],
-    security = [ SecurityRequirement(name = "bearerAuth") ],
+    security = [SecurityRequirement(name = "bearerAuth")],
   )
   @RequestMapping(
     method = [RequestMethod.GET],
     value = ["/prison-search/{prisonId}"],
     produces = ["application/json"],
   )
-  fun getPrisonById(@Parameter(description = "A prison identifier", required = true) @PathVariable("prisonId") prisonId: String): ResponseEntity<PrisonSearchResponse> = prisonRegisterApiService.getPrisonById(prisonId)?.let {
-    ResponseEntity.ok(it.toPrisonSearchResponse())
-  } ?: throw NotFoundException("No Prison found for $prisonId")
+  fun getPrisonById(
+    @Parameter(
+      description = "A prison identifier",
+      required = true,
+    ) @PathVariable("prisonId") prisonId: String,
+  ): ResponseEntity<PrisonSearchResponse> {
+    log.warn("Deprecated endpoint /prison-search/prisonId was called")
+    return prisonRegisterApiService.getPrisonById(prisonId)?.let {
+      ResponseEntity.ok(it.toPrisonSearchResponse())
+    } ?: throw NotFoundException("No Prison found for $prisonId")
+  }
 
+  @Deprecated("This endpoint is deprecated and may be removed in the future")
   @Operation(
     tags = ["Prison"],
     summary = "Search for prisons via prison register api by prison id.",
     operationId = "getPrisons",
     description = """""",
     responses = [
-      ApiResponse(responseCode = "201", description = "The prisoner search results.", content = [Content(array = ArraySchema(schema = Schema(implementation = PrisonSearchResponse::class)))]),
-      ApiResponse(responseCode = "400", description = "Bad input", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
-      ApiResponse(responseCode = "401", description = "The client is not authorized to perform this operation.", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
+      ApiResponse(
+        responseCode = "201",
+        description = "The prisoner search results.",
+        content = [Content(array = ArraySchema(schema = Schema(implementation = PrisonSearchResponse::class)))],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad input",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "The client is not authorized to perform this operation.",
+        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
+      ),
     ],
-    security = [ SecurityRequirement(name = "bearerAuth") ],
+    security = [SecurityRequirement(name = "bearerAuth")],
   )
   @RequestMapping(
     method = [RequestMethod.POST],
@@ -65,8 +104,16 @@ class PrisonSearchController(private val prisonRegisterApiService: PrisonRegiste
     produces = ["application/json"],
     consumes = ["application/json"],
   )
-  fun getPrisons(@Parameter(description = "", required = true) @RequestBody prisonSearchRequest: PrisonSearchRequest): ResponseEntity<List<PrisonSearchResponse>> = ResponseEntity.ok(
-    prisonRegisterApiService.getPrisons(prisonSearchRequest.prisonIds)
-      .map { it.toPrisonSearchResponse() },
-  )
+  fun getPrisons(
+    @Parameter(
+      description = "",
+      required = true,
+    ) @RequestBody prisonSearchRequest: PrisonSearchRequest,
+  ): ResponseEntity<List<PrisonSearchResponse>> {
+    log.warn("Deprecated endpoint /prison-search was called")
+    return ResponseEntity.ok(
+      prisonRegisterApiService.getPrisons(prisonSearchRequest.prisonIds)
+        .map { it.toPrisonSearchResponse() },
+    )
+  }
 }


### PR DESCRIPTION
Marks People and Prison Search endpoints that are not in use by the UI as deprecated

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
