### PR TITLE
[APG-536] Update PostgreSQL version in prod-to-preprod data refresh

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-api/templates/cronjob-prod-to-preprod-data-refresh.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-api/templates/cronjob-prod-to-preprod-data-refresh.yaml
@@ -71,7 +71,7 @@ spec:
             runAsUser: 999
           containers:
             - name: dbrefresh
-              image: "postgres:14"
+              image: "postgres:16"
               command:
                 - /bin/entrypoint.sh
               volumeMounts:


### PR DESCRIPTION
## Changes in this PR

- Upgraded the PostgreSQL image in the cronjob from version 14 to 16. 

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
