### PR TITLE
[APG-778] Refactor PNI storage logic to retrieve score from Oasys

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralService.kt
@@ -108,11 +108,12 @@ constructor(
     return referrerUser
   }
 
-  private fun savePNI(savedReferral: ReferralEntity) {
+  private fun retrieveAndStorePNI(referralId: UUID, prisonNumber: String) {
     try {
-      pniService.savePni(prisonNumber = savedReferral.prisonNumber, gender = null, savePni = true, referralId = savedReferral.id)
+      val pniScore = pniService.getOasysPniScore(prisonNumber)
+      pniService.savePni(pniScore, referralId)
     } catch (ex: Exception) {
-      log.warn("PNI could not be stored ${ex.message} for prisonNumber $savedReferral.prisonNumber")
+      log.warn("PNI could not be stored ${ex.message} for prisonNumber $prisonNumber")
     }
   }
 
@@ -166,7 +167,7 @@ constructor(
 
     // save PNI when referral is updated to "On Programme" status
     if (referral.status == ReferralStatus.ON_PROGRAMME.name) {
-      savePNI(referral)
+      retrieveAndStorePNI(referralId, referral.prisonNumber)
     }
 
     // audit the interaction

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
@@ -1163,7 +1163,8 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
   fun `should persist PNI when referral status is updated to On Programme`() {
     // Given
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
-    val referralCreated = createReferral(PRISON_NUMBER_1)
+    val prisonNumber = "A9999BB"
+    val referralCreated = createReferral(prisonNumber)
 
     val referralStatusUpdate1 = ReferralStatusUpdate(
       status = REFERRAL_SUBMITTED,
@@ -1196,10 +1197,10 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
     updateReferralStatus(referralCreated.id, referralStatusUpdate5)
 
     // Then
-    val pniResult = pniResultRepository.findByReferralIdAndPrisonNumber(referralCreated.id, PRISON_NUMBER_1)
+    val pniResult = pniResultRepository.findByReferralIdAndPrisonNumber(referralCreated.id, prisonNumber)
     pniResult shouldNotBe null
-    pniResult?.prisonNumber?.shouldBeEqual(PRISON_NUMBER_1)
-    pniResult?.crn?.shouldBeEqual("X739590")
+    pniResult?.prisonNumber?.shouldBeEqual(prisonNumber)
+    pniResult?.crn?.shouldBeEqual("D006518")
     pniResult?.oasysAssessmentId?.shouldBeEqual(2114584)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -48,6 +48,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.reposito
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PersonRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferrerUserRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.PniScore
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusRefData
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.TransferReferralRequest
@@ -391,7 +392,8 @@ class ReferralServiceTest {
     referralService.updateReferralStatusById(referralId, referralStatusUpdate)
 
     // Then
-    verify { pniService.savePni(referral.prisonNumber, gender = null, savePni = true, referral.id) }
+    verify { pniService.getOasysPniScore(referral.prisonNumber) }
+    verify { pniService.savePni(any<PniScore>(), referral.id) }
     verify { auditService.audit(capture(referralEntityCaptor), any(), any()) }
 
     val capturedReferralEntity = referralEntityCaptor.captured

--- a/src/test/resources/simulations/__files/prison-search-results_A9999BB.json
+++ b/src/test/resources/simulations/__files/prison-search-results_A9999BB.json
@@ -1,6 +1,6 @@
 [
   {
-    "prisonerNumber": "A999BB",
+    "prisonerNumber": "A9999BB",
     "bookingId": "1201102",
     "bookNumber": "38518A",
     "firstName": "JOHN",

--- a/src/test/resources/simulations/mappings/prison-api.json
+++ b/src/test/resources/simulations/mappings/prison-api.json
@@ -41,6 +41,19 @@
     },
     {
       "request": {
+        "urlPattern": "/api/offenders/A9999BB/booking/latest/sentence-summary",
+        "method": "GET"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "bodyFileName": "sentence-info.json"
+      }
+    },
+    {
+      "request": {
         "url": "/api/users/me/caseloads?allCaseloads=false",
         "method": "GET"
       },


### PR DESCRIPTION
## Changes in this PR

- Refactored the PNI storage method to retrieve the PNI score from OASys before saving for referral status updates to ON_PROGRAMME
- Updated affected tests and wiremock data to reflect the new workflow, including additional verifications and corrections to prison numbers.
