### PR TITLE
APG-837 - Adds deselectAndKeepOpen filter to findReferralStatusReasonsByStatusCode

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/ReferralStatusEntity.kt
@@ -105,12 +105,13 @@ interface ReferralStatusReasonRepository : JpaRepository<ReferralStatusReasonEnt
     FROM referral_status_reason r
     JOIN referral_status_category c 
     ON r.referral_status_category_code = c.code
-    WHERE c.referral_status_code = :statusCode
+    WHERE (:deselectOpen = FALSE OR r.deselect_open = TRUE)
+    AND c.referral_status_code = :statusCode
     AND c.active = true
   """,
     nativeQuery = true,
   )
-  fun findReferralStatusReasonsByStatusCode(statusCode: String): List<ReferralStatusReasonProjection>
+  fun findReferralStatusReasonsByStatusCode(statusCode: String, deselectOpen: Boolean): List<ReferralStatusReasonProjection>
 }
 
 interface ReferralStatusReasonProjection {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferenceDataController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/ReferenceDataController.kt
@@ -75,5 +75,6 @@ class ReferenceDataController(
   @GetMapping("/referral-statuses/{referralStatusType}/categories/reasons", produces = ["application/json"])
   fun getReferralStatusReasonsForReferralStatusType(
     @Parameter(description = "The referral status type (WITHDRAWN, DESELECTED or ASSESSED_SUITABLE)", required = true) @PathVariable referralStatusType: ReferralStatusType,
-  ): List<ReferralStatusReason> = referenceDataService.getAllReferralStatusReasonsForType(referralStatusType)
+    @Parameter(description = "Whether the status transition is for keep open or not for the DESELECTED status", required = false) @RequestParam(defaultValue = "false") deselectAndKeepOpen: Boolean = false,
+  ): List<ReferralStatusReason> = referenceDataService.getAllReferralStatusReasonsForType(referralStatusType, deselectAndKeepOpen)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralReferenceDataService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/ReferralReferenceDataService.kt
@@ -114,6 +114,6 @@ class ReferralReferenceDataService(
     referralStatusTransitionRepository.getPOMTransition(currentStatus, chosenStatus)
   }
 
-  fun getAllReferralStatusReasonsForType(referralStatusType: ReferralStatusType): List<ReferralStatusReason> = referralStatusReasonRepository.findReferralStatusReasonsByStatusCode(referralStatusType.name)
+  fun getAllReferralStatusReasonsForType(referralStatusType: ReferralStatusType, deselectAndKeepOpen: Boolean): List<ReferralStatusReason> = referralStatusReasonRepository.findReferralStatusReasonsByStatusCode(referralStatusType.name, deselectAndKeepOpen)
     .map { it.toModel() }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralReferenceDataIntegrationTest.kt
@@ -160,7 +160,7 @@ class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
   }
 
   @Test
-  fun `should return all deselected referral status reasons`() {
+  fun `should return all deselected referral status reasons when keep open is false`() {
     // Given
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
     // When
@@ -168,6 +168,20 @@ class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
     // Then
     response.shouldNotBeNull()
     response.size.shouldBeEqual(21)
+    response[0].code shouldBeEqual "D_ATTITUDE"
+    response[0].description shouldBeEqual "Attitude to group facilitators or others"
+    response[0].referralCategoryCode shouldBe "D_MOTIVATION"
+  }
+
+  @Test
+  fun `should return filtered deselected referral status reasons when keep open is true`() {
+    // Given
+    mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
+    // When
+    val response = getAllReferralStatusReasonsForType(ReferralStatusType.DESELECTED.name, true)
+    // Then
+    response.shouldNotBeNull()
+    response.size.shouldBeEqual(16)
     response[0].code shouldBeEqual "D_ATTITUDE"
     response[0].description shouldBeEqual "Attitude to group facilitators or others"
     response[0].referralCategoryCode shouldBe "D_MOTIVATION"
@@ -309,9 +323,9 @@ class ReferralReferenceDataIntegrationTest : IntegrationTestBase() {
     .expectBody<ReferralStatusReason>()
     .returnResult().responseBody!!
 
-  fun getAllReferralStatusReasonsForType(referralStatusType: String) = webTestClient
+  fun getAllReferralStatusReasonsForType(referralStatusType: String, deselectAndKeepOpen: Boolean = false) = webTestClient
     .get()
-    .uri("/reference-data/referral-statuses/$referralStatusType/categories/reasons")
+    .uri("/reference-data/referral-statuses/$referralStatusType/categories/reasons?deselectAndKeepOpen=$deselectAndKeepOpen")
     .header(HttpHeaders.AUTHORIZATION, jwtAuthHelper.bearerToken())
     .accept(MediaType.APPLICATION_JSON)
     .exchange()


### PR DESCRIPTION
When status code is set to DESELECTED, the deselectAndKeepOpen param will filter the reasons further by whether the referral is be closed or kept open

## Changes in this PR

## Release checklist

[Release process documentation](../doc/how-to/perform-a-release.md)

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
