### PR TITLE
[APG-886] Add entities and repositories for eligibility override and sexual offence selection

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/EligibilityOverrideReasonEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/EligibilityOverrideReasonEntity.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "eligibility_override_reason")
+class EligibilityOverrideReasonEntity(
+
+  @Id
+  @GeneratedValue
+  @Column(name = "id")
+  var id: UUID? = null,
+
+  @Column(name = "reason")
+  var reason: String,
+
+  @Column(name = "override_type")
+  var overrideType: OverrideType,
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "referral_id", referencedColumnName = "referral_id")
+  var referral: ReferralEntity,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OverrideType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OverrideType.kt
@@ -1,0 +1,5 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create
+
+enum class OverrideType {
+  HEALTHY_SEX_PROGRAMME,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import jakarta.persistence.Version
 import org.hibernate.annotations.SQLRestriction
@@ -76,6 +77,13 @@ class ReferralEntity(
 
   @Column(name = "has_ldc_been_overridden_by_programme_team")
   var hasLdcBeenOverriddenByProgrammeTeam: Boolean = false,
+
+  @OneToMany(mappedBy = "referral", fetch = FetchType.LAZY)
+  var selectedSexualOffenceDetails: MutableList<SelectedSexualOffenceDetailsEntity> = mutableListOf(),
+
+  @OneToMany(mappedBy = "referral", fetch = FetchType.LAZY)
+  var eligibilityOverrideReasons: MutableList<EligibilityOverrideReasonEntity> = mutableListOf(),
+
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/SelectedSexualOffenceDetailsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/SelectedSexualOffenceDetailsEntity.kt
@@ -1,0 +1,38 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.SexualOffenceDetailsEntity
+import java.util.UUID
+
+@Entity
+@Table(name = "selected_sexual_offence_details")
+class SelectedSexualOffenceDetailsEntity(
+  @Id
+  @GeneratedValue
+  @Column(name = "id")
+  var id: UUID? = null,
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "referral_id", referencedColumnName = "referral_id")
+  var referral: ReferralEntity,
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "sexual_offence_details_id", referencedColumnName = "id")
+  var sexualOffenceDetails: SexualOffenceDetailsEntity? = null,
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || this::class != other::class) return false
+    other as SelectedSexualOffenceDetailsEntity
+    return this.id == other.id
+  }
+
+  override fun hashCode(): Int = id.hashCode()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/SelectedSexualOffenceDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/SelectedSexualOffenceDetailsRepository.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.SelectedSexualOffenceDetailsEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.SexualOffenceDetailsEntity
+import java.util.UUID
+
+@Repository
+interface SelectedSexualOffenceDetailsRepository : JpaRepository<SelectedSexualOffenceDetailsEntity, UUID> {
+  fun findAllByReferralId(referralId: UUID): List<SelectedSexualOffenceDetailsEntity>
+  fun findAllBySexualOffenceDetails(sexualOffenceDetails: SexualOffenceDetailsEntity): List<SelectedSexualOffenceDetailsEntity>
+  fun findAllBySexualOffenceDetailsId(sexualOffenceDetailsId: UUID): List<SelectedSexualOffenceDetailsEntity>
+}

--- a/src/main/resources/db/migration/V132__add_selected_sexual_offence_details_table.sql
+++ b/src/main/resources/db/migration/V132__add_selected_sexual_offence_details_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE selected_sexual_offence_details (
+     id UUID PRIMARY KEY,
+     referral_id UUID NOT NULL,
+     sexual_offence_details_id UUID,
+     CONSTRAINT fk_referral FOREIGN KEY (referral_id) REFERENCES referral(referral_id),
+     CONSTRAINT fk_sexual_offence_details FOREIGN KEY (sexual_offence_details_id) REFERENCES sexual_offence_details(id)
+);
+
+-- Add indexes for the foreign keys
+CREATE INDEX idx_selected_sexual_offence_details_referral_id ON selected_sexual_offence_details(referral_id);
+CREATE INDEX idx_selected_sexual_offence_details_sexual_offence_details_id ON selected_sexual_offence_details(sexual_offence_details_id);

--- a/src/main/resources/db/migration/V133__add_eligibility_override_reason_table.sql
+++ b/src/main/resources/db/migration/V133__add_eligibility_override_reason_table.sql
@@ -1,0 +1,11 @@
+CREATE TABLE eligibility_override_reason (
+     id UUID PRIMARY KEY,
+     referral_id UUID NOT NULL,
+     reason text not null,
+     override_type text not null,
+     CONSTRAINT fk_eligibility_override_reason_referral FOREIGN KEY (referral_id) REFERENCES referral(referral_id)
+);
+
+-- Add indexes for the foreign keys
+CREATE INDEX idx_eligibility_override_reason_referral_id ON eligibility_override_reason(referral_id);
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/EligibilityOverrideReasonEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/EligibilityOverrideReasonEntityFactory.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory
+
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.EligibilityOverrideReasonEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OverrideType
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
+import java.util.UUID
+
+class EligibilityOverrideReasonEntityFactory {
+  private var id: UUID? = UUID.randomUUID()
+  private var reason: String = "Test override reason"
+  private var overrideType: OverrideType = OverrideType.HEALTHY_SEX_PROGRAMME
+  private var referral: ReferralEntity = ReferralEntityFactory().produce()
+
+  fun withId(id: UUID?) = apply { this.id = id }
+  fun withReason(reason: String) = apply { this.reason = reason }
+  fun withOverrideType(overrideType: OverrideType) = apply { this.overrideType = overrideType }
+  fun withReferral(referral: ReferralEntity) = apply { this.referral = referral }
+
+  fun produce() = EligibilityOverrideReasonEntity(
+    id = this.id,
+    reason = this.reason,
+    overrideType = this.overrideType,
+    referral = this.referral,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/SelectedSexualOffenceDetailsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/SelectedSexualOffenceDetailsEntityFactory.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory
+
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.SelectedSexualOffenceDetailsEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.SexualOffenceDetailsEntity
+import java.util.UUID
+
+class SelectedSexualOffenceDetailsEntityFactory {
+  private var id: UUID? = UUID.randomUUID()
+  private var referral: ReferralEntity = ReferralEntityFactory().produce()
+  private var sexualOffenceDetails: SexualOffenceDetailsEntity? = null
+
+  fun withId(id: UUID?) = apply { this.id = id }
+  fun withReferral(referral: ReferralEntity) = apply { this.referral = referral }
+  fun withSexualOffenceDetails(sexualOffenceDetails: SexualOffenceDetailsEntity?) = apply { this.sexualOffenceDetails = sexualOffenceDetails }
+
+  fun produce() = SelectedSexualOffenceDetailsEntity(
+    id = this.id,
+    referral = this.referral,
+    sexualOffenceDetails = this.sexualOffenceDetails,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/SexualOffenceDetailsEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/SexualOffenceDetailsEntityFactory.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory
+
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.SexualOffenceDetailsEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.type.SexualOffenceCategoryType
+import java.util.UUID
+
+class SexualOffenceDetailsEntityFactory {
+  private var id: UUID = UUID.randomUUID()
+  private var category: SexualOffenceCategoryType = SexualOffenceCategoryType.AGAINST_MINORS
+  private var description: String = "An offence"
+  private var hintText: String? = null
+  private var score: Int = 1
+
+  fun withId(id: UUID) = apply { this.id = id }
+  fun withCategory(category: SexualOffenceCategoryType) = apply { this.category = category }
+  fun withDescription(description: String) = apply { this.description = description }
+  fun withHintText(hintText: String?) = apply { this.hintText = hintText }
+  fun withScore(score: Int) = apply { this.score = score }
+
+  fun produce() = SexualOffenceDetailsEntity(
+    id = this.id,
+    category = this.category,
+    description = this.description,
+    hintText = this.hintText,
+    score = this.score,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/SelectedSexualOffenceDetailsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/SelectedSexualOffenceDetailsRepositoryTest.kt
@@ -1,0 +1,216 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.repository
+
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import jakarta.persistence.EntityManager
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.SelectedSexualOffenceDetailsEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.SelectedSexualOffenceDetailsRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.CourseEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OfferingEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferrerUserEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.SelectedSexualOffenceDetailsEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.SexualOffenceDetailsEntityFactory
+
+@SpringBootTest
+@AutoConfigureTestDatabase
+@Transactional
+@ActiveProfiles("test-h2")
+class SelectedSexualOffenceDetailsRepositoryTest {
+
+  @Autowired
+  private lateinit var entityManager: EntityManager
+
+  @Autowired
+  private lateinit var selectedSexualOffenceDetailsRepository: SelectedSexualOffenceDetailsRepository
+
+  @Test
+  fun `SelectedSexualOffenceDetailsRepository should save and retrieve SelectedSexualOffenceDetailsEntity objects`() {
+    // Given
+    var course = CourseEntityFactory().produce()
+    course = entityManager.merge(course)
+
+    var offering = OfferingEntityFactory().produce()
+    offering.course = course
+    offering = entityManager.merge(offering)
+
+    var referrer = ReferrerUserEntityFactory().produce()
+    referrer = entityManager.merge(referrer)
+
+    var referral = ReferralEntityFactory()
+      .withId(null)
+      .withReferrer(referrer)
+      .withOffering(offering)
+      .produce()
+    referral = entityManager.merge(referral)
+
+    // Create and persist a selected sexual offence details entity
+    var selectedSexualOffenceDetails = SelectedSexualOffenceDetailsEntityFactory()
+      .withId(null)
+      .withReferral(referral)
+      .produce()
+    selectedSexualOffenceDetails = entityManager.merge(selectedSexualOffenceDetails)
+
+    // When
+    val selectedOffenceDetails = entityManager.find(SelectedSexualOffenceDetailsEntity::class.java, selectedSexualOffenceDetails.id)
+    selectedOffenceDetails shouldNotBe null
+    selectedOffenceDetails.referral.id shouldBe referral.id
+
+    // Then
+    val foundDetails = selectedSexualOffenceDetailsRepository.findAllByReferralId(referral.id!!)
+    foundDetails.size shouldBe 1
+    foundDetails[0].id shouldBe selectedSexualOffenceDetails.id
+  }
+
+  @Test
+  fun `SelectedSexualOffenceDetailsRepository should find all details for a referral`() {
+    // Create and persist a referral
+    var course = CourseEntityFactory().produce()
+    course = entityManager.merge(course)
+
+    var offering = OfferingEntityFactory().produce()
+    offering.course = course
+    offering = entityManager.merge(offering)
+
+    var referrer = ReferrerUserEntityFactory().produce()
+    referrer = entityManager.merge(referrer)
+
+    var referral = ReferralEntityFactory()
+      .withId(null)
+      .withReferrer(referrer)
+      .withOffering(offering)
+      .produce()
+    referral = entityManager.merge(referral)
+
+    // Create and persist multiple selected sexual offence details entities
+    var details1 = SelectedSexualOffenceDetailsEntityFactory()
+      .withId(null)
+      .withReferral(referral)
+      .produce()
+    details1 = entityManager.merge(details1)
+
+    var details2 = SelectedSexualOffenceDetailsEntityFactory()
+      .withId(null)
+      .withReferral(referral)
+      .produce()
+    details2 = entityManager.merge(details2)
+
+    // Test the findAllByReferral_Id method
+    val foundDetails = selectedSexualOffenceDetailsRepository.findAllByReferralId(referral.id!!)
+    foundDetails.size shouldBe 2
+    foundDetails.map { it.id } shouldContainExactlyInAnyOrder listOf(details1.id, details2.id)
+  }
+
+  @Test
+  fun `A referral should have access to its selected sexual offence details`() {
+    // Given
+    var course = CourseEntityFactory().produce()
+    course = entityManager.merge(course)
+
+    var offering = OfferingEntityFactory().produce()
+    offering.course = course
+    offering = entityManager.merge(offering)
+
+    var referrer = ReferrerUserEntityFactory().produce()
+    referrer = entityManager.merge(referrer)
+
+    var referral = ReferralEntityFactory()
+      .withId(null)
+      .withReferrer(referrer)
+      .withOffering(offering)
+      .produce()
+    referral = entityManager.merge(referral)
+
+    // Create and persist multiple sexual offence details entities
+    var offenceDetails1 = SexualOffenceDetailsEntityFactory().produce()
+    offenceDetails1 = entityManager.merge(offenceDetails1)
+    var offenceDetails2 = SexualOffenceDetailsEntityFactory().produce()
+    offenceDetails2 = entityManager.merge(offenceDetails2)
+
+    // Create and persist multiple selected sexual offence details entities
+    var selectedDetails1 = SelectedSexualOffenceDetailsEntityFactory()
+      .withId(null)
+      .withReferral(referral)
+      .withSexualOffenceDetails(offenceDetails1)
+      .produce()
+    selectedDetails1 = entityManager.merge(selectedDetails1)
+
+    // When
+    var selectedDetails2 = SelectedSexualOffenceDetailsEntityFactory()
+      .withId(null)
+      .withReferral(referral)
+      .withSexualOffenceDetails(offenceDetails2)
+      .produce()
+    selectedDetails2 = entityManager.merge(selectedDetails2)
+    entityManager.flush()
+    entityManager.clear()
+
+    // Then
+    val referralEntity = entityManager.find(ReferralEntity::class.java, referral.id)
+    referralEntity.selectedSexualOffenceDetails.size shouldBe 2
+    referralEntity.selectedSexualOffenceDetails.map { it.id } shouldContainExactlyInAnyOrder listOf(selectedDetails1.id, selectedDetails2.id)
+  }
+
+  @Test
+  fun `SelectedSexualOffenceDetailsEntity should reference SexualOffenceDetailsEntity`() {
+    // Create and persist a referral
+    var course = CourseEntityFactory().produce()
+    course = entityManager.merge(course)
+
+    var offering = OfferingEntityFactory().produce()
+    offering.course = course
+    offering = entityManager.merge(offering)
+
+    var referrer = ReferrerUserEntityFactory().produce()
+    referrer = entityManager.merge(referrer)
+
+    var referral = ReferralEntityFactory()
+      .withId(null)
+      .withReferrer(referrer)
+      .withOffering(offering)
+      .produce()
+    referral = entityManager.merge(referral)
+
+    // Create and persist a sexual offence details entity
+    var sexualOffenceDetails = SexualOffenceDetailsEntityFactory().produce()
+    sexualOffenceDetails = entityManager.merge(sexualOffenceDetails)
+
+    // Create and persist a selected sexual offence details entity with a reference to the sexual offence details
+    var selectedSexualOffenceDetails = SelectedSexualOffenceDetailsEntityFactory()
+      .withId(null)
+      .withReferral(referral)
+      .withSexualOffenceDetails(sexualOffenceDetails)
+      .produce()
+    selectedSexualOffenceDetails = entityManager.merge(selectedSexualOffenceDetails)
+
+    // Verify the entity was persisted correctly with the reference
+    val persistedDetails = entityManager.find(SelectedSexualOffenceDetailsEntity::class.java, selectedSexualOffenceDetails.id)
+    persistedDetails shouldNotBe null
+    persistedDetails.run {
+      this.referral.id shouldBe referral.id
+      this.sexualOffenceDetails shouldNotBe null
+      this.sexualOffenceDetails?.id shouldBe sexualOffenceDetails.id
+      this.sexualOffenceDetails?.category shouldBe sexualOffenceDetails.category
+      this.sexualOffenceDetails?.description shouldBe sexualOffenceDetails.description
+      this.sexualOffenceDetails?.score shouldBe sexualOffenceDetails.score
+    }
+
+    // Test the findAllBySexualOffenceDetails method
+    val foundDetailsByEntity = selectedSexualOffenceDetailsRepository.findAllBySexualOffenceDetails(sexualOffenceDetails)
+    foundDetailsByEntity.size shouldBe 1
+    foundDetailsByEntity[0].id shouldBe selectedSexualOffenceDetails.id
+
+    // Test the findAllBySexualOffenceDetails_Id method
+    val foundDetailsById = selectedSexualOffenceDetailsRepository.findAllBySexualOffenceDetailsId(sexualOffenceDetails.id!!)
+    foundDetailsById.size shouldBe 1
+    foundDetailsById[0].id shouldBe selectedSexualOffenceDetails.id
+  }
+}


### PR DESCRIPTION
## Changes in this PR

- Introduced `EligibilityOverrideReasonEntity` and `SelectedSexualOffenceDetailsEntity` with related repositories, factories, and flyway database migrations scripts.
- Updated `ReferralEntity` to include relationships for these entities. 
- Added unit tests to ensure repository behaviours and entity associations work as expected.
