### PR TITLE
Gardening: Clean up documentation for ReferralReferenceData; Update deprecated annotation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PrisonSearchController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PrisonSearchController.kt
@@ -34,6 +34,7 @@ class PrisonSearchController(private val prisonRegisterApiService: PrisonRegiste
   @Deprecated("This endpoint is deprecated and may be removed in the future")
   @Operation(
     tags = ["Prison"],
+    deprecated = true,
     summary = "Details for a single prison",
     operationId = "getPrisonById",
     description = """""",
@@ -76,6 +77,7 @@ class PrisonSearchController(private val prisonRegisterApiService: PrisonRegiste
   @Deprecated("This endpoint is deprecated and may be removed in the future")
   @Operation(
     tags = ["Prison"],
+    deprecated = true,
     summary = "Search for prisons via prison register api by prison id.",
     operationId = "getPrisons",
     description = """""",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralStatusRefData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/ReferralStatusRefData.kt
@@ -3,64 +3,47 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
-/**
- *
- * @param code
- * @param description
- * @param colour
- * @param hintText
- * @param confirmationText
- * @param hasNotes flag to show this status has notes text box
- * @param hasConfirmation flag to show this status has confirmation box
- * @param closed flag to show this is a closed status
- * @param draft flag to show this is a draft status
- * @param hold flag to show this is a hold status
- * @param release flag to show this is a release status
- * @param deselectAndKeepOpen flag to show this a bespoke status of deslected and keep open
- * @param defaultOrder sort order for statuses
- * @param notesOptional flag to show whether the notes are optional
- */
 data class ReferralStatusRefData(
 
-  @Schema(example = "WITHDRAWN", required = true, description = "")
+  @Schema(example = "WITHDRAWN", required = true, description = "A enum-like, computer-friendly string describing the Referral Status")
   @get:JsonProperty("code", required = true) val code: String,
 
-  @Schema(example = "Withdrawn", required = true, description = "")
+  @Schema(example = "Withdrawn", required = true, description = "A human-readable string describing the Referral Status")
   @get:JsonProperty("description", required = true) val description: String,
 
-  @Schema(example = "light-grey", required = true, description = "")
+  @Schema(example = "light-grey", required = true, description = "A computer-friendly string describing the colour of the referral for display purposes.  This doesn't correspond to CSS default colours, or to hex values.")
   @get:JsonProperty("colour", required = true) val colour: String,
 
-  @Schema(example = "The application has been withdrawn", description = "")
+  @Schema(example = "The application has been withdrawn", description = "A human-friendly string that provides information about the status.  These are set by the system, not a human.")
   @get:JsonProperty("hintText") val hintText: String? = null,
 
-  @Schema(example = "I confirm that this person is eligible.", description = "")
+  @Schema(example = "I confirm that this person is eligible.", description = "Human-written text to confirm information about the Status", nullable = true)
   @get:JsonProperty("confirmationText") val confirmationText: String? = null,
 
-  @Schema(example = "null", description = "flag to show this status has notes text box")
+  @Schema(example = "null", description = "If true, this status should show a notes text box on the UI", nullable = true)
   @get:JsonProperty("hasNotes") val hasNotes: Boolean? = null,
 
-  @Schema(example = "null", description = "flag to show this status has confirmation box")
+  @Schema(example = "null", description = "If true, this status should show a confirmation box on the UI", nullable = true)
   @get:JsonProperty("hasConfirmation") val hasConfirmation: Boolean? = null,
 
-  @Schema(example = "null", description = "flag to show this is a closed status")
+  @Schema(example = "null", description = "If true, this is a closed status", nullable = true)
   @get:JsonProperty("closed") val closed: Boolean? = null,
 
-  @Schema(example = "null", description = "flag to show this is a draft status")
+  @Schema(example = "null", description = "If true, this is a draft status", nullable = true)
   @get:JsonProperty("draft") val draft: Boolean? = null,
 
-  @Schema(example = "null", description = "flag to show this is a hold status")
+  @Schema(example = "null", description = "If true, this is a hold status", nullable = true)
   @get:JsonProperty("hold") val hold: Boolean? = null,
 
-  @Schema(example = "null", description = "flag to show this is a release status")
+  @Schema(example = "null", description = "If true, this is a release status", nullable = true)
   @get:JsonProperty("release") val release: Boolean? = null,
 
-  @Schema(example = "null", description = "flag to show this a bespoke status of deslected and keep open")
+  @Schema(example = "null", description = "If true, this a bespoke status of deselected and keep open", nullable = true)
   @get:JsonProperty("deselectAndKeepOpen") val deselectAndKeepOpen: Boolean? = null,
 
-  @Schema(example = "null", description = "sort order for statuses")
+  @Schema(example = "null", description = "Sort order for statuses (presently this seems to be ignored in the UI)", nullable = true)
   @get:JsonProperty("defaultOrder") val defaultOrder: Int? = null,
 
-  @Schema(example = "null", description = "flag to show whether the notes are optional")
+  @Schema(example = "null", description = "Flag to show whether the notes are optional", nullable = true)
   @get:JsonProperty("notesOptional") val notesOptional: Boolean? = null,
 )


### PR DESCRIPTION
- **chore(PrisonSearchController): Add the 'deprecated' field to the deprecated endpoints.**
- **chore(ReferralStatusRefData): Improve documentation annotations; remove redundant/duplicated Javadoc documentation**
