### PR TITLE
chore(ApiExceptionHandler): Remove the EntityNotFoundException handler

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/config/ApiExceptionHandler.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.config
 
 import io.sentry.Sentry
-import jakarta.persistence.EntityNotFoundException
 import jakarta.validation.ValidationException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
@@ -72,20 +71,6 @@ class ApiExceptionHandler {
         ErrorResponse(
           status = INTERNAL_SERVER_ERROR,
           userMessage = "Service unavailable: ${e.message}",
-          developerMessage = e.message,
-        ),
-      )
-  }
-
-  @ExceptionHandler(EntityNotFoundException::class)
-  fun handleEntityNotFoundException(e: EntityNotFoundException): ResponseEntity<ErrorResponse> {
-    log.error("Entity not found", e)
-    return ResponseEntity
-      .status(NOT_FOUND)
-      .body(
-        ErrorResponse(
-          status = NOT_FOUND,
-          userMessage = "Not Found: ${e.message}",
           developerMessage = e.message,
         ),
       )


### PR DESCRIPTION
**WHAT**

This commit removes the app-wide handler for the
`EntityNotFoundException` (from jakarta).

**WHY**

The exception is never thrown, it appears that we have converged on the
`NotFoundException` instead.
