### PR TITLE
Apg 886 add create hsp referral api endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/ReferralEntity.kt
@@ -79,10 +79,10 @@ class ReferralEntity(
   var hasLdcBeenOverriddenByProgrammeTeam: Boolean = false,
 
   @OneToMany(mappedBy = "referral", fetch = FetchType.LAZY)
-  var selectedSexualOffenceDetails: MutableList<SelectedSexualOffenceDetailsEntity> = mutableListOf(),
+  var selectedSexualOffenceDetails: MutableSet<SelectedSexualOffenceDetailsEntity> = mutableSetOf(),
 
   @OneToMany(mappedBy = "referral", fetch = FetchType.LAZY)
-  var eligibilityOverrideReasons: MutableList<EligibilityOverrideReasonEntity> = mutableListOf(),
+  var eligibilityOverrideReasons: MutableSet<EligibilityOverrideReasonEntity> = mutableSetOf(),
 
 ) {
   override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/EligibilityOverrideReasonEntityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/EligibilityOverrideReasonEntityRepository.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.EligibilityOverrideReasonEntity
+import java.util.*
+
+@Repository
+interface EligibilityOverrideReasonEntityRepository : JpaRepository<EligibilityOverrideReasonEntity, UUID>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
+import java.util.Optional
 import java.util.UUID
 
 @Repository
@@ -33,4 +34,15 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
 
   fun findAllByPrisonNumber(prisonNumber: String): List<ReferralEntity>
   fun findAllByPrisonNumberAndStatusIn(prisonNumber: String, openReferralStatus: List<String>): List<ReferralEntity>
+
+  @Query(
+    """
+    SELECT r FROM ReferralEntity r 
+    LEFT JOIN FETCH r.selectedSexualOffenceDetails ssod 
+    LEFT JOIN FETCH ssod.sexualOffenceDetails
+    LEFT JOIN FETCH r.eligibilityOverrideReasons eor 
+    WHERE r.id = :id
+    """,
+  )
+  fun findByIdWithHspDetails(@Param("id") id: UUID): Optional<ReferralEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/HspReferralCreate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/HspReferralCreate.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import java.util.UUID
+
+data class HspReferralCreate(
+
+  @Schema(example = "550e8400-e29b-41d4-a716-446655440000", required = true, description = "The id (UUID) of the HSP offering")
+  @get:JsonProperty("offeringId", required = true) val offeringId: UUID,
+
+  @Schema(example = "A1234AA", required = true, description = "The prison number of the person who is being referred.")
+  @get:JsonProperty("prisonNumber", required = true) val prisonNumber: String,
+
+  @Schema(example = "[\"dd69bdbe-a61d-45e5-bb20-e52af4a0ac83\",\"550e8400-e29b-41d4-a716-446655440000\"]", required = true, description = "The list of IDs of the selected offences.")
+  @get:JsonProperty("selectedOffences", required = true) val selectedOffences: List<UUID> = emptyList(),
+
+  @Schema(example = "The prisoner meets the requirements", required = false, description = "The overriding reason why the prisoner should be considered suitable for the course.")
+  @get:JsonProperty("eligibilityOverrideReason", required = false) val eligibilityOverrideReason: String? = null,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/PersistenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/PersistenceHelper.kt
@@ -4,6 +4,9 @@ import jakarta.persistence.EntityManager
 import jakarta.persistence.PersistenceContext
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OfferingEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.SexualOffenceDetailsEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CourseIntensity
 import java.math.BigInteger
 import java.time.LocalDateTime
@@ -22,6 +25,8 @@ class PersistenceHelper {
     entityManager.createNativeQuery("DELETE FROM course_participation").executeUpdate()
     entityManager.createNativeQuery("DELETE FROM pni_result").executeUpdate()
     entityManager.createNativeQuery("DELETE FROM staff").executeUpdate()
+    entityManager.createNativeQuery("DELETE FROM selected_sexual_offence_details").executeUpdate()
+    entityManager.createNativeQuery("DELETE FROM eligibility_override_reason").executeUpdate()
     entityManager.createNativeQuery("DELETE FROM referral").executeUpdate()
     entityManager.createNativeQuery("DELETE FROM offering").executeUpdate()
     entityManager.createNativeQuery("DELETE FROM course_variant").executeUpdate()
@@ -30,6 +35,14 @@ class PersistenceHelper {
     entityManager.createNativeQuery("DELETE FROM audit_record").executeUpdate()
     entityManager.createNativeQuery("DELETE FROM organisation").executeUpdate()
     entityManager.createNativeQuery("DELETE FROM audience").executeUpdate()
+  }
+
+  fun createCourse(courseEntity: CourseEntity) {
+    entityManager.persist(courseEntity)
+  }
+
+  fun createOffering(offeringEntity: OfferingEntity) {
+    entityManager.persist(offeringEntity)
   }
 
   fun createCourse(courseId: UUID, identifier: String, name: String, description: String, altName: String, audience: String, withdrawn: Boolean = false, audienceColour: String = "light-blue", displayOnProgrammeDirectory: Boolean = true, intensity: String? = CourseIntensity.MODERATE.name) {
@@ -129,6 +142,10 @@ class PersistenceHelper {
       .setParameter("name", name)
       .setParameter("colour", colour)
       .executeUpdate()
+  }
+
+  fun createSexualOffenceDetails(sexualOffenceDetailsEntity: SexualOffenceDetailsEntity) {
+    entityManager.persist(sexualOffenceDetailsEntity)
   }
 
   fun createCourseVariant(id: UUID = UUID.randomUUID(), courseId: UUID, variantCourseId: UUID = UUID.randomUUID()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
@@ -319,10 +319,12 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
     )
 
     // When & Then
-    performRequestAndExpectStatusWithBody(HttpMethod.POST,
+    performRequestAndExpectStatusWithBody(
+      HttpMethod.POST,
       "/referral/hsp",
       body = hspReferralCreate,
-      expectedResponseStatus = HttpStatus.BAD_REQUEST.value())
+      expectedResponseStatus = HttpStatus.BAD_REQUEST.value(),
+    )
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/repository/ReferralRepositoryTest.kt
@@ -134,8 +134,8 @@ class ReferralRepositoryTest {
     // Then
     val referralEntity = entityManager.find(ReferralEntity::class.java, referral.id)
     referralEntity.eligibilityOverrideReasons.size shouldBe 1
-    referralEntity.eligibilityOverrideReasons[0].id shouldBe eligibilityOverrideReasonEntity.id
-    referralEntity.eligibilityOverrideReasons[0].reason shouldBe "Test override reason"
-    referralEntity.eligibilityOverrideReasons[0].overrideType shouldBe OverrideType.HEALTHY_SEX_PROGRAMME
+    referralEntity.eligibilityOverrideReasons.first().id shouldBe eligibilityOverrideReasonEntity.id
+    referralEntity.eligibilityOverrideReasons.first().reason shouldBe "Test override reason"
+    referralEntity.eligibilityOverrideReasons.first().overrideType shouldBe OverrideType.HEALTHY_SEX_PROGRAMME
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -33,8 +33,8 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REF
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRER_USERNAME
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomPrisonNumber
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.AuditAction
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.controller.ReferralController
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Referral
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toApi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.AuditService
@@ -87,7 +87,7 @@ constructor(
 
   @Test
   fun `createReferral with JWT, existing user, and valid payload returns 201 with correct body`() {
-    val referral: Referral = ReferralEntityFactory()
+    val referral: ReferralEntity = ReferralEntityFactory()
       .withOffering(
         OfferingEntityFactory()
           .withId(UUID.randomUUID())
@@ -99,15 +99,15 @@ constructor(
           .withUsername(REFERRER_USERNAME)
           .produce(),
       )
-      .produce().toApi()
+      .produce()
 
     val payload = mapOf(
-      "offeringId" to referral.offeringId,
+      "offeringId" to referral.offering.id,
       "prisonNumber" to referral.prisonNumber,
     )
 
-    every { referralService.getDuplicateReferrals(referral.prisonNumber, referral.offeringId) } returns null
-    every { referralService.createReferral(referral.prisonNumber, referral.offeringId) } returns referral
+    every { referralService.getDuplicateReferrals(referral.prisonNumber, referral.offering.id!!) } returns null
+    every { referralService.createReferral(referral.prisonNumber, referral.offering.id!!) } returns referral
 
     mockMvc.post("/referrals") {
       contentType = MediaType.APPLICATION_JSON
@@ -121,8 +121,8 @@ constructor(
       }
     }
 
-    verify { referralService.getDuplicateReferrals(referral.prisonNumber, referral.offeringId) }
-    verify { referralService.createReferral(referral.prisonNumber, referral.offeringId) }
+    verify { referralService.getDuplicateReferrals(referral.prisonNumber, referral.offering.id!!) }
+    verify { referralService.createReferral(referral.prisonNumber, referral.offering.id!!) }
   }
 
   @Test
@@ -150,7 +150,7 @@ constructor(
     )
 
     every { referralService.getDuplicateReferrals(any(), any()) } returns null
-    every { referralService.createReferral(any(), any()) } returns referral.toApi()
+    every { referralService.createReferral(any(), any()) } returns referral
 
     mockMvc.post("/referrals") {
       contentType = MediaType.APPLICATION_JSON

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -45,11 +45,14 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.r
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.update.ReferralUpdate
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.view.ReferralViewEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.view.ReferralViewRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.EligibilityOverrideReasonEntityRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OfferingRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OrganisationRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PersonRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferrerUserRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.SelectedSexualOffenceDetailsRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.SexualOffenceDetailsRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.PniScore
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusRefData
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusUpdate
@@ -76,7 +79,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.ent
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferrerUserEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.StaffEntityFactory
 import java.util.*
-import kotlin.String
 
 @ExtendWith(MockKExtension::class)
 class ReferralServiceTest {
@@ -143,6 +145,15 @@ class ReferralServiceTest {
 
   @MockK(relaxed = true)
   private lateinit var courseParticipationService: CourseParticipationService
+
+  @MockK(relaxed = true)
+  private lateinit var sexualOffenceDetailsRepository: SexualOffenceDetailsRepository
+
+  @MockK(relaxed = true)
+  private lateinit var eligibilityOverrideReasonEntityRepository: EligibilityOverrideReasonEntityRepository
+
+  @MockK(relaxed = true)
+  private lateinit var selectedSexualOffenceDetailsRepository: SelectedSexualOffenceDetailsRepository
 
   private var environment: String = "dev"
 
@@ -756,6 +767,9 @@ class ReferralServiceTest {
       courseParticipationService = courseParticipationService,
       referenceDataService = referralReferenceDataService,
       environment = "preprod",
+      sexualOffenceDetailsRepository = sexualOffenceDetailsRepository,
+      selectedSexualOffenceDetailsRepository = selectedSexualOffenceDetailsRepository,
+      eligibilityOverrideReasonEntityRepository = eligibilityOverrideReasonEntityRepository,
     )
 
     val exception = assertThrows<IllegalStateException> {


### PR DESCRIPTION
## Changes in this PR

- Implemented a new API endpoint to create Healthy Sex Programme (HSP) referrals, including handling selected offences and optional eligibility override reasons. 
- Updated repository, entity, and service layer logic to support storing and retrieving associated offence and override details.
-  Enhanced tests to validate the new functionality.


