### PR TITLE
[APG-923] Refactor gender handling to use centralised Gender enum.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OrganisationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OrganisationEntity.kt
@@ -2,8 +2,11 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.type.Gender
 import java.util.UUID
 
 @Entity
@@ -14,13 +17,13 @@ class OrganisationEntity(
   @Column(name = "organisation_id")
   var id: UUID? = null,
 
-  @Column
+  @Column(name = "code")
   var code: String,
 
-  @Column
+  @Column(name = "name")
   var name: String,
 
-  @Column
-  var gender: String,
-
+  @Enumerated(EnumType.STRING)
+  @Column(name = "gender")
+  var gender: Gender,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/Gender.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/Gender.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.type
+
+enum class Gender {
+  MALE,
+  FEMALE,
+  ANY,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/CourseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/CourseRepository.kt
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.type.Gender
 import java.util.UUID
 
 @Repository
@@ -40,7 +41,7 @@ interface CourseRepository : JpaRepository<CourseEntity, UUID> {
     AND org.gender = :gender
   """,
   )
-  fun findBuildingChoicesCourses(courseIds: List<UUID>, audience: String? = null, gender: String): List<CourseEntity>?
+  fun findBuildingChoicesCourses(courseIds: List<UUID>, audience: String? = null, gender: Gender): List<CourseEntity>?
 
   fun findAllByName(name: String): List<CourseEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/OrganisationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/OrganisationController.kt
@@ -108,7 +108,7 @@ class OrganisationController(
       Organisation(
         code = it.code,
         prisonName = it.name,
-        gender = it.gender,
+        gender = it.gender.name,
       ),
     )
   } ?: throw NotFoundException("No Organisation found at /organisation/$code")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/CourseOffering.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/CourseOffering.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.type.Gender
 import java.util.UUID
 
 /**
@@ -36,8 +37,3 @@ data class CourseOffering(
   @Schema(example = "M", description = "Gender for which course is offered")
   @get:JsonProperty("gender") val gender: Gender? = null,
 )
-
-enum class Gender {
-  MALE,
-  FEMALE,
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/RecordTransformers.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/RecordTransformers.kt
@@ -3,10 +3,10 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transf
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OfferingEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.PrerequisiteEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.type.Gender
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Course
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CourseOffering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CoursePrerequisite
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Gender
 
 fun CourseEntity.toApi(): Course = Course(
   id = id!!,
@@ -37,12 +37,12 @@ fun PrerequisiteEntity.toApi(): CoursePrerequisite = CoursePrerequisite(
   description = description,
 )
 
-fun OfferingEntity.toApi(genderForWhichCourseIsOffered: String): CourseOffering = CourseOffering(
+fun OfferingEntity.toApi(genderForWhichCourseIsOffered: Gender): CourseOffering = CourseOffering(
   id = id!!,
   organisationId = organisationId,
   contactEmail = contactEmail,
   secondaryContactEmail = secondaryContactEmail,
   referable = referable,
   withdrawn = withdrawn,
-  gender = Gender.valueOf(genderForWhichCourseIsOffered),
+  gender = genderForWhichCourseIsOffered,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/CourseService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.c
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OfferingEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OrganisationEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.PrerequisiteEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.type.Gender
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseVariantRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OfferingRepository
@@ -19,7 +20,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.C
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CourseOffering
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CoursePrerequisite
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CourseUpdateRequest
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Gender
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.addAudience
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toApi
 import java.util.UUID
@@ -152,7 +152,7 @@ constructor(
     offeringRepository.delete(existingOffering.id!!)
   }
 
-  fun findBuildingChoicesCourses(courseIds: List<UUID>, audience: String?, gender: String) = courseRepository.findBuildingChoicesCourses(courseIds, audience, gender)
+  fun findBuildingChoicesCourses(courseIds: List<UUID>, audience: String?, gender: Gender) = courseRepository.findBuildingChoicesCourses(courseIds, audience, gender)
   fun mapCourses(findBuildingChoicesCourses: List<CourseEntity>?, gender: Gender): List<Course>? = findBuildingChoicesCourses?.map {
     Course(
       id = it.id!!,
@@ -166,7 +166,7 @@ constructor(
       displayName = it.name + addAudience(it.name, it.audience),
       withdrawn = it.withdrawn,
       displayOnProgrammeDirectory = it.displayOnProgrammeDirectory,
-      courseOfferings = it.offerings.map { offeringEntity -> offeringEntity.toApi(gender.name) },
+      courseOfferings = it.offerings.map { offeringEntity -> offeringEntity.toApi(gender) },
     )
   }
 
@@ -233,7 +233,7 @@ constructor(
       findBuildingChoicesCourses(
         listOfBuildingCourseIds,
         audienceBasedOnGender,
-        genderToWhichCourseIsOffered.name,
+        genderToWhichCourseIsOffered,
       )
 
     return mapCourses(buildingChoicesCourses, genderToWhichCourseIsOffered)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OrganisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OrganisationService.kt
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonRegisterApi.model.Prison
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OrganisationEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.type.Gender
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OrganisationRepository
 import java.util.UUID
 
@@ -42,7 +43,7 @@ class OrganisationService(
               id = UUID.randomUUID(),
               code = it.prisonId,
               name = it.prisonName,
-              gender = gender,
+              gender = Gender.valueOf(gender),
             ),
           )
         } catch (e: Exception) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/CourseControllerIntegrationTest.kt
@@ -20,6 +20,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.type.Gender
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OfferingRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Audience
@@ -32,7 +33,6 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.C
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CoursePrerequisites
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CourseUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ErrorResponse
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Gender
 import java.time.LocalDateTime
 import java.util.Optional
 import java.util.UUID

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/OrganisationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/OrganisationEntityFactory.kt
@@ -2,18 +2,19 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.en
 
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomAlphanumericString
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.OrganisationEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.type.Gender
 import java.util.UUID
 
 class OrganisationEntityFactory {
   private var id: UUID = UUID.randomUUID()
   private var code: String = randomAlphanumericString()
   private var name: String = randomAlphanumericString()
-  private var gender: String = listOf("MALE", "FEMALE").asSequence().shuffled().first()
+  private var gender: Gender = Gender.entries.asSequence().shuffled().first()
 
   fun withId(id: UUID) = apply { this.id = id }
   fun withCode(code: String) = apply { this.code = code }
   fun withName(name: String) = apply { this.name = name }
-  fun withGender(gender: String) = apply { this.gender = gender }
+  fun withGender(gender: Gender) = apply { this.gender = gender }
 
   fun produce() = OrganisationEntity(
     id = this.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/transformer/RecordTransformersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/transformer/RecordTransformersTest.kt
@@ -4,8 +4,8 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.type.Gender
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.CoursePrerequisite
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Gender
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.transformer.toApi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.CourseEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OfferingEntityFactory
@@ -71,7 +71,7 @@ class RecordTransformersTest {
       .withSecondaryContactEmail("nobody-bwn2@digital.justice.gov.uk")
       .produce()
 
-    with(offering.toApi("MALE")) {
+    with(offering.toApi(Gender.MALE)) {
       id shouldBe offering.id
       organisationId shouldBe offering.organisationId
       contactEmail shouldBe offering.contactEmail

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/CourseServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/CourseServiceTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.BusinessException
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.type.Gender
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.view.CourseVariantEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseVariantRepository
@@ -255,7 +256,7 @@ class CourseServiceTest {
     every { organisationService.findOrganisationEntityByCode(any()) } returns OrganisationEntityFactory()
       .withCode(organisationId)
       .withName("Whatton")
-      .withGender("MALE").produce()
+      .withGender(Gender.MALE).produce()
     // When
     val recommendedBuildingChoicesCourse = courseService.getBuildingChoicesCourseForTransferringReferral(referral.id!!, "MODERATE_INTENSITY_BC")
 
@@ -295,7 +296,7 @@ class CourseServiceTest {
     every { courseRepository.findAllById(any()) } returns courseEntities
     every { organisationService.findOrganisationEntityByCode(any()) } returns OrganisationEntityFactory().withCode(
       organisationId,
-    ).withName("Whatton").withGender("MALE").produce()
+    ).withName("Whatton").withGender(Gender.MALE).produce()
     val recommendedBuildingChoicesCourse = courseService.getBuildingChoicesCourseForTransferringReferral(referral.id!!, "HIGH_INTENSITY_BC")
 
     recommendedBuildingChoicesCourse.id shouldBe courseId1


### PR DESCRIPTION
## Changes in this PR

- Moved the Gender enum to a dedicated package and replaces the String-based gender representation across the codebase. It ensures consistency, improves type safety, and reduces duplication by centralising gender logic in the shared `Gender` enum.
- Added the "ANY" gender type in lieu of incoming nationwide location refactoring
