### PR TITLE
[APG-923] Add `is_national` column to organisation and national HSP offering data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OrganisationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/create/OrganisationEntity.kt
@@ -26,4 +26,7 @@ class OrganisationEntity(
   @Enumerated(EnumType.STRING)
   @Column(name = "gender")
   var gender: Gender,
+
+  @Column(name = "is_national")
+  var isNational: Boolean? = null,
 )

--- a/src/main/resources/db/migration/V135__add_is_national_column_to_organisation.sql
+++ b/src/main/resources/db/migration/V135__add_is_national_column_to_organisation.sql
@@ -1,0 +1,2 @@
+ALTER TABLE organisation
+ADD COLUMN is_national BOOLEAN DEFAULT NULL;

--- a/src/main/resources/db/migration/V136__add_national_organisation_and_hsp_offering.sql
+++ b/src/main/resources/db/migration/V136__add_national_organisation_and_hsp_offering.sql
@@ -1,0 +1,22 @@
+-- Add a new national UK wide organisation
+INSERT INTO ORGANISATION (organisation_id, code, name, gender, is_national)
+SELECT '814dbc8a-cab6-4ba8-a210-cb8e8f7a4484', 'NAT', 'United Kingdom', 'ANY', true
+WHERE NOT EXISTS (SELECT 1
+                  FROM ORGANISATION
+                  WHERE code = 'NAT');
+
+-- Add a new offering for the HSP-SO course linked to the national organisation
+INSERT INTO offering (offering_id, course_id, organisation_id, contact_email, secondary_contact_email,
+                      withdrawn, referable, version)
+SELECT '06d6d856-dd50-4ce0-a25f-cafc8c37c79b',
+       (SELECT course_id FROM course where identifier = 'HSP-SO'),
+       'NAT',
+       'NationalHSP@justice.gov.uk',
+       null,
+       false,
+       false,
+       0
+WHERE NOT EXISTS (SELECT 1
+                  FROM offering
+                  WHERE course_id = (SELECT course_id FROM course where identifier = 'HSP-SO')
+                    AND organisation_id = 'NAT');


### PR DESCRIPTION
## Changes in this PR

- Update the `OrganisationEntity` class to include the new `isNational` field.
- Introduce a nullable `is_national` column to the `organisation` table in the database schema. 
- Added a national organisation representing the UK and link it to the offering for the HSP-SO course. 
