### PR TITLE
[APG-923] Enable referable flag for national HSP offering.

### DIFF
--- a/src/main/resources/db/migration/V138__update_national_hsp_offering_enable_referable.sql
+++ b/src/main/resources/db/migration/V138__update_national_hsp_offering_enable_referable.sql
@@ -1,0 +1,1 @@
+update offering set referable = true where organisation_id = 'NAT';


### PR DESCRIPTION
## Changes in this PR

This migration sets the `referable` flag to true for the offering associated with the national organisation ID (`NAT`). 

