### PR TITLE
[APG-924] Add support for new sentence category combinations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryType.kt
@@ -18,6 +18,8 @@ enum class SentenceCategoryType(val description: String) {
       sentenceCategoryList.containsAll(listOf(DETERMINATE, INDETERMINATE)) -> DETERMINATE_INDETERMINATE
       sentenceCategoryList.containsAll(listOf(DETERMINATE_RECALL, INDETERMINATE)) -> DETERMINATE_INDETERMINATE_RECALL
       sentenceCategoryList.containsAll(listOf(DETERMINATE, INDETERMINATE_RECALL)) -> DETERMINATE_INDETERMINATE_RECALL
+      sentenceCategoryList.containsAll(listOf(DETERMINATE, RECALL)) -> DETERMINATE_RECALL
+      sentenceCategoryList.containsAll(listOf(INDETERMINATE, RECALL)) -> INDETERMINATE_RECALL
       sentenceCategoryList.contains(DETERMINATE_RECALL) -> DETERMINATE_RECALL
       sentenceCategoryList.contains(INDETERMINATE_RECALL) -> INDETERMINATE_RECALL
       sentenceCategoryList.contains(DETERMINATE) -> DETERMINATE

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryTypeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/entity/referencedata/type/SentenceCategoryTypeTest.kt
@@ -78,17 +78,25 @@ class SentenceCategoryTypeTest {
   }
 
   @Test
-  fun `Should return INDETERMINATE if all other sentence categories are UNKNOWN or RECALL`() {
+  fun `Should return INDETERMINATE_RECALL if all other sentence categories are UNKNOWN or RECALL`() {
     // Given
     val list = listOf(SentenceCategoryType.INDETERMINATE, SentenceCategoryType.UNKNOWN, SentenceCategoryType.RECALL)
     // When & Then
-    assertThat(SentenceCategoryType.determineOverallCategory(list)).isEqualTo(SentenceCategoryType.INDETERMINATE)
+    assertThat(SentenceCategoryType.determineOverallCategory(list)).isEqualTo(SentenceCategoryType.INDETERMINATE_RECALL)
   }
 
   @Test
   fun `Should return DETERMINATE_RECALL if it's the only category in the list`() {
     // Given
     val list = listOf(SentenceCategoryType.DETERMINATE_RECALL)
+    // When & Then
+    assertThat(SentenceCategoryType.determineOverallCategory(list)).isEqualTo(SentenceCategoryType.DETERMINATE_RECALL)
+  }
+
+  @Test
+  fun `Should return DETERMINATE_RECALL if it's the list contains both RECALL and DETERMINATE sentence categories`() {
+    // Given
+    val list = listOf(SentenceCategoryType.DETERMINATE, SentenceCategoryType.RECALL)
     // When & Then
     assertThat(SentenceCategoryType.determineOverallCategory(list)).isEqualTo(SentenceCategoryType.DETERMINATE_RECALL)
   }


### PR DESCRIPTION
## Changes in this PR

- Updated logic to handle combinations of DETERMINATE and RECALL, as well as INDETERMINATE and RECALL. 
- Enhanced corresponding unit tests to validate new scenarios and ensure consistent behaviour.
