### PR TITLE
Update data extractor to latest

### DIFF
--- a/helm_deploy/hmpps-accredited-programmes-api/templates/cronjob-data-extractor-analytics.yaml
+++ b/helm_deploy/hmpps-accredited-programmes-api/templates/cronjob-data-extractor-analytics.yaml
@@ -12,7 +12,7 @@ spec:
           restartPolicy: "Never"
           containers:
             - name: data-extractor-analytics
-              image: ministryofjustice/data-engineering-data-extractor:v1
+              image: ministryofjustice/data-engineering-data-extractor:sha-b84888b
               imagePullPolicy: Always
               args: [ "extract_psql_all_tables_to_csv.sh && transfer_local_to_s3.sh" ]
               resources:


### PR DESCRIPTION
## Context
We had a critical alert from dependabot in the data extractor repository which required us to bump a few dependencies and create a new release. This PR bumps the data extractor to the latest release. We've tested this with the calculate-release-dates service and it worked without issue. Hope this is ok - happy to discuss. Thanks!

## Changes in this PR
Data extractor version bump

## Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released once merged.

### Pre-merge

- [ ] There are changes required to the Accredited Programmes UI for this change to work...
  - [ ] ... and they been released to production already

### Post-merge

- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-preprod-environment) release to preprod
- [ ] [Manually approve](../doc/how-to/perform-a-release.md#releasing-to-the-production-environment) release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/projects/hmpps-accredited-programmes-api/?project=4505330122686464&referrer=sidebar&statsPeriod=24h). -->
