### PR TITLE
[APG-944] Handle nullable scores in PNI models and tests

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/ScoredAnswer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/ScoredAnswer.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model
 
 interface ScoredAnswer {
-  val score: Int
+  val score: Int?
 
-  enum class YesNo(override val score: Int) : ScoredAnswer {
+  enum class YesNo(override val score: Int?) : ScoredAnswer {
     YES(2),
     NO(0),
-    Unknown(0),
+    Unknown(null),
     ;
 
     companion object {
@@ -14,11 +14,11 @@ interface ScoredAnswer {
     }
   }
 
-  enum class Problem(override val score: Int) : ScoredAnswer {
+  enum class Problem(override val score: Int?) : ScoredAnswer {
     NONE(0),
     SOME(1),
     SIGNIFICANT(2),
-    MISSING(0),
+    MISSING(null),
     ;
 
     companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PNIControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PNIControllerIntegrationTest.kt
@@ -77,7 +77,7 @@ class PNIControllerIntegrationTest : IntegrationTestBase() {
           individualSexScores = IndividualSexScores(
             sexualPreOccupation = 2,
             offenceRelatedSexualInterests = 1,
-            emotionalCongruence = 1,
+            emotionalCongruence = null,
           ),
         ),
         thinkingDomainScore = ThinkingDomainScore(
@@ -102,7 +102,7 @@ class PNIControllerIntegrationTest : IntegrationTestBase() {
             impulsivity = 0,
             temperControl = 2,
             problemSolvingSkills = 0,
-            difficultiesCoping = 0,
+            difficultiesCoping = null,
           ),
         ),
       ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniServiceIntegrationTest.kt
@@ -94,7 +94,7 @@ class PniServiceIntegrationTest : IntegrationTestBase() {
           individualSexScores = IndividualSexScores(
             sexualPreOccupation = 2,
             offenceRelatedSexualInterests = 1,
-            emotionalCongruence = 1,
+            emotionalCongruence = null,
           ),
         ),
         thinkingDomainScore = ThinkingDomainScore(
@@ -119,7 +119,7 @@ class PniServiceIntegrationTest : IntegrationTestBase() {
             impulsivity = 0,
             temperControl = 2,
             problemSolvingSkills = 0,
-            difficultiesCoping = 0,
+            difficultiesCoping = null,
           ),
         ),
       ),

--- a/src/test/resources/simulations/__files/oasys-pni-response-success.json
+++ b/src/test/resources/simulations/__files/oasys-pni-response-success.json
@@ -46,7 +46,7 @@
       "openSexualOffendingQuestions" : "NO",
       "sexualPreOccupation" : "SIGNIFICANT",
       "offenceRelatedSexualInterests" : "SOME",
-      "emotionalCongruence" : "SOME",
+      "emotionalCongruence" : "MISSING",
       "proCriminalAttitudes" : "SOME",
       "hostileOrientation" : "SOME",
       "relCloseFamily" : "NONE",


### PR DESCRIPTION
## Changes in this PR

-  `getPniInfoByPrisonNumber` API endpoint returns null values when values are missing rather than zero which represents no issues present for a particular risk or need.