### PR TITLE
[APG-896] Update offence score for possession of indecent images under 18s and fix related test

### DIFF
--- a/src/main/resources/db/migration/V141__update_sexual_offence_details.sql
+++ b/src/main/resources/db/migration/V141__update_sexual_offence_details.sql
@@ -1,0 +1,1 @@
+UPDATE sexual_offence_details set score = 1 where description = 'Possessing indecent images of under-18s';

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferenceDataControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferenceDataControllerIntegrationTest.kt
@@ -238,7 +238,7 @@ class ReferenceDataControllerIntegrationTest : IntegrationTestBase() {
 
     response.filter { it.categoryCode == SexualOffenceCategoryType.AGAINST_MINORS }.size.shouldBeEqual(6)
     assertThat(response.filter { it.categoryCode == SexualOffenceCategoryType.AGAINST_MINORS }).allMatch { it.categoryDescription == "Sexual offence against somebody aged under 18" }
-    response.filter { it.categoryCode == SexualOffenceCategoryType.AGAINST_MINORS && it.id == UUID.fromString("f5afed62-0747-432e-97b4-19b255e72b52") }.getOrNull(0)?.score?.shouldBeEqual(3)
+    response.filter { it.categoryCode == SexualOffenceCategoryType.AGAINST_MINORS && it.id == UUID.fromString("f5afed62-0747-432e-97b4-19b255e72b52") }.getOrNull(0)?.score?.shouldBeEqual(1)
 
     response.filter { it.categoryCode == SexualOffenceCategoryType.INCLUDES_VIOLENCE_FORCE_HUMILIATION }.size.shouldBeEqual(11)
     assertThat(response.filter { it.categoryCode == SexualOffenceCategoryType.INCLUDES_VIOLENCE_FORCE_HUMILIATION }).allMatch { it.categoryDescription == "Sexual offences that include violence, force or humiliation" }


### PR DESCRIPTION
## Changes in this PR

- Correct the offence score for possession of indecent images under 18s
- Updates to associated integration test
