### PR TITLE
Upgrade Testcontainers to version 2.0.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,10 +58,10 @@ dependencies {
 
   testImplementation("org.awaitility:awaitility-kotlin")
 
-  testImplementation("org.testcontainers:testcontainers:2.0.3")
-  testImplementation("org.testcontainers:postgresql:1.21.4")
-  testImplementation("org.testcontainers:localstack:1.21.4")
-  testImplementation("org.testcontainers:junit-jupiter:1.21.4")
+  testImplementation("org.testcontainers:testcontainers:2.0.4")
+  testImplementation("org.testcontainers:testcontainers-postgresql:2.0.4")
+  testImplementation("org.testcontainers:testcontainers-localstack:2.0.4")
+  testImplementation("org.testcontainers:testcontainers-junit-jupiter:2.0.4")
   testImplementation("org.jetbrains.kotlin:kotlin-test")
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/IntegrationTestBase.kt
@@ -99,7 +99,7 @@ abstract class IntegrationTestBase {
 
     @JvmStatic
     private val localStackContainer: LocalStackContainer =
-      LocalStackContainer(DockerImageName.parse("localstack/localstack"))
+      LocalStackContainer(DockerImageName.parse("localstack/localstack:3.8.1"))
         .apply {
           withEnv("DEFAULT_REGION", "eu-west-2")
           withServices(Service.SNS, Service.SQS)


### PR DESCRIPTION

## Changes in this PR

- Upgraded Testcontainers dependencies to version 2.0.4 to ensure compatibility and improved stability.

