### PR TITLE
Pin GitHub Actions dependencies to specific commit SHAs

### DIFF
--- a/.github/workflows/branch-name-validator.yml
+++ b/.github/workflows/branch-name-validator.yml
@@ -6,8 +6,8 @@ jobs:
   check-jira-prefix:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: deepakputhraya/action-branch-name@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: deepakputhraya/action-branch-name@e0f8db53a8e289f1ae6f6c3e8dc70a3d366fd876
         with:
           regex: '^(no-ticket/|renovate[-/]|hotfix/|FRI-[0-9]+/|APG-[0-9]+/)' # start branch with either 'no-ticket/' or 'FRI-NUMBER/' or 'APG-NUMBER/', allowing for bots and hotfixes
           ignore: main

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       # Temporarily disabled due to Kotlin version incompatibility
       # The gradle-spring-boot plugin 9.3.0 requires Kotlin 2.2.21+
@@ -31,13 +31,13 @@ jobs:
       # Re-enable once CodeQL adds support for newer Kotlin versions
       - name: Initialize CodeQL
         if: false
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@f94817b9f0deeb3871261446912ae8f854d1b675
         with:
           languages: 'java'
           # Use only 'java' to analyze code written in Java, Kotlin or both
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: 'temurin'
           java-version: 21
@@ -52,6 +52,6 @@ jobs:
       # Temporarily disabled due to Kotlin version incompatibility
       - name: Perform CodeQL Analysis
         if: false
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@f94817b9f0deeb3871261446912ae8f854d1b675
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Block fixup and squash commits
-        uses: 13rac1/block-fixup-merge-action@v2.0.0
+        uses: 13rac1/block-fixup-merge-action@bd5504fb9ca0253e109d98eb86b7debc01970cdc

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - id: app_version
         name: Application version creators
-        uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/create_app_version@v2 # WORKFLOW_VERSION
+        uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/create_app_version@d79e83be2cc392b981dd92c8f6f85007d18032e9
   gradle_verify:
     name: Validate the kotlin
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/gradle_verify.yml@v2 # WORKFLOW_VERSION

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Get PR information
         id: pr-info
         run: |


### PR DESCRIPTION

## Changes in this PR

- Updated GitHub Actions configurations to pin dependencies to specific commit SHAs, ensuring improved stability and reproducibility.

