### PR TITLE
Replace create_app_version action with hmpps-github-shared-actions v1

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - id: app_version
         name: Application version creators
-        uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/create_app_version@d79e83be2cc392b981dd92c8f6f85007d18032e9
+        uses: ministryofjustice/hmpps-github-shared-actions/.github/actions/build-test-and-deploy/create_app_version@f52dbae537425d92f2216c4a2d9e0e44e603abb1 #v1
   gradle_verify:
     name: Validate the kotlin
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/gradle_verify.yml@v2 # WORKFLOW_VERSION


### PR DESCRIPTION
## What
Replaces old `create_app_version` action references in `pipeline.yml` with:
- `ministryofjustice/hmpps-github-shared-actions/.github/actions/build-test-and-deploy/create_app_version@f52dbae537425d92f2216c4a2d9e0e44e603abb1 #v1`

## Why
The shared actions have moved repository.

## Notes
- Only updates `.github/workflows/pipeline.yml`
- Converts any existing ref/hash/version for `create_app_version`