### PR TITLE
Add fields for Subject Access Request and refactor test data factories

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,6 +18,8 @@ on:
 permissions:
   contents: read
   packages: write
+  actions: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/AuditRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/AuditRepository.kt
@@ -1,9 +1,22 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.AuditEntity
 import java.util.UUID
 
 @Repository
-interface AuditRepository : JpaRepository<AuditEntity, UUID>
+interface AuditRepository : JpaRepository<AuditEntity, UUID> {
+  @Query(
+    """
+    SELECT a 
+    FROM AuditEntity a
+    WHERE a.prisonNumber = :prisonerNumber
+    """,
+  )
+  fun getSarAuditRecords(
+    @Param("prisonerNumber") prisonerNumber: String,
+  ): List<AuditEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/CourseRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/CourseRepository.kt
@@ -43,5 +43,15 @@ interface CourseRepository : JpaRepository<CourseEntity, UUID> {
   )
   fun findBuildingChoicesCourses(courseIds: List<UUID>, audience: String? = null, gender: Gender): List<CourseEntity>?
 
+  @Query(
+    """
+    SELECT DISTINCT c FROM CourseEntity c
+    JOIN FETCH c.offerings o
+    JOIN ReferralEntity r ON r.offering.id = o.id
+    WHERE r.prisonNumber = :prisonNumber
+  """,
+  )
+  fun getSarCourses(prisonNumber: String): List<CourseEntity>
+
   fun findAllByName(name: String): List<CourseEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/PniResultRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/PniResultRepository.kt
@@ -6,7 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.v
 import java.util.*
 
 @Repository
-interface PNIResultEntityRepository : JpaRepository<PniResultEntity, UUID> {
+interface PniResultRepository : JpaRepository<PniResultEntity, UUID> {
   fun findAllByPrisonNumber(prisonNumber: String): List<PniResultEntity>
 
   fun findByReferralIdAndPrisonNumber(referralId: UUID, prisonNumber: String): PniResultEntity?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralStatusHistoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralStatusHistoryRepository.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.reposit
 
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralStatusHistoryEntity
 import java.util.UUID
@@ -13,4 +14,15 @@ interface ReferralStatusHistoryRepository : JpaRepository<ReferralStatusHistoryE
   fun getAllByReferralIdOrderByStatusStartDateDesc(referralId: UUID): List<ReferralStatusHistoryEntity>
 
   fun deleteAllByReferralIdIsIn(referralIds: List<UUID>)
+
+  @EntityGraph(attributePaths = ["previousStatus", "status", "category", "reason"])
+  @Query(
+    """
+    SELECT rsh FROM ReferralStatusHistoryEntity rsh
+    JOIN ReferralEntity r ON rsh.referralId = r.id
+    WHERE r.prisonNumber = :prisonNumber
+    ORDER BY rsh.statusStartDate DESC
+    """,
+  )
+  fun findByPrisonNumber(prisonNumber: String): List<ReferralStatusHistoryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/StaffRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/StaffRepository.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.StaffEntity
 import java.math.BigInteger
@@ -10,4 +11,13 @@ import java.util.UUID
 interface StaffRepository : JpaRepository<StaffEntity, UUID> {
 
   fun findByStaffId(staffId: BigInteger): StaffEntity?
+
+  @Query(
+    """
+    SELECT DISTINCT s FROM StaffEntity s 
+    JOIN ReferralEntity r ON s.staffId = r.primaryPomStaffId OR s.staffId = r.secondaryPomStaffId 
+    WHERE r.prisonNumber = :prisonNumber
+  """,
+  )
+  fun findByPrisonNumber(prisonNumber: String): List<StaffEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/OasysTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/transformer/OasysTransformer.kt
@@ -44,7 +44,8 @@ fun OasysOffenceDetail.toModel() = OffenceDetail(
   peerGroupInfluences = peerGroupInfluences,
   motivationAndTriggers = offenceMotivation,
   acceptsResponsibility = acceptsResponsibilityYesNo == YES,
-  acceptsResponsibilityDetail = patternOffending,
+  acceptsResponsibilityDetail = acceptsResponsibility,
+  patternOffending = patternOffending,
 )
 
 fun OasysRelationships.toModel() = Relationships(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniService.kt
@@ -20,7 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exceptio
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.AuditAction
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.view.PniResultEntity
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PNIResultEntityRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PniResultRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PniRuleRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.DomainScore
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualCognitiveScores
@@ -49,7 +49,7 @@ class PniService(
   private val pniNeedsEngine: PniNeedsEngine,
   private val pniRiskEngine: PniRiskEngine,
   private val pniRuleRepository: PniRuleRepository,
-  private val pniResultEntityRepository: PNIResultEntityRepository,
+  private val pniResultRepository: PniResultRepository,
   private val personService: PersonService,
   private val objectMapper: ObjectMapper,
 ) {
@@ -67,7 +67,7 @@ class PniService(
     val completedAssessment = oasysService.getLatestCompletedLayerThreeAssessment(oasysAssessmentTimeline)
       ?: throw NotFoundException("No completed assessments found for $pniScore.prisonNumber")
 
-    pniResultEntityRepository.save(buildEntity(pniScore, completedAssessment, referralId))
+    pniResultRepository.save(buildEntity(pniScore, completedAssessment, referralId))
   }
 
   fun getOasysPniScore(prisonNumber: String): PniScore {
@@ -179,7 +179,7 @@ class PniService(
     )
 
     if (savePni) {
-      pniResultEntityRepository.save(buildEntity(pniScore, completedAssessment, referralId))
+      pniResultRepository.save(buildEntity(pniScore, completedAssessment, referralId))
     }
     return pniScore
   }
@@ -336,7 +336,7 @@ class PniService(
   )
 
   fun deletePniData(referralIds: List<UUID>) {
-    pniResultEntityRepository.deleteAllById(referralIds)
+    pniResultRepository.deleteAllById(referralIds)
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestService.kt
@@ -2,12 +2,23 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.AuditEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralStatusHistoryEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.StaffEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.view.PniResultEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.AuditRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseParticipationRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PniResultRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralStatusHistoryRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StaffRepository
 import uk.gov.justice.hmpps.kotlin.sar.HmppsPrisonSubjectAccessRequestService
 import uk.gov.justice.hmpps.kotlin.sar.HmppsSubjectAccessRequestContent
+import java.math.BigInteger
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
@@ -15,29 +26,45 @@ import java.util.*
 @Service
 @Transactional
 class SubjectAccessRequestService(
-  private val repository: ReferralRepository,
+  private val referralRepository: ReferralRepository,
   private val courseParticipationRepository: CourseParticipationRepository,
+  private val auditRepository: AuditRepository,
+  private val courseRepository: CourseRepository,
+  private val pniResultRepository: PniResultRepository,
+  private val referralStatusHistoryRepository: ReferralStatusHistoryRepository,
+  private val staffRepository: StaffRepository,
+
 ) : HmppsPrisonSubjectAccessRequestService {
 
-  override fun getPrisonContentFor(prn: String, fromDate: LocalDate?, toDate: LocalDate?): uk.gov.justice.hmpps.kotlin.sar.HmppsSubjectAccessRequestContent? = HmppsSubjectAccessRequestContent(
+  override fun getPrisonContentFor(prn: String, fromDate: LocalDate?, toDate: LocalDate?): HmppsSubjectAccessRequestContent? = HmppsSubjectAccessRequestContent(
     content = Content(
-      repository.getSarReferrals(prn).filter { referral ->
+      referralRepository.getSarReferrals(prn).filter { referral ->
         val afterFromDate = fromDate?.let { referral.submittedOn?.isAfter(it.atStartOfDay()) } ?: true
         val beforeToDate = toDate?.let { referral.submittedOn?.isBefore(it.plusDays(1).atStartOfDay()) } ?: true
         afterFromDate && beforeToDate
       }.toSarReferral(),
-      courseParticipationRepository.getSarParticipations(prn).filter { referral ->
-        val afterFromDate = fromDate?.let { referral.createdDateTime.isAfter(it.atStartOfDay()) } ?: true
-        val beforeToDate = toDate?.let { referral.createdDateTime.isBefore(it.plusDays(1).atStartOfDay()) } ?: true
+      courseParticipationRepository.getSarParticipations(prn).filter { courseParticipation ->
+        val afterFromDate = fromDate?.let { courseParticipation.createdDateTime.isAfter(it.atStartOfDay()) } ?: true
+        val beforeToDate = toDate?.let { courseParticipation.createdDateTime.isBefore(it.plusDays(1).atStartOfDay()) } ?: true
         afterFromDate && beforeToDate
-      }
-        .toSarParticipation(),
+      }.toSarParticipation(),
+      auditRepository.getSarAuditRecords(prn).toSarAudit(),
+      courseRepository.getSarCourses(prn).toSarCourse(),
+      pniResultRepository.findAllByPrisonNumber(prn).toSarPniResult(),
+      referralStatusHistoryRepository.findByPrisonNumber(prn).toSarReferralStatusHistory(),
+      staffRepository.findByPrisonNumber(prn).toSarStaff(),
     ),
+
   )
 
   data class Content(
     val referrals: List<SarReferral>,
     val courseParticipation: List<SarCourseParticipation>,
+    val auditRecords: List<SarAuditRecord>,
+    val courses: List<SarCourse>,
+    val pniResults: List<SarPniResult>,
+    val referralStatusHistory: List<SarReferralStatusHistoryEntity>,
+    val staff: List<SarStaff>,
   )
 
   data class SarReferral(
@@ -53,10 +80,14 @@ class SubjectAccessRequestService(
     val audience: String?,
     val courseOrganisation: String?,
     val originalReferralId: UUID?,
+    val deleted: Boolean,
+    val version: Long,
   )
 
   data class SarCourseParticipation(
     val prisonNumber: String,
+    val referralId: UUID?,
+    val isDraft: Boolean?,
     val yearStarted: Int?,
     val source: String?,
     val type: String?,
@@ -71,9 +102,41 @@ class SubjectAccessRequestService(
     val updatedDateTime: LocalDateTime?,
   )
 
+  data class SarAuditRecord(
+    val referrerUsername: String?,
+    val auditUsername: String,
+  )
+
+  data class SarCourse(
+    val description: String?,
+    val alternateName: String?,
+    val audience: String,
+    val listDisplayName: String?,
+    val intensity: String?,
+  )
+
+  data class SarPniResult(
+    val pniResultJson: String?,
+  )
+
+  data class SarReferralStatusHistoryEntity(
+    val version: Long,
+  )
+
+  data class SarStaff(
+    val id: UUID?,
+    val staffId: BigInteger?,
+    val firstName: String,
+    val lastName: String,
+    val primaryEmail: String?,
+    val username: String,
+  )
+
   private fun List<CourseParticipationEntity>.toSarParticipation(): List<SarCourseParticipation> = map {
     SarCourseParticipation(
       prisonNumber = it.prisonNumber,
+      referralId = it.referralId,
+      isDraft = it.isDraft,
       source = it.source,
       type = it.setting?.type?.name,
       outcomeStatus = it.outcome?.status?.name,
@@ -103,6 +166,48 @@ class SubjectAccessRequestService(
       it.offering.course.audience,
       it.offering.organisationId,
       it.originalReferralId,
+      it.deleted,
+      it.version,
+    )
+  }
+
+  private fun List<AuditEntity>.toSarAudit(): List<SarAuditRecord> = map {
+    SarAuditRecord(
+      referrerUsername = it.referrerUsername,
+      auditUsername = it.auditUsername,
+    )
+  }
+
+  private fun List<CourseEntity>.toSarCourse(): List<SarCourse> = map {
+    SarCourse(
+      description = it.description,
+      alternateName = it.alternateName,
+      audience = it.audience,
+      listDisplayName = it.listDisplayName,
+      intensity = it.intensity,
+    )
+  }
+
+  private fun List<PniResultEntity>.toSarPniResult(): List<SarPniResult> = map {
+    SarPniResult(
+      pniResultJson = it.pniResultJson,
+    )
+  }
+
+  private fun List<ReferralStatusHistoryEntity>.toSarReferralStatusHistory(): List<SarReferralStatusHistoryEntity> = map {
+    SarReferralStatusHistoryEntity(
+      version = it.version,
+    )
+  }
+
+  private fun List<StaffEntity>.toSarStaff(): List<SarStaff> = map {
+    SarStaff(
+      id = it.id,
+      staffId = it.staffId,
+      username = it.username,
+      firstName = it.firstName,
+      lastName = it.lastName,
+      primaryEmail = it.primaryEmail,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/PersistenceHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/common/config/PersistenceHelper.kt
@@ -50,8 +50,8 @@ class PersistenceHelper {
     entityManager.persist(referralEntity)
   }
 
-  fun createCourse(courseId: UUID, identifier: String, name: String, description: String, altName: String, audience: String, withdrawn: Boolean = false, audienceColour: String = "light-blue", displayOnProgrammeDirectory: Boolean = true, intensity: String? = CourseIntensity.MODERATE.name) {
-    entityManager.createNativeQuery("INSERT INTO course (course_id, identifier, name, description, alternate_name, audience, withdrawn, audience_colour, display_on_programme_directory, intensity) VALUES (:id, :identifier, :name, :description, :altName, :audience, :withdrawn, :audienceColour, :display_on_programme_directory, :intensity)")
+  fun createCourse(courseId: UUID, identifier: String, name: String, description: String, altName: String, audience: String, withdrawn: Boolean = false, audienceColour: String = "light-blue", displayOnProgrammeDirectory: Boolean = true, intensity: String? = CourseIntensity.MODERATE.name, listDisplayName: String? = null) {
+    entityManager.createNativeQuery("INSERT INTO course (course_id, identifier, name, description, alternate_name, audience, withdrawn, audience_colour, display_on_programme_directory, intensity, list_display_name) VALUES (:id, :identifier, :name, :description, :altName, :audience, :withdrawn, :audienceColour, :display_on_programme_directory, :intensity, :list_display_name)")
       .setParameter("id", courseId)
       .setParameter("identifier", identifier)
       .setParameter("name", name)
@@ -62,6 +62,7 @@ class PersistenceHelper {
       .setParameter("audienceColour", audienceColour)
       .setParameter("display_on_programme_directory", displayOnProgrammeDirectory)
       .setParameter("intensity", intensity)
+      .setParameter("list_display_name", listDisplayName)
       .executeUpdate()
   }
 
@@ -178,6 +179,132 @@ class PersistenceHelper {
       .setParameter("username", username)
       .setParameter("primaryEmail", primaryEmail)
       .setParameter("accountType", accountType)
+      .executeUpdate()
+  }
+
+  fun createAuditRecord(
+    id: UUID = UUID.randomUUID(),
+    referralId: UUID? = null,
+    prisonNumber: String,
+    referrerUsername: String? = null,
+    referralStatusFrom: String? = null,
+    referralStatusTo: String? = null,
+    courseId: UUID? = null,
+    courseName: String? = null,
+    courseLocation: String? = null,
+    auditAction: String,
+    auditUsername: String,
+    auditDateTime: LocalDateTime = LocalDateTime.now(),
+  ) {
+    entityManager.createNativeQuery("INSERT INTO audit_record (audit_record_id, referral_id, prison_number, referrer_username, referral_status_from, referral_status_to, course_id, course_name, course_location, audit_action, audit_username, audit_date_time) VALUES (:id, :referralId, :prisonNumber, :referrerUsername, :referralStatusFrom, :referralStatusTo, :courseId, :courseName, :courseLocation, :auditAction, :auditUsername, :auditDateTime)")
+      .setParameter("id", id)
+      .setParameter("referralId", referralId)
+      .setParameter("prisonNumber", prisonNumber)
+      .setParameter("referrerUsername", referrerUsername)
+      .setParameter("referralStatusFrom", referralStatusFrom)
+      .setParameter("referralStatusTo", referralStatusTo)
+      .setParameter("courseId", courseId)
+      .setParameter("courseName", courseName)
+      .setParameter("courseLocation", courseLocation)
+      .setParameter("auditAction", auditAction)
+      .setParameter("auditUsername", auditUsername)
+      .setParameter("auditDateTime", auditDateTime)
+      .executeUpdate()
+  }
+
+  fun createPniResult(
+    pniResultId: UUID = UUID.randomUUID(),
+    prisonNumber: String,
+    crn: String? = null,
+    referralId: UUID? = null,
+    oasysAssessmentId: Long? = null,
+    oasysAssessmentCompletedDate: LocalDateTime? = null,
+    programmePathway: String? = null,
+    needsClassification: String? = null,
+    overallNeedsScore: Int? = null,
+    riskClassification: String? = null,
+    pniAssessmentDate: LocalDateTime? = null,
+    pniValid: Boolean = true,
+    pniResultJson: String? = null,
+    basicSkillsScore: Int? = null,
+  ) {
+    entityManager.createNativeQuery("INSERT INTO pni_result (pni_result_id, prison_number, crn, referral_id, oasys_assessment_id, oasys_assessment_completed_date, programme_pathway, needs_classification, overall_needs_score, risk_classification, pni_assessment_date, pni_valid, pni_result_json, basic_skills_score) VALUES (:id, :prisonNumber, :crn, :referralId, :oasysAssessmentId, :oasysAssessmentCompletedDate, :programmePathway, :needsClassification, :overallNeedsScore, :riskClassification, :pniAssessmentDate, :pniValid, :pniResultJson, :basicSkillsScore)")
+      .setParameter("id", pniResultId)
+      .setParameter("prisonNumber", prisonNumber)
+      .setParameter("crn", crn)
+      .setParameter("referralId", referralId)
+      .setParameter("oasysAssessmentId", oasysAssessmentId)
+      .setParameter("oasysAssessmentCompletedDate", oasysAssessmentCompletedDate)
+      .setParameter("programmePathway", programmePathway)
+      .setParameter("needsClassification", needsClassification)
+      .setParameter("overallNeedsScore", overallNeedsScore)
+      .setParameter("riskClassification", riskClassification)
+      .setParameter("pniAssessmentDate", pniAssessmentDate)
+      .setParameter("pniValid", pniValid)
+      .setParameter("pniResultJson", pniResultJson)
+      .setParameter("basicSkillsScore", basicSkillsScore)
+      .executeUpdate()
+  }
+
+  fun createReferralStatus(
+    code: String,
+    description: String,
+    hintText: String = "Hint",
+    colour: String = "light-blue",
+    hasNotes: Boolean = false,
+    hasConfirmation: Boolean = false,
+    confirmationText: String = "Confirmation",
+    active: Boolean = true,
+    draft: Boolean = false,
+    closed: Boolean = false,
+    hold: Boolean = false,
+    release: Boolean = false,
+    defaultOrder: Int = 1,
+    notesOptional: Boolean = true,
+    caseNotesSubtype: String = "REFERRAL",
+    caseNotesMessage: String = "Case notes",
+  ) {
+    entityManager.createNativeQuery("INSERT INTO referral_status (code, description, hint_text, colour, has_notes, has_confirmation, confirmation_text, active, draft, closed, hold, release, default_order, notes_optional, case_notes_subtype, case_notes_message) VALUES (:code, :description, :hintText, :colour, :hasNotes, :hasConfirmation, :confirmationText, :active, :draft, :closed, :hold, :release, :defaultOrder, :notesOptional, :caseNotesSubtype, :caseNotesMessage)")
+      .setParameter("code", code)
+      .setParameter("description", description)
+      .setParameter("hintText", hintText)
+      .setParameter("colour", colour)
+      .setParameter("hasNotes", hasNotes)
+      .setParameter("hasConfirmation", hasConfirmation)
+      .setParameter("confirmationText", confirmationText)
+      .setParameter("active", active)
+      .setParameter("draft", draft)
+      .setParameter("closed", closed)
+      .setParameter("hold", hold)
+      .setParameter("release", release)
+      .setParameter("defaultOrder", defaultOrder)
+      .setParameter("notesOptional", notesOptional)
+      .setParameter("caseNotesSubtype", caseNotesSubtype)
+      .setParameter("caseNotesMessage", caseNotesMessage)
+      .executeUpdate()
+  }
+
+  fun createReferralStatusHistory(
+    id: UUID = UUID.randomUUID(),
+    referralId: UUID,
+    statusStartDate: LocalDateTime = LocalDateTime.now(),
+    username: String,
+    status: String,
+    previousStatus: String? = null,
+    notes: String? = null,
+    statusEndDate: LocalDateTime? = null,
+    durationAtThisStatus: Long? = null,
+  ) {
+    entityManager.createNativeQuery("INSERT INTO referral_status_history (status_history_id, referral_id, status_start_date, username, status, previous_status, notes, status_end_date, duration_at_this_status) VALUES (:id, :referralId, :statusStartDate, :username, :status, :previousStatus, :notes, :statusEndDate, :durationAtThisStatus)")
+      .setParameter("id", id)
+      .setParameter("referralId", referralId)
+      .setParameter("statusStartDate", statusStartDate)
+      .setParameter("username", username)
+      .setParameter("status", status)
+      .setParameter("previousStatus", previousStatus)
+      .setParameter("notes", notes)
+      .setParameter("statusEndDate", statusEndDate)
+      .setParameter("durationAtThisStatus", durationAtThisStatus)
       .executeUpdate()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/OasysControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/OasysControllerIntegrationTest.kt
@@ -69,8 +69,8 @@ class OasysControllerIntegrationTest : IntegrationTestBase() {
       peerGroupInfluences = "No",
       motivationAndTriggers = "Mainly due to jealousy and fuelled by drug use",
       acceptsResponsibility = true,
-      acceptsResponsibilityDetail = "This has happened numerous times in the past",
-      patternOffending = null,
+      acceptsResponsibilityDetail = "he accepts that he is totally to blame",
+      patternOffending = "This has happened numerous times in the past",
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PNIControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PNIControllerIntegrationTest.kt
@@ -10,7 +10,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.expectBody
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PNIResultEntityRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PniResultRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.DomainScore
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualCognitiveScores
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualRelationshipScores
@@ -32,7 +32,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type.Sa
 @Import(JwtAuthHelper::class)
 class PNIControllerIntegrationTest : IntegrationTestBase() {
   @Autowired
-  lateinit var pniResultEntityRepository: PNIResultEntityRepository
+  lateinit var pniResultRepository: PniResultRepository
 
   @Test
   fun `Get pni info for prisoner successful`() {
@@ -136,7 +136,7 @@ class PNIControllerIntegrationTest : IntegrationTestBase() {
     // When
     getPniInfoByPrisonNumberAndSave(prisonNumber)
     // Then
-    val pniResults = pniResultEntityRepository.findAllByPrisonNumber(prisonNumber)
+    val pniResults = pniResultRepository.findAllByPrisonNumber(prisonNumber)
     pniResults[0].prisonNumber shouldBe prisonNumber
     val pniScore = buildPniScore(prisonNumber)
     pniResults[0].crn shouldBe pniScore.crn

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/ReferralControllerIntegrationTest.kt
@@ -60,8 +60,8 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.r
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.AuditRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseParticipationRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.OfferingRepository
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PNIResultEntityRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PersonRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PniResultRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralStatusHistoryRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StaffRepository
@@ -107,7 +107,7 @@ class ReferralControllerIntegrationTest : IntegrationTestBase() {
   lateinit var referralRepository: ReferralRepository
 
   @Autowired
-  lateinit var pniResultRepository: PNIResultEntityRepository
+  lateinit var pniResultRepository: PniResultRepository
 
   @Autowired
   lateinit var staffRepository: StaffRepository

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/SubjectAccessRequestServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/SubjectAccessRequestServiceIntegrationTest.kt
@@ -1,0 +1,149 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.AuditAction
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseSetting
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.SubjectAccessRequestService
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+class SubjectAccessRequestServiceIntegrationTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var subjectAccessRequestService: SubjectAccessRequestService
+
+  @Test
+  fun `should return all fields in SAR content`() {
+    // Given
+    val prisonNumber = "A1234BC"
+    val courseId = UUID.randomUUID()
+    val offeringId = UUID.randomUUID()
+    val referralId = UUID.randomUUID()
+    val participationId = UUID.randomUUID()
+    val staffId = 12345.toBigInteger()
+
+    persistenceHelper.clearAllTableContent()
+
+    persistenceHelper.createOrganisation(code = "MDI", name = "HMP Moorland")
+    persistenceHelper.createCourse(
+      courseId = courseId,
+      identifier = "C1",
+      name = "Course 1",
+      description = "Course 1 Description",
+      altName = "C1 Alt Name",
+      audience = "General",
+      intensity = "HIGH",
+      listDisplayName = "Course 1",
+    )
+    persistenceHelper.createOffering(
+      offeringId = offeringId,
+      courseId = courseId,
+      orgId = "MDI",
+      contactEmail = "test@example.com",
+      secondaryContactEmail = "test2@example.com",
+      referable = true,
+    )
+    persistenceHelper.createReferrerUser("TEST_USER")
+    persistenceHelper.createReferral(
+      referralId = referralId,
+      offeringId = offeringId,
+      prisonNumber = prisonNumber,
+      referrerUsername = "TEST_USER",
+      additionalInformation = "Some info",
+      oasysConfirmed = true,
+      hasReviewedProgrammeHistory = true,
+      status = "REFERRAL_STARTED",
+      submittedOn = LocalDateTime.now(),
+      primaryPomStaffId = staffId,
+    )
+    persistenceHelper.createCourseParticipation(
+      participationId = participationId,
+      referralId = referralId,
+      prisonNumber = prisonNumber,
+      courseName = "Course 1",
+      source = "Source",
+      detail = "Detail",
+      location = "Location",
+      type = CourseSetting.CUSTODY.name,
+      outcomeStatus = "INCOMPLETE",
+      yearStarted = 2023,
+      yearCompleted = 2024,
+      createdByUsername = "TEST_USER",
+      createdDateTime = LocalDateTime.now(),
+      lastModifiedByUsername = "TEST_USER",
+      lastModifiedDateTime = LocalDateTime.now(),
+    )
+    persistenceHelper.createAuditRecord(
+      prisonNumber = prisonNumber,
+      auditAction = AuditAction.CREATE_REFERRAL.name,
+      auditUsername = "TEST_USER",
+      referrerUsername = "TEST_USER",
+    )
+    persistenceHelper.createPniResult(
+      prisonNumber = prisonNumber,
+      pniResultJson = "{\"result\": \"success\"}",
+    )
+    persistenceHelper.createReferralStatusHistory(
+      referralId = referralId,
+      username = "TEST_USER",
+      status = "REFERRAL_STARTED",
+    )
+    persistenceHelper.createStaff(
+      staffId = 12345.toBigInteger(),
+      firstName = "John",
+      lastName = "Doe",
+      username = "JDOE",
+      primaryEmail = "john.doe@example.com",
+    )
+
+    // When
+    val result = subjectAccessRequestService.getPrisonContentFor(prisonNumber, LocalDate.now(), LocalDate.now().plusDays(1))
+
+    // Then
+    assertNotNull(result)
+    val content = result!!.content as SubjectAccessRequestService.Content
+    assertThat(content.referrals).hasSize(1)
+    assertThat(content.courseParticipation).hasSize(1)
+    assertThat(content.auditRecords).hasSize(1)
+    assertThat(content.courses).hasSize(1)
+    assertThat(content.pniResults).hasSize(1)
+    assertThat(content.referralStatusHistory).hasSize(1)
+    assertThat(content.staff).hasSize(1)
+
+    with(content.referrals[0]) {
+      assertThat(prisonerNumber).isEqualTo(prisonNumber)
+      assertThat(courseName).isEqualTo("Course 1")
+      assertThat(referrerUsername).isEqualTo("TEST_USER")
+    }
+
+    with(content.courseParticipation[0]) {
+      assertThat(prisonNumber).isEqualTo(prisonNumber)
+      assertThat(courseName).isEqualTo("Course 1")
+      assertThat(outcomeStatus).isEqualTo("INCOMPLETE")
+    }
+
+    with(content.auditRecords[0]) {
+      assertThat(auditUsername).isEqualTo("TEST_USER")
+      assertThat(referrerUsername).isEqualTo("TEST_USER")
+    }
+
+    with(content.courses[0]) {
+      assertThat(description).isEqualTo("Course 1 Description")
+      assertThat(listDisplayName).isEqualTo("Course 1")
+    }
+
+    with(content.pniResults[0]) {
+      assertThat(pniResultJson).isEqualTo("{\"result\": \"success\"}")
+    }
+
+    with(content.staff[0]) {
+      assertThat(firstName).isEqualTo("John")
+      assertThat(lastName).isEqualTo("Doe")
+      assertThat(username).isEqualTo("JDOE")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/OasysServiceTest.kt
@@ -47,7 +47,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisoner
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerAlertsApi.model.AlertsResponse
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.AlertFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.PniCalculationFactory
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.PniResponseFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.model.PniResponseFactory
 import java.time.LocalDateTime
 
 class OasysServiceTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniServiceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniServiceIntegrationTest.kt
@@ -13,7 +13,7 @@ import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Ldc
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.config.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.NotFoundException
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PNIResultEntityRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PniResultRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.DomainScore
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualCognitiveScores
@@ -27,7 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.S
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.SexDomainScore
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ThinkingDomainScore
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type.SaraRisk
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.PniResponseFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.model.PniResponseFactory
 import java.math.BigDecimal
 import java.util.UUID
 
@@ -40,7 +40,7 @@ class PniServiceIntegrationTest : IntegrationTestBase() {
   lateinit var pniService: PniService
 
   @Autowired
-  lateinit var pniResultEntityRepository: PNIResultEntityRepository
+  lateinit var pniResultRepository: PniResultRepository
 
   @Test
   fun `should throw NotFoundException when attempting to calculate PNI score for an unknown prisoner number`() {
@@ -191,7 +191,7 @@ class PniServiceIntegrationTest : IntegrationTestBase() {
     pniService.savePni(pniScore, referralId)
 
     // Then
-    val pniResults = pniResultEntityRepository.findAllByPrisonNumber(prisonNumber)
+    val pniResults = pniResultRepository.findAllByPrisonNumber(prisonNumber)
     assertThat(pniResults).hasSize(1)
     assertThat(pniResults[0].prisonNumber).isEqualTo(prisonNumber)
     assertThat(pniResults[0].crn).isEqualTo("D006518")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestServiceTest.kt
@@ -3,18 +3,28 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseParticipationSetting
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.CourseSetting
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferrerUserEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.AuditRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseParticipationRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.CourseRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PniResultRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.ReferralStatusHistoryRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StaffRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.AuditEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.CourseEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.CourseParticipationEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.CourseParticipationOutcomeFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OfferingEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.PniResultEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralStatusHistoryEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.StaffEntityFactory
+import java.math.BigInteger
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -24,11 +34,25 @@ class SubjectAccessRequestServiceTest {
 
   private val referralRepository: ReferralRepository = mockk()
   private val courseParticipationRepository: CourseParticipationRepository = mockk()
+  private val auditRepository: AuditRepository = mockk()
+  private val courseRepository: CourseRepository = mockk()
+  private val pniResultRepository: PniResultRepository = mockk()
+  private val referralStatusHistoryRepository: ReferralStatusHistoryRepository = mockk()
+  private val staffRepository: StaffRepository = mockk()
+
   private lateinit var service: SubjectAccessRequestService
 
   @BeforeEach
   fun setup() {
-    service = SubjectAccessRequestService(referralRepository, courseParticipationRepository)
+    service = SubjectAccessRequestService(
+      referralRepository,
+      courseParticipationRepository,
+      auditRepository,
+      courseRepository,
+      pniResultRepository,
+      referralStatusHistoryRepository,
+      staffRepository,
+    )
   }
 
   @Test
@@ -38,53 +62,116 @@ class SubjectAccessRequestServiceTest {
     val fromDate = LocalDate.of(2022, 1, 1)
     val toDate = LocalDate.of(2023, 1, 1)
 
-    val referralEntity = ReferralEntity(
-      prisonNumber = prn,
-      oasysConfirmed = true,
-      status = "COMPLETED",
-      hasReviewedProgrammeHistory = true,
-      additionalInformation = "Info",
-      submittedOn = LocalDateTime.of(2022, 6, 1, 10, 0),
-      referrerOverrideReason = "Override",
-      referrer = ReferrerUserEntity(username = "user1"),
-      offering = OfferingEntityFactory().withCourse(CourseEntityFactory().withName("Anger Management").produce()).produce(),
-      originalReferralId = UUID.randomUUID(),
-    )
+    val referralEntity = ReferralEntityFactory()
+      .withPrisonNumber(prn)
+      .withOasysConfirmed(true)
+      .withStatus("COMPLETED")
+      .withHasReviewedProgrammeHistory(true)
+      .withAdditionalInformation("Info")
+      .withSubmittedOn(LocalDateTime.of(2022, 6, 1, 10, 0))
+      .withReferrerOverrideReason("Override")
+      .withReferrer(ReferrerUserEntity(username = "user1"))
+      .withOffering(
+        OfferingEntityFactory().withCourse(CourseEntityFactory().withName("Anger Management").produce()).produce(),
+      )
+      .withOriginalReferralId(UUID.randomUUID())
+      .produce()
 
-    val participationEntity = CourseParticipationEntity(
-      prisonNumber = prn,
-      source = "SOURCE",
-      setting = CourseParticipationSetting("REMOTE", CourseSetting.COMMUNITY),
-      outcome = CourseParticipationOutcomeFactory().produce(),
-      detail = "Details",
-      courseName = "Drug Awareness",
-      createdByUsername = "creator",
-      createdDateTime = LocalDateTime.of(2022, 7, 1, 10, 0),
-      lastModifiedByUsername = "modifier",
-      lastModifiedDateTime = LocalDateTime.of(2022, 8, 1, 10, 0),
-    )
+    val participationEntity = CourseParticipationEntityFactory()
+      .withPrisonNumber(prn)
+      .withSource("SOURCE")
+      .withSetting(CourseParticipationSetting("REMOTE", CourseSetting.COMMUNITY))
+      .withOutcome(CourseParticipationOutcomeFactory().produce())
+      .withDetail("Details")
+      .withCourseName("Drug Awareness")
+      .withCreatedByUsername("creator")
+      .withCreatedDateTime(LocalDateTime.of(2022, 7, 1, 10, 0))
+      .withLastModifiedByUsername("modifier")
+      .withLastModifiedDateTime(LocalDateTime.of(2022, 8, 1, 10, 0))
+      .produce()
 
     every { referralRepository.getSarReferrals(prn) } returns listOf(referralEntity)
     every { courseParticipationRepository.getSarParticipations(prn) } returns listOf(participationEntity)
+    every { auditRepository.getSarAuditRecords(prn) } returns listOf(
+      AuditEntityFactory()
+        .withPrisonNumber(prn)
+        .withAuditUsername("user1")
+        .withReferrerUsername("user1")
+        .produce(),
+    )
+    every { courseRepository.getSarCourses(prn) } returns listOf(
+      CourseEntityFactory()
+        .withDescription("course description")
+        .withAudience("audience")
+        .withIntensity("High intensity")
+        .withAlternateName("Alternate name")
+        .withListDisplayName("Drug Awareness")
+        .produce(),
+    )
+
+    every { pniResultRepository.findAllByPrisonNumber(prn) } returns listOf(
+      PniResultEntityFactory()
+        .withPrisonNumber(prn)
+        .withPniResultJson("{ \"status\": \"accepted\",}")
+        .produce(),
+    )
+    every { referralStatusHistoryRepository.findByPrisonNumber(prn) } returns listOf(ReferralStatusHistoryEntityFactory().produce())
+    every { staffRepository.findByPrisonNumber(prn) } returns listOf(StaffEntityFactory().produce())
 
     // When
     val result = service.getPrisonContentFor(prn, fromDate, toDate)
 
     // Then
+    assertThat(result).isNotNull()
     with(result!!.content as SubjectAccessRequestService.Content) {
-      assertEquals(1, referrals.size)
-      assertEquals(1, courseParticipation.size)
+      assertThat(referrals.size).isEqualTo(1)
+      assertThat(courseParticipation.size).isEqualTo(1)
+      assertThat(auditRecords.size).isEqualTo(1)
+      assertThat(courses.size).isEqualTo(1)
+      assertThat(pniResults.size).isEqualTo(1)
+      assertThat(referralStatusHistory.size).isEqualTo(1)
+      assertThat(staff.size).isEqualTo(1)
 
       val referral = referrals[0]
-      assertEquals("Anger Management", referral.courseName)
-      assertEquals("user1", referral.referrerUsername)
+      assertThat(referral.courseName).isEqualTo("Anger Management")
+      assertThat(referral.referrerUsername).isEqualTo("user1")
 
       val participation = courseParticipation[0]
-      assertEquals("Drug Awareness", participation.courseName)
-      assertEquals("INCOMPLETE", participation.outcomeStatus)
+      assertThat(participation.courseName).isEqualTo("Drug Awareness")
+      assertThat(participation.outcomeStatus).isEqualTo("INCOMPLETE")
+
+      val audit = auditRecords[0]
+      assertThat(audit.auditUsername).isEqualTo("user1")
+      assertThat(audit.referrerUsername).isEqualTo("user1")
+
+      val course = courses[0]
+      assertThat(course.description).isEqualTo("course description")
+      assertThat(course.audience).isEqualTo("audience")
+      assertThat(course.intensity).isEqualTo("High intensity")
+      assertThat(course.alternateName).isEqualTo("Alternate name")
+      assertThat(course.listDisplayName).isEqualTo("Drug Awareness")
+
+      val pniResult = pniResults[0]
+      assertThat(pniResult.pniResultJson).isEqualTo("{ \"status\": \"accepted\",}")
+
+      val referralStatusHistory = referralStatusHistory[0]
+      assertThat(referralStatusHistory.version).isEqualTo(0)
+
+      val staff = this.staff[0]
+      assertThat(staff.id).isNotNull
+      assertThat(staff.staffId).isEqualTo(BigInteger("487505"))
+      assertThat(staff.username).isEqualTo("JDOE_ADM")
+      assertThat(staff.firstName).isEqualTo("John")
+      assertThat(staff.lastName).isEqualTo("Doe")
+      assertThat(staff.primaryEmail).isEqualTo("john.doe@email.com")
     }
 
     verify { referralRepository.getSarReferrals(prn) }
     verify { courseParticipationRepository.getSarParticipations(prn) }
+    verify { auditRepository.getSarAuditRecords(prn) }
+    verify { courseRepository.getSarCourses(prn) }
+    verify { pniResultRepository.findAllByPrisonNumber(prn) }
+    verify { referralStatusHistoryRepository.findByPrisonNumber(prn) }
+    verify { staffRepository.findByPrisonNumber(prn) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseEntityFactory.kt
@@ -24,6 +24,7 @@ class CourseEntityFactory {
   private var audienceColour: String = randomUppercaseString()
   private var withdrawn: Boolean = false
   private var intensity: String = CourseIntensity.values().random().name
+  private var listDisplayName: String = randomUppercaseString()
 
   fun withId(id: UUID?) = apply {
     this.id = id
@@ -65,6 +66,10 @@ class CourseEntityFactory {
     this.intensity = intensity
   }
 
+  fun withListDisplayName(listDisplayName: String) = apply {
+    this.listDisplayName = listDisplayName
+  }
+
   fun produce() = CourseEntity(
     id = this.id,
     name = this.name,
@@ -77,6 +82,7 @@ class CourseEntityFactory {
     audienceColour = this.audienceColour,
     withdrawn = this.withdrawn,
     intensity = this.intensity,
+    listDisplayName = this.listDisplayName,
   )
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseParticipationEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/CourseParticipationEntityFactory.kt
@@ -32,6 +32,8 @@ class CourseParticipationEntityFactory {
   fun withOutcome(outcome: CourseParticipationOutcome?) = apply { this.outcome = outcome }
   fun withCreatedByUsername(createdByUsername: String) = apply { this.createdByUsername = createdByUsername }
   fun withCreatedDateTime(createdDateTime: LocalDateTime) = apply { this.createdDateTime = createdDateTime }
+  fun withLastModifiedByUsername(lastModifiedByUsername: String?) = apply { this.lastModifiedByUsername = lastModifiedByUsername }
+  fun withLastModifiedDateTime(lastModifiedDateTime: LocalDateTime?) = apply { this.lastModifiedDateTime = lastModifiedDateTime }
 
   fun produce() = CourseParticipationEntity(
     id = this.id,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralEntityFactory.kt
@@ -20,6 +20,7 @@ class ReferralEntityFactory {
   private var referrerOverrideReason: String? = null
   private var hasLdc: Boolean = false
   private var hasLdcBeenOverwrittenByProgrammeTeam: Boolean = false
+  private var originalReferralId: UUID? = null
 
   fun withId(id: UUID?) = apply { this.id = id }
   fun withOffering(offering: OfferingEntity) = apply { this.offering = offering }
@@ -32,6 +33,8 @@ class ReferralEntityFactory {
   fun withReferrerOverrideReason(referrerOverrideReason: String?) = apply { this.referrerOverrideReason = referrerOverrideReason }
   fun withLdc(hasLdc: Boolean) = apply { this.hasLdc = hasLdc }
   fun withHasLdcBeenOverwrittenByProgrammeTeam(hasLdcBeenOverwrittenByProgrammeTeam: Boolean) = apply { this.hasLdcBeenOverwrittenByProgrammeTeam = hasLdcBeenOverwrittenByProgrammeTeam }
+  fun withSubmittedOn(submittedOn: LocalDateTime?) = apply { this.submittedOn = submittedOn }
+  fun withOriginalReferralId(originalReferralId: UUID?) = apply { this.originalReferralId = originalReferralId }
 
   fun produce() = ReferralEntity(
     id = this.id,
@@ -46,5 +49,6 @@ class ReferralEntityFactory {
     referrerOverrideReason = this.referrerOverrideReason,
     hasLdc = this.hasLdc,
     hasLdcBeenOverriddenByProgrammeTeam = this.hasLdcBeenOverwrittenByProgrammeTeam,
+    originalReferralId = this.originalReferralId,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralStatusEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralStatusEntityFactory.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory
+
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRAL_SUBMITTED
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRAL_SUBMITTED_COLOUR
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.REFERRAL_SUBMITTED_DESCRIPTION
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusEntity
+
+class ReferralStatusEntityFactory {
+  private var code: String = REFERRAL_SUBMITTED
+  private var description: String = REFERRAL_SUBMITTED_DESCRIPTION
+  private var hintText: String = "Hint"
+  private var colour: String = REFERRAL_SUBMITTED_COLOUR
+  private var hasNotes: Boolean = false
+  private var hasConfirmation: Boolean = false
+  private var confirmationText: String = "Confirmation"
+  private var active: Boolean = true
+  private var draft: Boolean = false
+  private var closed: Boolean = false
+  private var hold: Boolean = false
+  private var release: Boolean = false
+  private var defaultOrder: Int = 1
+  private var notesOptional: Boolean = true
+  private var caseNotesSubtype: String = "Subtype"
+  private var caseNotesMessage: String = "Message"
+
+  fun withCode(code: String) = apply { this.code = code }
+  fun withDescription(description: String) = apply { this.description = description }
+  fun withHintText(hintText: String) = apply { this.hintText = hintText }
+  fun withColour(colour: String) = apply { this.colour = colour }
+  fun withHasNotes(hasNotes: Boolean) = apply { this.hasNotes = hasNotes }
+  fun withHasConfirmation(hasConfirmation: Boolean) = apply { this.hasConfirmation = hasConfirmation }
+  fun withConfirmationText(confirmationText: String) = apply { this.confirmationText = confirmationText }
+  fun withActive(active: Boolean) = apply { this.active = active }
+  fun withDraft(draft: Boolean) = apply { this.draft = draft }
+  fun withClosed(closed: Boolean) = apply { this.closed = closed }
+  fun withHold(hold: Boolean) = apply { this.hold = hold }
+  fun withRelease(release: Boolean) = apply { this.release = release }
+  fun withDefaultOrder(defaultOrder: Int) = apply { this.defaultOrder = defaultOrder }
+  fun withNotesOptional(notesOptional: Boolean) = apply { this.notesOptional = notesOptional }
+  fun withCaseNotesSubtype(caseNotesSubtype: String) = apply { this.caseNotesSubtype = caseNotesSubtype }
+  fun withCaseNotesMessage(caseNotesMessage: String) = apply { this.caseNotesMessage = caseNotesMessage }
+
+  fun produce() = ReferralStatusEntity(
+    code = this.code,
+    description = this.description,
+    hintText = this.hintText,
+    colour = this.colour,
+    hasNotes = this.hasNotes,
+    hasConfirmation = this.hasConfirmation,
+    confirmationText = this.confirmationText,
+    active = this.active,
+    draft = this.draft,
+    closed = this.closed,
+    hold = this.hold,
+    release = this.release,
+    defaultOrder = this.defaultOrder,
+    notesOptional = this.notesOptional,
+    caseNotesSubtype = this.caseNotesSubtype,
+    caseNotesMessage = this.caseNotesMessage,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralStatusHistoryEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/ReferralStatusHistoryEntityFactory.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory
+
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.util.randomUppercaseString
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.ReferralStatusHistoryEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusCategoryEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusEntity
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.referencedata.ReferralStatusReasonEntity
+import java.time.LocalDateTime
+import java.util.UUID
+
+class ReferralStatusHistoryEntityFactory {
+  private var id: UUID? = UUID.randomUUID()
+  private var version: Long = 0
+  private var referralId: UUID = UUID.randomUUID()
+  private var statusStartDate: LocalDateTime = LocalDateTime.now()
+  private var username: String = randomUppercaseString()
+  private var status: ReferralStatusEntity = ReferralStatusEntityFactory().produce()
+  private var previousStatus: ReferralStatusEntity? = null
+  private var category: ReferralStatusCategoryEntity? = null
+  private var reason: ReferralStatusReasonEntity? = null
+  private var notes: String? = null
+  private var statusEndDate: LocalDateTime? = null
+  private var durationAtThisStatus: Long? = null
+
+  fun withId(id: UUID?) = apply { this.id = id }
+  fun withVersion(version: Long) = apply { this.version = version }
+  fun withReferralId(referralId: UUID) = apply { this.referralId = referralId }
+  fun withStatusStartDate(statusStartDate: LocalDateTime) = apply { this.statusStartDate = statusStartDate }
+  fun withUsername(username: String) = apply { this.username = username }
+  fun withStatus(status: ReferralStatusEntity) = apply { this.status = status }
+  fun withPreviousStatus(previousStatus: ReferralStatusEntity?) = apply { this.previousStatus = previousStatus }
+  fun withCategory(category: ReferralStatusCategoryEntity?) = apply { this.category = category }
+  fun withReason(reason: ReferralStatusReasonEntity?) = apply { this.reason = reason }
+  fun withNotes(notes: String?) = apply { this.notes = notes }
+  fun withStatusEndDate(statusEndDate: LocalDateTime?) = apply { this.statusEndDate = statusEndDate }
+  fun withDurationAtThisStatus(durationAtThisStatus: Long?) = apply { this.durationAtThisStatus = durationAtThisStatus }
+
+  fun produce() = ReferralStatusHistoryEntity(
+    id = this.id,
+    version = this.version,
+    referralId = this.referralId,
+    statusStartDate = this.statusStartDate,
+    username = this.username,
+    status = this.status,
+    previousStatus = this.previousStatus,
+    category = this.category,
+    reason = this.reason,
+    notes = this.notes,
+    statusEndDate = this.statusEndDate,
+    durationAtThisStatus = this.durationAtThisStatus,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/StaffEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/entity/factory/StaffEntityFactory.kt
@@ -9,9 +9,9 @@ class StaffEntityFactory {
   private var id: UUID? = UUID.randomUUID()
   private var staffId: BigInteger = "487505".toBigInteger()
   private var firstName: String = "John"
-  private var lastName: String = "Smith"
-  private var primaryEmail: String? = "john.smith@digital.justice.gov.uk"
-  private var username: String = "JSMITH_ADM"
+  private var lastName: String = "Doe"
+  private var primaryEmail: String? = "john.doe@email.com"
+  private var username: String = "JDOE_ADM"
   private var accountType: AccountType = AccountType.ADMIN
 
   fun withId(id: UUID?) = apply {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/model/PniResponseFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/model/PniResponseFactory.kt
@@ -1,4 +1,5 @@
-package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.model
+
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Ldc
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Osp
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.PniAssessment
@@ -7,6 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Questions
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.RiskScoreLevel
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.ScoredAnswer
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.PniCalculationFactory
 
 class PniResponseFactory {
   private var pniCalculation: PniCalculation? = PniCalculationFactory().produce()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/model/ReferralStatusRefDataFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/domain/model/ReferralStatusRefDataFactory.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.model
 
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ReferralStatusRefData
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/restapi/controller/ReferralControllerTest.kt
@@ -46,8 +46,8 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.Securit
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.CourseEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.OfferingEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralEntityFactory
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralStatusRefDataFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferrerUserEntityFactory
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.model.ReferralStatusRefDataFactory
 import java.util.*
 
 @AutoConfigureMockMvc


### PR DESCRIPTION

## Changes in this PR

- Added additional fields to the Subject Access Request service.
- Created a new integration test for the updated service.
- Refactored test data factories to improve reusability.
- Fix live defect that incorrectly returns Oasys pattern of offending in the wrong field

