### PR TITLE
Fix: Add @JsonIgnoreProperties to AlertCodeSummary to handle upstream API changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonerAlertsApi/model/AlertCodeSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonerAlertsApi/model/AlertCodeSummary.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerAlertsApi.model
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class AlertCodeSummary(
   val alertTypeCode: String,
   val alertTypeDescription: String,

--- a/src/test/resources/simulations/__files/prisoner-alerts-A9999BB-results.json
+++ b/src/test/resources/simulations/__files/prisoner-alerts-A9999BB-results.json
@@ -7,7 +7,8 @@
         "alertTypeCode": "X",
         "alertTypeDescription": "Self Harm",
         "code": "XCDO",
-        "description": "ACCT Open (HMPS)"
+        "description": "ACCT Open (HMPS)",
+        "canBeAdministered": true
       },
       "description": "Put this one back",
       "authorisedBy": "Michael Willis ",

--- a/src/test/resources/simulations/__files/prisoner-alerts-results.json
+++ b/src/test/resources/simulations/__files/prisoner-alerts-results.json
@@ -7,7 +7,8 @@
         "alertTypeCode": "X",
         "alertTypeDescription": "Security",
         "code": "XCDO",
-        "description": "Involved in 2024 civil disorder"
+        "description": "Involved in 2024 civil disorder",
+        "canBeAdministered": true
       },
       "description": "Put this one back",
       "authorisedBy": "Michael Willis ",


### PR DESCRIPTION

**What**
Added @JsonIgnoreProperties(ignoreUnknown = true) to the AlertCodeSummary data class, matching the pattern already used on the sibling Alert model.

**Why**
The upstream Prisoner Alerts API added a new canBeAdministered field to the alertCode object. Our model didn't tolerate unknown properties, causing Jackson UnrecognizedPropertyException on every call to retrieve alerts. This meant OasysService.getActiveAlerts() returned null for all prisoners — alert data was completely missing from referral detail pages.

**Prod log evidence:**
WARN OasysService : Failure to retrieve ActiveAlerts for prisonNumber A3744AJ reason
com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "canBeAdministered"

**Changes**
AlertCodeSummary.kt — Added @JsonIgnoreProperties(ignoreUnknown = true) annotation
Wiremock fixtures — Added canBeAdministered field to test JSON to prove the fix works and prevent regression

**Testing**
PrisonerAlertsApiClientIntegrationTest passes with the new field present in fixtures
The test now exercises the exact scenario that was failing in production
 
