### PR TITLE
APG-2328 Ignore unknown Alerts JSON properties and enhance prisoner alerts test data

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonerAlertsApi/model/AlertCodeSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/prisonerAlertsApi/model/AlertCodeSummary.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.prisonerAlertsApi.model
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class AlertCodeSummary(
   val alertTypeCode: String,
   val alertTypeDescription: String,

--- a/src/test/resources/simulations/__files/prisoner-alerts-results.json
+++ b/src/test/resources/simulations/__files/prisoner-alerts-results.json
@@ -7,7 +7,8 @@
         "alertTypeCode": "X",
         "alertTypeDescription": "Security",
         "code": "XCDO",
-        "description": "Involved in 2024 civil disorder"
+        "description": "Involved in 2024 civil disorder",
+        "canBeAdministered" : true
       },
       "description": "Put this one back",
       "authorisedBy": "Michael Willis ",


### PR DESCRIPTION


## Changes in this PR

- Updated `AlertCodeSummary` to ignore unknown JSON properties.
- Added `canBeAdministered` field to prisoner alerts test data.

