### PR TITLE
Update dependencies and refactor configuration files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,8 +21,10 @@ dependencies {
   val sentryVersion = "8.41.0"
   val jsonWebtokenVersion = "0.13.0"
   val springSecurityVersion = "7.0.5"
+  val flywayVersion = "11.17.1"
 
   runtimeOnly("org.postgresql:postgresql:42.7.11")
+  implementation("org.flywaydb:flyway-core:$flywayVersion")
   implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.2.0")
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:7.3.2")
 
@@ -37,7 +39,7 @@ dependencies {
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-csv")
   implementation("com.google.guava:guava:33.6.0-jre")
 
-  implementation("io.sentry:sentry-spring-boot-starter-jakarta:$sentryVersion")
+  implementation("io.sentry:sentry-spring-boot-4:$sentryVersion")
   implementation("io.sentry:sentry-logback:$sentryVersion")
 
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
@@ -49,7 +51,6 @@ dependencies {
 
   testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
   testImplementation("com.ninja-squad:springmockk:4.0.2")
-  testImplementation("org.springframework.boot:spring-boot-starter-test")
   testImplementation("io.jsonwebtoken:jjwt-api:$jsonWebtokenVersion")
   testImplementation("io.jsonwebtoken:jjwt-impl:$jsonWebtokenVersion")
   testImplementation("io.jsonwebtoken:jjwt-orgjson:$jsonWebtokenVersion")
@@ -67,9 +68,10 @@ dependencies {
   testImplementation("org.testcontainers:testcontainers-localstack:2.0.5")
   testImplementation("org.testcontainers:testcontainers-junit-jupiter:2.0.5")
   testImplementation("org.jetbrains.kotlin:kotlin-test")
-  testRuntimeOnly("org.flywaydb:flyway-database-postgresql")
   testImplementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-test-support:2.4.2")
   testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.2.0")
+
+  runtimeOnly("org.flywaydb:flyway-database-postgresql:$flywayVersion")
 }
 
 java {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/config/WebClientConfiguration.kt
@@ -17,7 +17,6 @@ import org.springframework.security.oauth2.client.web.reactive.function.client.S
 import org.springframework.web.reactive.function.client.ExchangeStrategies
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.netty.http.client.HttpClient
-import uk.gov.justice.hmpps.kotlin.auth.healthWebClient
 import java.time.Duration
 
 @Configuration
@@ -184,10 +183,4 @@ class WebClientConfiguration(
     )
     .filter(oauth2Client)
     .build()
-
-  @Bean
-  fun prisonRegisterWebClient(
-    builder: WebClient.Builder,
-    @Value("\${services.prison-register-api.base-url}") prisonRegisterApiBaseUrl: String,
-  ): WebClient = builder.healthWebClient(prisonRegisterApiBaseUrl)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/health/HealthCheck.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/health/HealthCheck.kt
@@ -11,8 +11,8 @@ class PrisonerSearchApiHealthCheck(@Qualifier("prisonerSearchApiWebClient") webC
 @Component
 class PrisonApiHealthCheck(@Qualifier("prisonApiWebClient") webClient: WebClient) : HealthPingCheck(webClient)
 
-@Component("prisonRegisterApi")
-class PrisonRegisterApiHealthCheck(@Qualifier("prisonRegisterWebClient") webClient: WebClient) : HealthPingCheck(webClient)
+@Component
+class PrisonRegisterApiHealthCheck(@Qualifier("prisonRegisterApiWebClient") webClient: WebClient) : HealthPingCheck(webClient)
 
 @Component
 class OasysApiWebClientHealthCheck(@Qualifier("oasysApiWebClient") webClient: WebClient) : HealthPingCheck(webClient)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -167,6 +167,7 @@ hmpps:
     template:
       path: /sar_template.mustache
       enabled: true
+    additionalAccessRole: ACCREDITED_PROGRAMMES_API
 
 log-client-credentials-jwt-info: false
 


### PR DESCRIPTION
## Context

The custody API k8s deployment has been broken since early June as a  result of some incompatible library dependencies.

## Changes in this PR

- Added Flyway dependency and updated Sentry to a newer version in `build.gradle.kts`.
- Removed unused `prisonRegisterWebClient` bean from `WebClientConfiguration.kt`.
- Updated `application.yml` to include the new `additionalAccessRole` property for SAR admin endpoint access.
- Refactored `PrisonRegisterApiHealthCheck` for improved maintainability.

