### PR TITLE
Remove SAR additional access role property from application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -167,7 +167,6 @@ hmpps:
     template:
       path: /sar_template.mustache
       enabled: true
-    additionalAccessRole: ACCREDITED_PROGRAMMES_API
 
 log-client-credentials-jwt-info: false
 


### PR DESCRIPTION

## Changes in this PR

- Removed the  `additionalAccessRole` property from `application.yml` 
