### PR TITLE
APG-2246 Update SAR endpoint security to allow nested paths

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/config/SecurityConfiguration.kt
@@ -42,7 +42,7 @@ class SecurityConfiguration(
           "/info",
           "/swagger-ui.html",
         ).permitAll()
-        .requestMatchers("/subject-access-request").hasAnyRole("SAR_DATA_ACCESS")
+        .requestMatchers("/subject-access-request/**").hasAnyRole("SAR_DATA_ACCESS")
         .anyRequest().hasRole("ACCREDITED_PROGRAMMES_API")
     }
     .anonymous { it.disable() }


### PR DESCRIPTION
## Context

The SAR team need to be able to access both `/subject-access-request` and `/subject-access-request/template` URLS

## Changes in this PR

Tweak the request matcher to allow this.

