### PR TITLE
APG-2342 Remove deprecated methods and unused imports, refactor PNI and sentence data handling

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PNIController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PNIController.kt
@@ -9,14 +9,12 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.PniScore
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.PrisonNumberRequest
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.PniService
 import java.util.UUID
 
@@ -86,56 +84,5 @@ class PNIController(
       pniService.savePni(pniScore, referralId)
     }
     return ResponseEntity.ok(pniScore)
-  }
-
-  @Operation(
-    tags = ["PNI"],
-    summary = "Get Oasys PNI data for prisoner",
-    operationId = "getOasysPNIByPrisonNumbers",
-    description = """Get comparison of PNI data for given prisoners""",
-    responses = [
-      ApiResponse(
-        responseCode = "200",
-        description = "successful operation",
-        content = [Content(schema = Schema(implementation = String::class))],
-      ),
-      ApiResponse(
-        responseCode = "401",
-        description = "Unauthorised. The request was unauthorised.",
-        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
-      ),
-      ApiResponse(
-        responseCode = "403",
-        description = "Forbidden.  The client is not authorised to access person.",
-        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
-      ),
-      ApiResponse(
-        responseCode = "404",
-        description = "Invalid prison number",
-        content = [Content(schema = Schema(implementation = ErrorResponse::class))],
-      ),
-    ],
-  )
-  @RequestMapping(
-    method = [RequestMethod.POST],
-    value = ["/comparePniResults"],
-    produces = ["application/json"],
-  )
-  fun getOasysPNIByPrisonNumbers(
-    @Parameter(
-      description = "",
-      required = true,
-    ) @RequestBody prisonNumberRequest: PrisonNumberRequest,
-  ): ResponseEntity<String> {
-    log.info("Request received $prisonNumberRequest to compare PNI data for ${prisonNumberRequest.prisonNumbers} prisoners")
-    val result: StringBuilder = StringBuilder().append("*********** PNI COMPARISON ***************\n")
-    val mismatchedPrisonNumbers = StringBuilder().append("*********** MISMATCHED PRISON NUMBERS ***************\n")
-    prisonNumberRequest.prisonNumbers.forEach { prisonId ->
-      val pniComparisonMessage = pniService.fetchAndStoreOasysPni(prisonId)
-      mismatchedPrisonNumbers.append("$prisonId, ")
-      result.append(pniComparisonMessage)
-    }
-    log.info("Mismatched prison numbers: $mismatchedPrisonNumbers")
-    return ResponseEntity.ok(result.toString())
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PeopleController.kt
@@ -224,10 +224,8 @@ class PeopleController(
       prisonNumber = prisonNumber,
       auditAction = AuditAction.SENTENCE_DETAILS.name,
     )
-    return ResponseEntity.ok(
-      personService
-        .getSentenceDetails(prisonNumber),
-    )
+    val sentenceInformation = personService.getSentenceInformation(prisonNumber)
+    return ResponseEntity.ok(personService.getSentenceDetails(sentenceInformation))
   }
 
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PersonService.kt
@@ -42,7 +42,7 @@ class PersonService(
     peopleSearchApiService.getPrisoners(listOf(prisonNumber)).firstOrNull()?.let {
       var personEntity = personRepository.findPersonEntityByPrisonNumber(prisonNumber)
       if (personEntity == null) {
-        val earliestReleaseDateAndType = earliestReleaseDateAndType(it)
+        val earliestReleaseDateAndType = earliestReleaseDateAndType(sentenceInformation)
         log.info("Earliest release date and type for prisoner not in our database $prisonNumber ${earliestReleaseDateAndType.first} ${earliestReleaseDateAndType.second}")
         personEntity = PersonEntity(
           surname = it.lastName,
@@ -60,16 +60,15 @@ class PersonService(
           gender = it.gender,
         )
       } else {
-        updatePerson(it, personEntity, sentenceType)
+        updatePerson(it, personEntity, sentenceInformation)
       }
-
       personRepository.save(personEntity)
     }
   }
 
   fun getPerson(prisonNumber: String) = personRepository.findPersonEntityByPrisonNumber(prisonNumber)
 
-  private fun earliestReleaseDateAndType(prisoner: Prisoner): Pair<LocalDate?, String?> = getSentenceDetails(prisoner.prisonerNumber)
+  private fun earliestReleaseDateAndType(sentenceInformation: SentenceInformation?): Pair<LocalDate?, String?> = getSentenceDetails(sentenceInformation)
     ?.keyDates
     ?.firstOrNull { it.earliestReleaseDate == true }
     ?.let { Pair(it.date, it.description) }
@@ -78,9 +77,10 @@ class PersonService(
   private fun updatePerson(
     prisoner: Prisoner,
     personEntity: PersonEntity,
-    sentenceType: String,
+    sentenceInformation: SentenceInformation?,
   ) {
-    val earliestReleaseDateAndType = earliestReleaseDateAndType(prisoner)
+    val sentenceType = determineSentenceType(sentenceInformation)
+    val earliestReleaseDateAndType = earliestReleaseDateAndType(sentenceInformation)
     log.info("Earliest release date and type for prisoner in our database ${prisoner.prisonerNumber} ${earliestReleaseDateAndType.first} ${earliestReleaseDateAndType.second}")
     personEntity.surname = prisoner.lastName
     personEntity.forename = prisoner.firstName
@@ -154,9 +154,8 @@ class PersonService(
     ?.distinct()
     .orEmpty()
 
-  fun getSentenceDetails(prisonNumber: String): SentenceDetails? {
-    val sentenceInformation = getSentenceInformation(prisonNumber)
-      ?: throw NotFoundException("No sentence information found for person with id: $prisonNumber")
+  fun getSentenceDetails(sentenceInformation: SentenceInformation?): SentenceDetails? {
+    sentenceInformation ?: throw NotFoundException("No sentence information found for person")
 
     val sentences = sentenceInformation.latestPrisonTerm.courtSentences
       .flatMap { it.sentences }
@@ -174,7 +173,7 @@ class PersonService(
         val sentenceInformation = getSentenceInformation(prisonNumber)
         val sentenceType = determineSentenceType(sentenceInformation)
         peopleSearchApiService.getPrisoners(listOf(prisonNumber)).firstOrNull()?.let {
-          updatePerson(it, personEntity, sentenceType)
+          updatePerson(it, personEntity, sentenceInformation)
         }
         personRepository.save(personEntity)
         log.info("Prisoner $prisonNumber update successful")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PniService.kt
@@ -4,39 +4,19 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.NeedLevel
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysAssessmentTimeline
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysAttitude
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysBehaviour
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysLifestyle
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysOffendingInfo
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysPsychiatric
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysRelationships
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.OasysRiskPredictorScores
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.ProgrammePathway
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.RiskLevel
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Timeline
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Type
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.BusinessException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.common.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.create.AuditAction
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.view.PniResultEntity
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PniResultRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.PniRuleRepository
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.DomainScore
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualCognitiveScores
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualNeedsAndRiskScores
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualNeedsScores
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualRelationshipScores
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualRiskScores
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualSelfManagementScores
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.IndividualSexScores
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.NeedsScore
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.PniScore
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.RiskScore
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model.Sara
-import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service.type.SaraRisk
-import java.math.BigDecimal
-import java.math.RoundingMode
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -46,19 +26,12 @@ private const val LEARNING_DISABILITIES_AND_CHALLENGES_THRESHOLD = 3
 class PniService(
   private val oasysService: OasysService,
   private val auditService: AuditService,
-  private val pniNeedsEngine: PniNeedsEngine,
   private val pniRiskEngine: PniRiskEngine,
   private val pniRuleRepository: PniRuleRepository,
   private val pniResultRepository: PniResultRepository,
-  private val personService: PersonService,
   private val objectMapper: ObjectMapper,
 ) {
   private val log = LoggerFactory.getLogger(this::class.java)
-
-  @Deprecated("Use savePni(pniScore: PniScore, referralId: UUID? = null) method instead")
-  fun savePni(prisonNumber: String, gender: String?, savePni: Boolean = false, referralId: UUID? = null) {
-    getPniScore(prisonNumber, gender, savePni, referralId)
-  }
 
   fun savePni(pniScore: PniScore, referralId: UUID? = null) {
     log.info("Saving PNI score for prisonNumber: $pniScore.prisonNumber")
@@ -105,107 +78,6 @@ class PniService(
     return pniScore
   }
 
-  @Deprecated("Use getOasysPniScore(..) method instead")
-  fun getPniScore(
-    prisonNumber: String,
-    gender: String? = null,
-    savePni: Boolean = false,
-    referralId: UUID? = null,
-  ): PniScore {
-    log.info("Request received to process PNI for prisonNumber $prisonNumber")
-
-    auditService.audit(
-      prisonNumber = prisonNumber,
-      auditAction = AuditAction.PNI.name,
-    )
-
-    val oasysAssessmentTimeline = oasysService.getAssessments(prisonNumber)
-    val completedAssessment = oasysService.getLatestCompletedLayerThreeAssessment(oasysAssessmentTimeline)
-      ?: throw NotFoundException("No completed assessments found for $prisonNumber")
-
-    val assessmentId = completedAssessment.id
-
-    // section 6
-    val relationships = oasysService.getRelationships(assessmentId)
-    // section 7
-    val lifestyle = oasysService.getLifestyle(assessmentId)
-    // section 10
-    val psychiatric = oasysService.getPsychiatric(assessmentId)
-    // section 11
-    val behavior = oasysService.getBehaviour(assessmentId)
-    // section 12
-    val attitude = oasysService.getAttitude(assessmentId)
-
-    val learning = oasysService.getLearning(assessmentId)
-
-    // SARA result
-    val saraResult = buildSaraResult(oasysAssessmentTimeline, relationships, assessmentId)
-
-    // risks
-    val oasysOffendingInfo = oasysService.getOffendingInfo(assessmentId)
-    val oasysRiskPredictor = oasysService.getRiskPredictors(assessmentId)
-
-    val individualNeedsAndRiskScores = IndividualNeedsAndRiskScores(
-      individualNeedsScores = buildNeedsScores(behavior, relationships, attitude, lifestyle, psychiatric),
-      individualRiskScores = buildRiskScores(oasysRiskPredictor, oasysOffendingInfo, saraResult),
-    )
-
-    val genderOfPerson = getGenderOfPerson(prisonNumber, gender)
-    val ldcScore = oasysService.getLDCScore(prisonNumber)
-    val overallNeedsScore = pniNeedsEngine.getOverallNeedsScore(
-      individualNeedsAndRiskScores,
-      prisonNumber,
-      genderOfPerson,
-      ldcScore,
-    )
-
-    log.info("Overall needs score for prisonNumber $prisonNumber is ${overallNeedsScore.overallNeedsScore} classification ${overallNeedsScore.classification} ")
-
-    val overallRiskScore =
-      pniRiskEngine.getOverallRiskScore(individualNeedsAndRiskScores.individualRiskScores, genderOfPerson)
-
-    log.info("Overall risk classification for prisonNumber $prisonNumber is ${overallNeedsScore.classification} ")
-
-    val programmePathway = getProgramPathway(overallNeedsScore, overallRiskScore, prisonNumber)
-
-    val pniScore = PniScore(
-      prisonNumber = prisonNumber,
-      crn = oasysOffendingInfo?.crn,
-      assessmentId = assessmentId,
-      programmePathway = programmePathway,
-      needsScore = overallNeedsScore,
-      validationErrors = overallNeedsScore.validate(),
-      riskScore = overallRiskScore,
-    )
-
-    if (savePni) {
-      pniResultRepository.save(buildEntity(pniScore, completedAssessment, referralId))
-    }
-    return pniScore
-  }
-
-  private fun buildSaraResult(
-    timeline: OasysAssessmentTimeline,
-    oasysRelationships: OasysRelationships?,
-    assessmentId: Long,
-  ): Sara = if (oasysRelationships?.sara == null) {
-    val completedAssessmentIdWithSara = oasysService.getAssessmentIdWithCompletedSara(timeline)
-    val relationshipsWithSara = completedAssessmentIdWithSara?.let { oasysService.getRelationships(it) }
-    Sara(
-      overallResult = getOverallSARAResult(relationshipsWithSara?.sara),
-      saraRiskOfViolenceTowardsPartner = relationshipsWithSara?.sara?.imminentRiskOfViolenceTowardsPartner,
-      saraRiskOfViolenceTowardsOthers = relationshipsWithSara?.sara?.imminentRiskOfViolenceTowardsOthers,
-      saraAssessmentId = completedAssessmentIdWithSara,
-    )
-  } else {
-    Sara(
-      overallResult = getOverallSARAResult(oasysRelationships.sara),
-      saraRiskOfViolenceTowardsPartner = oasysRelationships.sara.imminentRiskOfViolenceTowardsPartner,
-      saraRiskOfViolenceTowardsOthers = oasysRelationships.sara.imminentRiskOfViolenceTowardsOthers,
-      saraAssessmentId = assessmentId,
-    )
-  }
-
   private fun buildEntity(
     pniScore: PniScore,
     completedAssessment: Timeline?,
@@ -226,120 +98,9 @@ class PniService(
     basicSkillsScore = pniScore.needsScore.basicSkillsScore,
   )
 
-  private fun getProgramPathway(
-    overallNeedsScore: NeedsScore,
-    overallRiskScore: RiskScore,
-    prisonNumber: String,
-  ): String {
-    if (overallNeedsScore.validate().isNotEmpty()) {
-      return "MISSING_INFORMATION"
-    }
-
-    val programmePathway =
-      getPathwayAfterApplyingExceptionRules(overallNeedsScore.classification, overallRiskScore.individualRiskScores)
-        ?: pniRuleRepository.findPniRuleEntityByOverallNeedAndOverallRisk(
-          overallNeedsScore.classification,
-          overallRiskScore.classification,
-        )?.combinedPathway
-        ?: throw BusinessException("Programme pathway for $prisonNumber is missing for the combination of needsClassification ${overallNeedsScore.classification} and riskClassification ${overallRiskScore.classification}")
-
-    log.info("Programme pathway for $prisonNumber: ${overallNeedsScore.classification} + ${overallRiskScore.classification}  -> $programmePathway")
-
-    return programmePathway
-  }
-
-  private fun getPathwayAfterApplyingExceptionRules(
-    needsClassification: String,
-    individualRiskScores: IndividualRiskScores,
-  ): String? = when {
-    pniRiskEngine.isHighIntensityBasedOnRiskScores(individualRiskScores) -> ProgrammePathway.HIGH_INTENSITY_BC.name
-    needsClassification == NeedsClassification.LOW_NEED.name &&
-      (pniRiskEngine.isHighSara(individualRiskScores) || pniRiskEngine.isMediumSara(individualRiskScores)) -> ProgrammePathway.MODERATE_INTENSITY_BC.name
-
-    else -> null
-  }
-
   fun hasLDC(prisonNumber: String) = oasysService.getLDCScore(prisonNumber)?.let { it >= LEARNING_DISABILITIES_AND_CHALLENGES_THRESHOLD }
-
-  private fun buildRiskScores(
-    oasysRiskPredictorScores: OasysRiskPredictorScores?,
-    oasysOffendingInfo: OasysOffendingInfo?,
-    sara: Sara,
-  ): IndividualRiskScores = IndividualRiskScores(
-    ogrs3 = oasysRiskPredictorScores?.groupReconvictionScore?.twoYears?.round(),
-    ovp = oasysRiskPredictorScores?.violencePredictorScore?.twoYears?.round(),
-    ospIic = oasysOffendingInfo?.ospIICRisk ?: oasysOffendingInfo?.ospIRisk,
-    ospDc = oasysOffendingInfo?.ospDCRisk ?: oasysOffendingInfo?.ospCRisk,
-    rsr = oasysRiskPredictorScores?.riskOfSeriousRecidivismScore?.percentageScore?.round(),
-    sara = sara,
-  )
-
-  private fun getOverallSARAResult(sara: uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model.Sara?): SaraRisk? = SaraRisk.highestRisk(
-    SaraRisk.fromString(sara?.imminentRiskOfViolenceTowardsPartner),
-    SaraRisk.fromString(sara?.imminentRiskOfViolenceTowardsOthers),
-  )
-
-  fun getGenderOfPerson(prisonNumber: String, prisonerGender: String?): String = prisonerGender
-    ?: personService.getPerson(prisonNumber)?.gender
-    ?: run {
-      log.info("Prisoner $prisonNumber is not available in our db, fetching from external service.")
-      personService.createOrUpdatePerson(prisonNumber)
-      personService.getPerson(prisonNumber)?.gender
-    }
-    ?: throw BusinessException("Gender information missing for prisonNumber $prisonNumber. PNI could not be determined")
-
-  fun fetchAndStoreOasysPni(prisonId: String): String {
-    try {
-      val acpPniResult = getPniScore(prisonId, savePni = false).programmePathway
-      val oasysPniResult = oasysService.getOasysPniProgrammePathway(prisonId)
-
-      if (acpPniResult != oasysPniResult) {
-        return "$prisonId,$acpPniResult,$oasysPniResult\n"
-      }
-      log.info("No mismatch in PNI for $prisonId: $acpPniResult")
-    } catch (e: Exception) {
-      log.error("Error while fetching PNI for $prisonId", e)
-      return "Error while fetching PNI for $prisonId  \n"
-    }
-    return ""
-  }
-
-  private fun buildNeedsScores(
-    behavior: OasysBehaviour?,
-    relationships: OasysRelationships?,
-    attitude: OasysAttitude?,
-    lifestyle: OasysLifestyle?,
-    psychiatric: OasysPsychiatric?,
-  ) = IndividualNeedsScores(
-    individualSexScores = IndividualSexScores(
-      sexualPreOccupation = behavior?.sexualPreOccupation.getScore(),
-      offenceRelatedSexualInterests = behavior?.offenceRelatedSexualInterests.getScore(),
-      emotionalCongruence = relationships?.emotionalCongruence.getScore(),
-    ),
-
-    individualCognitiveScores = IndividualCognitiveScores(
-      proCriminalAttitudes = attitude?.proCriminalAttitudes.getScore(),
-      hostileOrientation = attitude?.hostileOrientation.getScore(),
-    ),
-    individualRelationshipScores = IndividualRelationshipScores(
-      curRelCloseFamily = relationships?.relCloseFamily.getScore(),
-      prevExpCloseRel = relationships?.prevCloseRelationships.getScore(),
-      easilyInfluenced = lifestyle?.easilyInfluenced.getScore(),
-      aggressiveControllingBehaviour = behavior?.aggressiveControllingBehavour.getScore(),
-    ),
-    individualSelfManagementScores = IndividualSelfManagementScores(
-      impulsivity = behavior?.impulsivity.getScore(),
-      temperControl = behavior?.temperControl.getScore(),
-      problemSolvingSkills = behavior?.problemSolvingSkills.getScore(),
-      difficultiesCoping = psychiatric?.difficultiesCoping.getScore(),
-    ),
-  )
 
   fun deletePniData(referralIds: List<UUID>) {
     pniResultRepository.deleteAllById(referralIds)
   }
 }
-
-private fun String?.getScore() = this?.trim()?.split("-")?.firstOrNull()?.trim()?.toIntOrNull()
-
-private fun BigDecimal.round(): BigDecimal = this.setScale(2, RoundingMode.HALF_UP)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/unit/service/ReferralServiceTest.kt
@@ -623,7 +623,7 @@ class ReferralServiceTest {
     referralService.updateReferralStatusById(referralId, referralStatusUpdate)
 
     // Then
-    verify(exactly = 0) { pniService.savePni(referral.prisonNumber, gender = null, savePni = true, referral.id) }
+    verify(exactly = 0) { pniService.savePni(any(), referral.id) }
   }
 
   @Test


### PR DESCRIPTION
## Context

Pre-refactor for APG-2342 of some unused and deprecated PNI logic and refactor to remove duplicate invocation of the call to get sentence information for a prisoner.

## Changes in this PR

- Eliminated obsolete PNI endpoints and logic (`getOasysPNIByPrisonNumbers`, `getPniScore`).
- Simplified sentence detail operations by adopting `SentenceInformation` directly, thereby removing duplicated invocations of getSentenceInformation()
- Removed unused imports and redundant code from services and tests.

