### PR TITLE
Support search functionality by first and last names

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PeopleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PeopleController.kt
@@ -230,7 +230,7 @@ class PeopleController(
 
   @Operation(
     tags = ["Person"],
-    summary = "Search for a prisoner via prison search api by prisoner id and caseload.",
+    summary = "Search for a prisoner via prison search api by prisoner id, prisoner names and prison code.",
     operationId = "searchPeople",
     description = """""",
     responses = [
@@ -265,7 +265,7 @@ class PeopleController(
     ) @RequestBody peopleSearchRequest: PeopleSearchRequest,
   ): ResponseEntity<List<PeopleSearchResponse>> {
     auditService.audit(
-      prisonNumber = peopleSearchRequest.prisonerIdentifier,
+      prisonNumber = peopleSearchRequest.prisonerIdentifier ?: "Unknown prisoner identifier",
       auditAction = AuditAction.NOMIS_SEARCH_FOR_PERSON.name,
     )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/PeopleSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/PeopleSearchRequest.kt
@@ -1,18 +1,29 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 
-/**
- *
- * @param prisonerIdentifier Prisoner identifier for this case we only accept prison number
- * @param prisonIds List of Prison Ids (can include OUT and TRN) to restrict the search by. Unrestricted if not supplied or null
- */
 data class PeopleSearchRequest(
 
-  @Schema(example = "A1234AA", required = true, description = "Prisoner identifier for this case we only accept prison number")
-  @get:JsonProperty("prisonerIdentifier", required = true) val prisonerIdentifier: String,
+  @Schema(
+    example = "A1234AA",
+    description = "Prisoner identifier, the NOMIS id",
+  )
+  val prisonerIdentifier: String? = null,
 
-  @Schema(example = "[\"MDI\"]", description = "List of Prison Ids (can include OUT and TRN) to restrict the search by. Unrestricted if not supplied or null")
-  @get:JsonProperty("prisonIds") val prisonIds: List<String>? = null,
+  @Schema(
+    example = "[\"MDI\"]",
+    description = "List of Prison Ids (can include OUT and TRN) to restrict the search by. Unrestricted if not supplied or null",
+  )
+  val prisonIds: List<String>? = null,
+
+  @Schema(
+    example = "John",
+    description = "First name of the prisoner",
+  )
+  val firstName: String? = null,
+  @Schema(
+    example = "Doe",
+    description = "Last name of the prisoner",
+  )
+  val lastName: String? = null,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PeopleControllerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/PeopleControllerIntegrationTest.kt
@@ -74,11 +74,14 @@ class PeopleControllerIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `search for a person by prisonId`() {
+    // Given
     mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
-
     val peopleSearchRequest = PeopleSearchRequest("C6666DD", listOf("MDI"))
+
+    // When
     val response = searchPrisoners(peopleSearchRequest)
 
+    // Then
     response.shouldNotBeNull()
     response.first() shouldBeEqual PeopleSearchResponse(
       bookingId = "1202335",
@@ -94,6 +97,38 @@ class PeopleControllerIntegrationTest : IntegrationTestBase() {
       lastName = "SMITH",
       paroleEligibilityDate = null,
       prisonerNumber = "C6666DD",
+      religion = null,
+      sentenceExpiryDate = null,
+      sentenceStartDate = null,
+      tariffDate = null,
+    )
+  }
+
+  @Test
+  fun `should allow searching for a person by first and last names`() {
+    // Given
+    mockClientCredentialsJwtRequest(jwt = jwtAuthHelper.bearerToken())
+    val peopleSearchRequest = PeopleSearchRequest(firstName = "MICKEY", lastName = "SMITH")
+
+    // When
+    val response = searchPrisoners(peopleSearchRequest)
+
+    // Then
+    response.shouldNotBeNull()
+    response.first() shouldBeEqual PeopleSearchResponse(
+      bookingId = "1202335",
+      conditionalReleaseDate = null,
+      prisonId = "MDI",
+      prisonName = "Nottingham (HMP)",
+      dateOfBirth = LocalDate.of(1975, 1, 1),
+      ethnicity = "White: Eng./Welsh/Scot./N.Irish/British",
+      gender = "Male",
+      homeDetentionCurfewEligibilityDate = null,
+      indeterminateSentence = false,
+      firstName = "MICKEY",
+      lastName = "SMITH",
+      paroleEligibilityDate = null,
+      prisonerNumber = "C7777CC",
       religion = null,
       sentenceExpiryDate = null,
       sentenceStartDate = null,

--- a/src/test/resources/simulations/mappings/prison-search-api.json
+++ b/src/test/resources/simulations/mappings/prison-search-api.json
@@ -34,6 +34,22 @@
     },
     {
       "request": {
+        "urlPattern": "/prisoner-search/match-prisoners",
+        "method": "POST",
+        "bodyPatterns" : [ {
+          "contains" : "MICKEY"
+        } ]
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "bodyFileName": "prison-search-results-match-C7777CC.json"
+      }
+    },
+    {
+      "request": {
         "urlPattern": "/prisoner-search/prisoner-numbers",
         "method": "POST",
         "bodyPatterns" : [ {


### PR DESCRIPTION
## Context

This pull request enables the prisoner search functionality to include queries by both first and last names. The endpoint can therefore be used for ad hoc queries to search for a new NOMIS prisoner number in the event of a merged prisoner number.

## Changes in this PR

- Extended prisoner search to allow searching by first and last names without prisoner number
- Updated domain model to accommodate changes.
- Added test.
