### PR TITLE
APG-2342 Make `bookingId` and `prisonerNumber` nullable in response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/PeopleSearchResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/PeopleSearchResponse.kt
@@ -26,10 +26,10 @@ import io.swagger.v3.oas.annotations.media.Schema
 data class PeopleSearchResponse(
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("bookingId", required = true) val bookingId: String,
+  @get:JsonProperty("bookingId", required = true) val bookingId: String? = null,
 
   @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("prisonerNumber", required = true) val prisonerNumber: String,
+  @get:JsonProperty("prisonerNumber", required = true) val prisonerNumber: String? = null,
 
   @Schema(example = "null", description = "")
   @get:JsonProperty("conditionalReleaseDate") val conditionalReleaseDate: java.time.LocalDate? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/PeopleSearchResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/model/PeopleSearchResponse.kt
@@ -1,78 +1,58 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.restapi.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
 
-/**
- *
- * @param bookingId
- * @param prisonerNumber
- * @param conditionalReleaseDate
- * @param prisonId
- * @param prisonName
- * @param dateOfBirth
- * @param ethnicity
- * @param gender
- * @param homeDetentionCurfewEligibilityDate
- * @param indeterminateSentence
- * @param firstName
- * @param lastName
- * @param paroleEligibilityDate
- * @param religion
- * @param sentenceExpiryDate
- * @param sentenceStartDate
- * @param tariffDate
- */
 data class PeopleSearchResponse(
 
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("bookingId", required = true) val bookingId: String? = null,
+  @Schema(example = "1202156", description = "The NOMIS booking ID")
+  val bookingId: String? = null,
 
-  @Schema(example = "null", required = true, description = "")
-  @get:JsonProperty("prisonerNumber", required = true) val prisonerNumber: String? = null,
+  @Schema(example = "A9999DY", description = "The NOMIS prisoner number")
+  val prisonerNumber: String? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("conditionalReleaseDate") val conditionalReleaseDate: java.time.LocalDate? = null,
+  @Schema(example = "2027-08-25", description = "The conditional release date")
+  val conditionalReleaseDate: LocalDate? = null,
 
   @Schema(example = "MDI", description = "ID of the prison")
-  @get:JsonProperty("prisonId") val prisonId: String? = null,
+  val prisonId: String? = null,
 
-  @Schema(example = "HMP Leeds", description = "")
-  @get:JsonProperty("prisonName") val prisonName: String? = null,
+  @Schema(example = "HMP Leeds", description = "The name of the prison")
+  val prisonName: String? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("dateOfBirth") val dateOfBirth: java.time.LocalDate? = null,
+  @Schema(example = "1986-06-23", description = "The prisoner's date of birth")
+  val dateOfBirth: LocalDate? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("ethnicity") val ethnicity: String? = null,
+  @Schema(example = "White", description = "The prisoner's ethnicity")
+  val ethnicity: String? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("gender") val gender: String? = null,
+  @Schema(example = "Female", description = "The prisoner's gender")
+  val gender: String? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("homeDetentionCurfewEligibilityDate") val homeDetentionCurfewEligibilityDate: java.time.LocalDate? = null,
+  @Schema(example = "2027-08-25", description = "The prisoner's home detention curfew eligibility date")
+  val homeDetentionCurfewEligibilityDate: LocalDate? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("indeterminateSentence") val indeterminateSentence: Boolean? = null,
+  @Schema(example = "false", description = "A boolean denoting whether the prisoner has an indeterminate sentence")
+  val indeterminateSentence: Boolean? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("firstName") val firstName: String? = null,
+  @Schema(example = "John", description = "The prisoner's first name")
+  val firstName: String? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("lastName") val lastName: String? = null,
+  @Schema(example = "Doe", description = "The prisoner's last name")
+  val lastName: String? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("paroleEligibilityDate") val paroleEligibilityDate: java.time.LocalDate? = null,
+  @Schema(example = "2027-08-25", description = "The prisoner's parole eligibility date")
+  val paroleEligibilityDate: LocalDate? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("religion") val religion: String? = null,
+  @Schema(example = "Christian", description = "The prisoner's religion")
+  val religion: String? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("sentenceExpiryDate") val sentenceExpiryDate: java.time.LocalDate? = null,
+  @Schema(example = "2027-08-25", description = "The prisoner's sentence expiry date")
+  val sentenceExpiryDate: LocalDate? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("sentenceStartDate") val sentenceStartDate: java.time.LocalDate? = null,
+  @Schema(example = "2027-08-25", description = "The prisoner's sentence start date")
+  val sentenceStartDate: LocalDate? = null,
 
-  @Schema(example = "null", description = "")
-  @get:JsonProperty("tariffDate") val tariffDate: java.time.LocalDate? = null,
+  @Schema(example = "2027-08-25", description = "The prisoner's tariff date")
+  val tariffDate: LocalDate? = null,
 )


### PR DESCRIPTION

## Changes in this PR

- Updated the `PeopleSearchResponse` model to allow `bookingId` and `prisonerNumber` to be nullable.

