### PR TITLE
APG-2492: batch staff-surname lookups in SAR generation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/StaffRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/StaffRepository.kt
@@ -7,6 +7,24 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.entity.c
 import java.math.BigInteger
 import java.util.UUID
 
+/**
+ * Projection returned by [StaffRepository.findSurnamesByUsernames] so callers can
+ * build a `username -> lastName` map without loading full staff rows.
+ */
+interface UsernameSurnameProjection {
+  val username: String
+  val lastName: String
+}
+
+/**
+ * Projection returned by [StaffRepository.findSurnamesByStaffIds] so callers can
+ * build a `staffId -> lastName` map without loading full staff rows.
+ */
+interface StaffIdSurnameProjection {
+  val staffId: BigInteger
+  val lastName: String
+}
+
 @Repository
 interface StaffRepository : JpaRepository<StaffEntity, UUID> {
 
@@ -17,6 +35,34 @@ interface StaffRepository : JpaRepository<StaffEntity, UUID> {
 
   @Query("SELECT s.lastName FROM StaffEntity s WHERE s.staffId = :staffId")
   fun findLastNameByStaffId(staffId: BigInteger): List<String>
+
+  /**
+   * Batch equivalent of [findLastNameByUsername]: returns one row per matched
+   * staff record so callers can group into a `username -> lastName` map in a
+   * single query. Uses idx_staff_username (see V144).
+   */
+  @Query(
+    """
+    SELECT s.username AS username, s.lastName AS lastName
+    FROM StaffEntity s
+    WHERE s.username IN :usernames
+    """,
+  )
+  fun findSurnamesByUsernames(usernames: Collection<String>): List<UsernameSurnameProjection>
+
+  /**
+   * Batch equivalent of [findLastNameByStaffId]: returns one row per matched
+   * staff record so callers can group into a `staffId -> lastName` map in a
+   * single query. Uses idx_staff_staff_id (see V144).
+   */
+  @Query(
+    """
+    SELECT s.staffId AS staffId, s.lastName AS lastName
+    FROM StaffEntity s
+    WHERE s.staffId IN :staffIds
+    """,
+  )
+  fun findSurnamesByStaffIds(staffIds: Collection<BigInteger>): List<StaffIdSurnameProjection>
 
   @Query(
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/StaffRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/StaffRepository.kt
@@ -30,22 +30,27 @@ interface StaffRepository : JpaRepository<StaffEntity, UUID> {
 
   fun findByStaffId(staffId: BigInteger): StaffEntity?
 
-  @Query("SELECT s.lastName FROM StaffEntity s WHERE s.username = :username")
+  @Query("SELECT s.lastName FROM StaffEntity s WHERE s.username = :username ORDER BY s.id")
   fun findLastNameByUsername(username: String): List<String>
 
-  @Query("SELECT s.lastName FROM StaffEntity s WHERE s.staffId = :staffId")
+  @Query("SELECT s.lastName FROM StaffEntity s WHERE s.staffId = :staffId ORDER BY s.id")
   fun findLastNameByStaffId(staffId: BigInteger): List<String>
 
   /**
    * Batch equivalent of [findLastNameByUsername]: returns one row per matched
    * staff record so callers can group into a `username -> lastName` map in a
    * single query. Uses idx_staff_username (see V144).
+   *
+   * `ORDER BY s.id` guarantees that when a username has more than one matching
+   * staff row, callers grouping by `username` and picking `.first()` always
+   * select the same row across repeated queries.
    */
   @Query(
     """
     SELECT s.username AS username, s.lastName AS lastName
     FROM StaffEntity s
     WHERE s.username IN :usernames
+    ORDER BY s.username, s.id
     """,
   )
   fun findSurnamesByUsernames(usernames: Collection<String>): List<UsernameSurnameProjection>
@@ -54,12 +59,17 @@ interface StaffRepository : JpaRepository<StaffEntity, UUID> {
    * Batch equivalent of [findLastNameByStaffId]: returns one row per matched
    * staff record so callers can group into a `staffId -> lastName` map in a
    * single query. Uses idx_staff_staff_id (see V144).
+   *
+   * `ORDER BY s.id` guarantees that when a staff id has more than one matching
+   * staff row, callers grouping by `staffId` and picking `.first()` always
+   * select the same row across repeated queries.
    */
   @Query(
     """
     SELECT s.staffId AS staffId, s.lastName AS lastName
     FROM StaffEntity s
     WHERE s.staffId IN :staffIds
+    ORDER BY s.staffId, s.id
     """,
   )
   fun findSurnamesByStaffIds(staffIds: Collection<BigInteger>): List<StaffIdSurnameProjection>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StaffLookupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StaffLookupService.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.service
 
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StaffRepository
@@ -15,13 +16,71 @@ import java.math.BigInteger
  * Kept as a service (rather than calling the repository directly) so that future
  * cross-cutting concerns – caching, batching, or a change of fallback rule – have a
  * single home.
+ *
+ * The batch variants [resolveSurnamesByUsername] / [resolveSurnamesByStaffId] should
+ * be preferred when resolving many identifiers at once (e.g. building a SAR content
+ * payload) as they collapse N lookups into a single query per identifier type.
  */
 @Service
 @Transactional(readOnly = true)
 class StaffLookupService(
   private val staffRepository: StaffRepository,
 ) {
+  private val log = LoggerFactory.getLogger(StaffLookupService::class.java)
+
   fun findLastNameByUsername(username: String?): String? = username?.takeIf { it.isNotBlank() }?.let { staffRepository.findLastNameByUsername(it).firstOrNull() }
 
   fun findLastNameByStaffId(staffId: BigInteger?): String? = staffId?.let { staffRepository.findLastNameByStaffId(it).firstOrNull() }
+
+  /**
+   * Batch-resolve a set of usernames to surnames in a single query.
+   *
+   * Nulls and blank strings are filtered out before hitting the database; the
+   * returned map only contains entries for usernames with at least one matching
+   * staff row. When a username maps to multiple staff rows (which the schema
+   * permits – see V144 migration notes) the first row is retained and a WARN is
+   * logged so duplicates remain visible in production telemetry.
+   */
+  fun resolveSurnamesByUsername(usernames: Collection<String?>): Map<String, String> {
+    val cleaned = usernames.asSequence()
+      .filterNotNull()
+      .filter { it.isNotBlank() }
+      .toSet()
+    if (cleaned.isEmpty()) return emptyMap()
+    val rows = staffRepository.findSurnamesByUsernames(cleaned)
+    return rows.groupBy { it.username }.mapValues { (username, matches) ->
+      if (matches.size > 1) {
+        log.warn(
+          "Multiple staff rows found for username='{}' ({} rows); using the first surname.",
+          username,
+          matches.size,
+        )
+      }
+      matches.first().lastName
+    }
+  }
+
+  /**
+   * Batch-resolve a set of numeric staff IDs to surnames in a single query.
+   *
+   * Nulls are filtered out before hitting the database; the returned map only
+   * contains entries for staff IDs with at least one matching staff row. When a
+   * staff ID maps to multiple rows the first row is retained and a WARN is
+   * logged so duplicates remain visible in production telemetry.
+   */
+  fun resolveSurnamesByStaffId(staffIds: Collection<BigInteger?>): Map<BigInteger, String> {
+    val cleaned = staffIds.filterNotNull().toSet()
+    if (cleaned.isEmpty()) return emptyMap()
+    val rows = staffRepository.findSurnamesByStaffIds(cleaned)
+    return rows.groupBy { it.staffId }.mapValues { (staffId, matches) ->
+      if (matches.size > 1) {
+        log.warn(
+          "Multiple staff rows found for staffId={} ({} rows); using the first surname.",
+          staffId,
+          matches.size,
+        )
+      }
+      matches.first().lastName
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StaffLookupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StaffLookupService.kt
@@ -38,7 +38,8 @@ class StaffLookupService(
    * Nulls and blank strings are filtered out before hitting the database; the
    * returned map only contains entries for usernames with at least one matching
    * staff row. When a username maps to multiple staff rows (which the schema
-   * permits – see V144 migration notes) the first row is retained and a WARN is
+   * permits – see V144 migration notes) the first row is retained (ordered by
+   * `staff.id` in JPQL for stability across repeated calls) and a WARN is
    * logged so duplicates remain visible in production telemetry.
    */
   fun resolveSurnamesByUsername(usernames: Collection<String?>): Map<String, String> {
@@ -62,7 +63,8 @@ class StaffLookupService(
    *
    * Nulls are filtered out before hitting the database; the returned map only
    * contains entries for staff IDs with at least one matching staff row. When a
-   * staff ID maps to multiple rows the first row is retained and a WARN is
+   * staff ID maps to multiple rows the first row is retained (ordered by
+   * `staff.id` in JPQL for stability across repeated calls) and a WARN is
    * logged so duplicates remain visible in production telemetry.
    */
   fun resolveSurnamesByStaffId(staffIds: Collection<BigInteger?>): Map<BigInteger, String> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StaffLookupService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StaffLookupService.kt
@@ -42,10 +42,7 @@ class StaffLookupService(
    * logged so duplicates remain visible in production telemetry.
    */
   fun resolveSurnamesByUsername(usernames: Collection<String?>): Map<String, String> {
-    val cleaned = usernames.asSequence()
-      .filterNotNull()
-      .filter { it.isNotBlank() }
-      .toSet()
+    val cleaned = usernames.filterNotNull().filter { it.isNotBlank() }.toSet()
     if (cleaned.isEmpty()) return emptyMap()
     val rows = staffRepository.findSurnamesByUsernames(cleaned)
     return rows.groupBy { it.username }.mapValues { (username, matches) ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestService.kt
@@ -27,6 +27,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.reposito
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StaffRepository
 import uk.gov.justice.hmpps.kotlin.sar.HmppsPrisonSubjectAccessRequestService
 import uk.gov.justice.hmpps.kotlin.sar.HmppsSubjectAccessRequestContent
+import java.math.BigInteger
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
@@ -55,25 +56,39 @@ class SubjectAccessRequestService(
       afterFromDate && beforeToDate
     }
 
+    val filteredParticipations = courseParticipationRepository.getSarParticipations(prn).filter { courseParticipation ->
+      val afterFromDate = fromDate?.let { courseParticipation.createdDateTime.isAfter(it.atStartOfDay()) } ?: true
+      val beforeToDate = toDate?.let { courseParticipation.createdDateTime.isBefore(it.plusDays(1).atStartOfDay()) } ?: true
+      afterFromDate && beforeToDate
+    }
+
+    val auditRecords = auditRepository.getSarAuditRecords(prn)
     val referralStatusHistory = referralStatusHistoryRepository.findByPrisonNumber(prn)
     val selectedSexualOffenceDetails = filteredReferrals
       .flatMap { it.selectedSexualOffenceDetails }
       .distinctBy { it.id }
 
+    // Resolve every staff surname referenced by the SAR payload in exactly two
+    // queries (one by-username, one by-staff-id), rather than the previous
+    // per-row point-lookup pattern which produced O(N) queries per referral /
+    // course participation / audit / status-history row.
+    val staffSurnames = resolveStaffSurnames(
+      filteredReferrals,
+      filteredParticipations,
+      auditRecords,
+      referralStatusHistory,
+    )
+
     return HmppsSubjectAccessRequestContent(
       content = Content(
-        referrals = filteredReferrals.toSarReferral(),
-        courseParticipation = courseParticipationRepository.getSarParticipations(prn).filter { courseParticipation ->
-          val afterFromDate = fromDate?.let { courseParticipation.createdDateTime.isAfter(it.atStartOfDay()) } ?: true
-          val beforeToDate = toDate?.let { courseParticipation.createdDateTime.isBefore(it.plusDays(1).atStartOfDay()) } ?: true
-          afterFromDate && beforeToDate
-        }.toSarParticipation(),
-        auditRecords = auditRepository.getSarAuditRecords(prn).toSarAudit(),
+        referrals = filteredReferrals.toSarReferral(staffSurnames),
+        courseParticipation = filteredParticipations.toSarParticipation(staffSurnames),
+        auditRecords = auditRecords.toSarAudit(staffSurnames),
         courses = courseRepository.getSarCourses(prn).toSarCourse(),
         pniResults = pniResultRepository.findAllByPrisonNumber(prn).toSarPniResult(),
         person = personRepository.findPersonEntityByPrisonNumber(prn)?.toSarPerson(),
         oasysPniResults = oasysPniResultEntityRepository.findAllByPrisonNumber(prn).toSarOasysPniResult(),
-        referralStatusHistory = referralStatusHistory.toSarReferralStatusHistory(),
+        referralStatusHistory = referralStatusHistory.toSarReferralStatusHistory(staffSurnames),
         referralStatusReasons = referralStatusHistory.mapNotNull { it.reason }.distinctBy { it.code }.toSarReferralStatusReason(),
         selectedSexualOffenceDetails = selectedSexualOffenceDetails.toSarSelectedSexualOffenceDetails(),
         sexualOffenceDetails = selectedSexualOffenceDetails.mapNotNull { it.sexualOffenceDetails }.distinctBy { it.id }.toSarSexualOffenceDetails(),
@@ -84,6 +99,54 @@ class SubjectAccessRequestService(
       ),
 
     )
+  }
+
+  /**
+   * Pre-resolves every staff surname referenced across the four SAR entity
+   * collections that carry staff identifiers, collapsing what used to be
+   * O(rows) point-lookups into two batch queries.
+   */
+  private fun resolveStaffSurnames(
+    referrals: List<ReferralEntity>,
+    participations: List<CourseParticipationEntity>,
+    audits: List<AuditEntity>,
+    statusHistory: List<ReferralStatusHistoryEntity>,
+  ): StaffSurnames {
+    val usernames = buildSet {
+      referrals.forEach { add(it.referrer.username) }
+      participations.forEach {
+        add(it.createdByUsername)
+        it.lastModifiedByUsername?.let(::add)
+      }
+      audits.forEach {
+        it.referrerUsername?.let(::add)
+        add(it.auditUsername)
+      }
+      statusHistory.forEach { add(it.username) }
+    }
+    val staffIds = buildSet {
+      referrals.forEach {
+        it.primaryPomStaffId?.let(::add)
+        it.secondaryPomStaffId?.let(::add)
+      }
+    }
+    return StaffSurnames(
+      byUsername = staffLookupService.resolveSurnamesByUsername(usernames),
+      byStaffId = staffLookupService.resolveSurnamesByStaffId(staffIds),
+    )
+  }
+
+  /**
+   * In-memory view of the two staff-surname maps built once per SAR request.
+   * Both lookup helpers short-circuit on null so mappers can consult them
+   * uniformly regardless of whether the source column is nullable.
+   */
+  private data class StaffSurnames(
+    val byUsername: Map<String, String>,
+    val byStaffId: Map<BigInteger, String>,
+  ) {
+    fun forUsername(username: String?): String? = username?.let { byUsername[it] }
+    fun forStaffId(staffId: BigInteger?): String? = staffId?.let { byStaffId[it] }
   }
 
   data class Content(
@@ -232,7 +295,7 @@ class SubjectAccessRequestService(
     val username: String,
   )
 
-  private fun List<CourseParticipationEntity>.toSarParticipation(): List<SarCourseParticipation> = map {
+  private fun List<CourseParticipationEntity>.toSarParticipation(surnames: StaffSurnames): List<SarCourseParticipation> = map {
     SarCourseParticipation(
       prisonNumber = it.prisonNumber,
       isDraft = it.isDraft,
@@ -246,14 +309,14 @@ class SubjectAccessRequestService(
       location = it.setting?.location,
       detail = it.detail,
       courseName = it.courseName,
-      createdByUser = staffLookupService.findLastNameByUsername(it.createdByUsername),
+      createdByUser = surnames.forUsername(it.createdByUsername),
       createdDateTime = it.createdDateTime,
-      updatedByUser = staffLookupService.findLastNameByUsername(it.lastModifiedByUsername),
+      updatedByUser = surnames.forUsername(it.lastModifiedByUsername),
       updatedDateTime = it.lastModifiedDateTime,
     )
   }
 
-  private fun List<ReferralEntity>.toSarReferral(): List<SarReferral> = map {
+  private fun List<ReferralEntity>.toSarReferral(surnames: StaffSurnames): List<SarReferral> = map {
     SarReferral(
       it.prisonNumber,
       it.oasysConfirmed,
@@ -261,10 +324,10 @@ class SubjectAccessRequestService(
       it.hasReviewedProgrammeHistory,
       it.additionalInformation,
       it.submittedOn,
-      staffLookupService.findLastNameByStaffId(it.primaryPomStaffId),
-      staffLookupService.findLastNameByStaffId(it.secondaryPomStaffId),
+      surnames.forStaffId(it.primaryPomStaffId),
+      surnames.forStaffId(it.secondaryPomStaffId),
       it.referrerOverrideReason,
-      staffLookupService.findLastNameByUsername(it.referrer.username),
+      surnames.forUsername(it.referrer.username),
       it.originalReferralId,
       it.hasLdc,
       it.hasLdcBeenOverriddenByProgrammeTeam,
@@ -272,16 +335,16 @@ class SubjectAccessRequestService(
     )
   }
 
-  private fun List<AuditEntity>.toSarAudit(): List<SarAuditRecord> = map {
+  private fun List<AuditEntity>.toSarAudit(surnames: StaffSurnames): List<SarAuditRecord> = map {
     SarAuditRecord(
       prisonNumber = it.prisonNumber,
-      referrerUsername = staffLookupService.findLastNameByUsername(it.referrerUsername),
+      referrerUsername = surnames.forUsername(it.referrerUsername),
       referralStatusFrom = it.referralStatusFrom,
       referralStatusTo = it.referralStatusTo,
       courseName = it.courseName,
       courseLocation = it.courseLocation,
       auditAction = it.auditAction,
-      auditUsername = staffLookupService.findLastNameByUsername(it.auditUsername),
+      auditUsername = surnames.forUsername(it.auditUsername),
       auditDateTime = it.auditDateTime,
     )
   }
@@ -334,7 +397,7 @@ class SubjectAccessRequestService(
     )
   }
 
-  private fun List<ReferralStatusHistoryEntity>.toSarReferralStatusHistory(): List<SarReferralStatusHistoryEntity> = map {
+  private fun List<ReferralStatusHistoryEntity>.toSarReferralStatusHistory(surnames: StaffSurnames): List<SarReferralStatusHistoryEntity> = map {
     SarReferralStatusHistoryEntity(
       id = it.id,
       referralId = it.referralId,
@@ -346,7 +409,7 @@ class SubjectAccessRequestService(
       statusStartDate = it.statusStartDate,
       statusEndDate = it.statusEndDate,
       durationAtThisStatus = it.durationAtThisStatus,
-      username = staffLookupService.findLastNameByUsername(it.username),
+      username = surnames.forUsername(it.username),
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/StaffRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/StaffRepositoryIntegrationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.reposit
 
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -78,6 +79,89 @@ class StaffRepositoryIntegrationTest : IntegrationTestBase() {
 
     // When
     val result = staffRepository.findLastNameByStaffId(BigInteger.valueOf(9_999_999))
+
+    // Then
+    result.shouldBeEmpty()
+  }
+
+  @Test
+  fun `findSurnamesByUsernames returns a projection row per matched staff username`() {
+    // Given
+    persistenceHelper.clearAllTableContent()
+    persistenceHelper.createStaff(
+      staffId = "1".toBigInteger(),
+      firstName = "Alex",
+      lastName = "River",
+      username = "ARIVER",
+      primaryEmail = "a@justice.gov.uk",
+    )
+    persistenceHelper.createStaff(
+      staffId = "2".toBigInteger(),
+      firstName = "Bea",
+      lastName = "Smith",
+      username = "BSMITH",
+      primaryEmail = "b@justice.gov.uk",
+    )
+
+    // When
+    val result = staffRepository.findSurnamesByUsernames(listOf("ARIVER", "BSMITH", "MISSING"))
+
+    // Then – MISSING is silently dropped by the IN clause
+    val byUsername = result.associate { it.username to it.lastName }
+    byUsername shouldBe mapOf("ARIVER" to "River", "BSMITH" to "Smith")
+  }
+
+  @Test
+  fun `findSurnamesByUsernames returns empty list when no usernames match`() {
+    // Given
+    persistenceHelper.clearAllTableContent()
+
+    // When
+    val result = staffRepository.findSurnamesByUsernames(listOf("DOES_NOT_EXIST"))
+
+    // Then
+    result.shouldBeEmpty()
+  }
+
+  @Test
+  fun `findSurnamesByStaffIds returns a projection row per matched staff id`() {
+    // Given
+    persistenceHelper.clearAllTableContent()
+    persistenceHelper.createStaff(
+      staffId = "1".toBigInteger(),
+      firstName = "Alex",
+      lastName = "River",
+      username = "ARIVER",
+      primaryEmail = "a@justice.gov.uk",
+    )
+    persistenceHelper.createStaff(
+      staffId = "2".toBigInteger(),
+      firstName = "Bea",
+      lastName = "Smith",
+      username = "BSMITH",
+      primaryEmail = "b@justice.gov.uk",
+    )
+
+    // When
+    val result = staffRepository.findSurnamesByStaffIds(
+      listOf("1".toBigInteger(), "2".toBigInteger(), "9999".toBigInteger()),
+    )
+
+    // Then – unmatched IDs are silently dropped by the IN clause
+    val byStaffId = result.associate { it.staffId to it.lastName }
+    byStaffId shouldBe mapOf(
+      "1".toBigInteger() to "River",
+      "2".toBigInteger() to "Smith",
+    )
+  }
+
+  @Test
+  fun `findSurnamesByStaffIds returns empty list when no staff ids match`() {
+    // Given
+    persistenceHelper.clearAllTableContent()
+
+    // When
+    val result = staffRepository.findSurnamesByStaffIds(listOf("9999".toBigInteger()))
 
     // Then
     result.shouldBeEmpty()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/StaffRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/StaffRepositoryIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration.IntegrationTestBase
 import java.math.BigInteger
+import java.util.UUID
 import kotlin.test.Test
 
 /**
@@ -165,5 +166,100 @@ class StaffRepositoryIntegrationTest : IntegrationTestBase() {
 
     // Then
     result.shouldBeEmpty()
+  }
+
+  // -------------------------------------------------------------------------
+  // Deterministic-ordering guarantees for duplicate username / staffId rows.
+  // The projection queries add `ORDER BY <key>, s.id` so that callers grouping
+  // by the key and taking `.first()` always pick the row with the smallest UUID.
+  // These tests seed two rows with the same lookup key but different UUIDs so
+  // the ordering has something to actually order.
+  // -------------------------------------------------------------------------
+
+  private val idAlpha: UUID = UUID.fromString("00000000-0000-0000-0000-000000000001")
+  private val idBravo: UUID = UUID.fromString("00000000-0000-0000-0000-000000000002")
+
+  @Test
+  fun `findLastNameByUsername returns rows ordered by id when the username has duplicates`() {
+    // Given – two rows share username DUP, distinct UUIDs; alpha's UUID sorts first.
+    persistenceHelper.clearAllTableContent()
+    persistenceHelper.createStaff(
+      id = idBravo,
+      staffId = "20".toBigInteger(),
+      firstName = "Bea",
+      lastName = "Bravo",
+      username = "DUP",
+      primaryEmail = "b@justice.gov.uk",
+    )
+    persistenceHelper.createStaff(
+      id = idAlpha,
+      staffId = "10".toBigInteger(),
+      firstName = "Alex",
+      lastName = "Alpha",
+      username = "DUP",
+      primaryEmail = "a@justice.gov.uk",
+    )
+
+    // When
+    val result = staffRepository.findLastNameByUsername("DUP")
+
+    // Then – Alpha wins because its UUID sorts first.
+    result.shouldContainExactly("Alpha", "Bravo")
+  }
+
+  @Test
+  fun `findSurnamesByUsernames orders duplicate rows by id so first() is stable`() {
+    // Given
+    persistenceHelper.clearAllTableContent()
+    persistenceHelper.createStaff(
+      id = idBravo,
+      staffId = "20".toBigInteger(),
+      firstName = "Bea",
+      lastName = "Bravo",
+      username = "DUP",
+      primaryEmail = "b@justice.gov.uk",
+    )
+    persistenceHelper.createStaff(
+      id = idAlpha,
+      staffId = "10".toBigInteger(),
+      firstName = "Alex",
+      lastName = "Alpha",
+      username = "DUP",
+      primaryEmail = "a@justice.gov.uk",
+    )
+
+    // When
+    val result = staffRepository.findSurnamesByUsernames(listOf("DUP"))
+
+    // Then – both rows returned in a stable order (alpha's UUID first).
+    result.map { it.lastName } shouldBe listOf("Alpha", "Bravo")
+  }
+
+  @Test
+  fun `findSurnamesByStaffIds orders duplicate rows by id so first() is stable`() {
+    // Given – two rows share staffId 42, distinct UUIDs.
+    persistenceHelper.clearAllTableContent()
+    persistenceHelper.createStaff(
+      id = idBravo,
+      staffId = "42".toBigInteger(),
+      firstName = "Bea",
+      lastName = "Bravo",
+      username = "BB",
+      primaryEmail = "b@justice.gov.uk",
+    )
+    persistenceHelper.createStaff(
+      id = idAlpha,
+      staffId = "42".toBigInteger(),
+      firstName = "Alex",
+      lastName = "Alpha",
+      username = "AA",
+      primaryEmail = "a@justice.gov.uk",
+    )
+
+    // When
+    val result = staffRepository.findSurnamesByStaffIds(listOf("42".toBigInteger()))
+
+    // Then
+    result.map { it.lastName } shouldBe listOf("Alpha", "Bravo")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StaffLookupServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/StaffLookupServiceTest.kt
@@ -5,7 +5,9 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StaffIdSurnameProjection
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.StaffRepository
+import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.domain.repository.UsernameSurnameProjection
 import java.math.BigInteger
 
 class StaffLookupServiceTest {
@@ -66,5 +68,139 @@ class StaffLookupServiceTest {
     assertThat(service.findLastNameByStaffId(null)).isNull()
 
     verify(exactly = 0) { staffRepository.findLastNameByStaffId(any()) }
+  }
+
+  @Test
+  fun `resolveSurnamesByUsername returns a map keyed by username for every match`() {
+    every {
+      staffRepository.findSurnamesByUsernames(setOf("ARIVER", "BSMITH"))
+    } returns listOf(
+      usernameProjection("ARIVER", "River"),
+      usernameProjection("BSMITH", "Smith"),
+    )
+
+    val result = service.resolveSurnamesByUsername(listOf("ARIVER", "BSMITH"))
+
+    assertThat(result).containsExactlyInAnyOrderEntriesOf(
+      mapOf("ARIVER" to "River", "BSMITH" to "Smith"),
+    )
+  }
+
+  @Test
+  fun `resolveSurnamesByUsername omits usernames with no matching staff row`() {
+    every {
+      staffRepository.findSurnamesByUsernames(setOf("ARIVER", "MISSING"))
+    } returns listOf(usernameProjection("ARIVER", "River"))
+
+    val result = service.resolveSurnamesByUsername(listOf("ARIVER", "MISSING"))
+
+    assertThat(result).containsOnly(java.util.Map.entry("ARIVER", "River"))
+  }
+
+  @Test
+  fun `resolveSurnamesByUsername picks the first surname when the username has duplicate rows`() {
+    every {
+      staffRepository.findSurnamesByUsernames(setOf("ARIVER"))
+    } returns listOf(
+      usernameProjection("ARIVER", "River"),
+      usernameProjection("ARIVER", "Rivera"),
+    )
+
+    val result = service.resolveSurnamesByUsername(listOf("ARIVER"))
+
+    assertThat(result).containsOnly(java.util.Map.entry("ARIVER", "River"))
+  }
+
+  @Test
+  fun `resolveSurnamesByUsername drops nulls and blanks before hitting the repository`() {
+    every { staffRepository.findSurnamesByUsernames(setOf("ARIVER")) } returns
+      listOf(usernameProjection("ARIVER", "River"))
+
+    val result = service.resolveSurnamesByUsername(listOf("ARIVER", null, "", "   "))
+
+    assertThat(result).containsOnly(java.util.Map.entry("ARIVER", "River"))
+    verify(exactly = 1) { staffRepository.findSurnamesByUsernames(setOf("ARIVER")) }
+  }
+
+  @Test
+  fun `resolveSurnamesByUsername short-circuits when all inputs are null or blank`() {
+    val result = service.resolveSurnamesByUsername(listOf(null, "", "  "))
+
+    assertThat(result).isEmpty()
+    verify(exactly = 0) { staffRepository.findSurnamesByUsernames(any()) }
+  }
+
+  @Test
+  fun `resolveSurnamesByStaffId returns a map keyed by staff id for every match`() {
+    val a = BigInteger.valueOf(1)
+    val b = BigInteger.valueOf(2)
+    every {
+      staffRepository.findSurnamesByStaffIds(setOf(a, b))
+    } returns listOf(
+      staffIdProjection(a, "River"),
+      staffIdProjection(b, "Smith"),
+    )
+
+    val result = service.resolveSurnamesByStaffId(listOf(a, b))
+
+    assertThat(result).containsExactlyInAnyOrderEntriesOf(mapOf(a to "River", b to "Smith"))
+  }
+
+  @Test
+  fun `resolveSurnamesByStaffId omits staff ids with no matching row`() {
+    val a = BigInteger.valueOf(1)
+    val b = BigInteger.valueOf(2)
+    every {
+      staffRepository.findSurnamesByStaffIds(setOf(a, b))
+    } returns listOf(staffIdProjection(a, "River"))
+
+    val result = service.resolveSurnamesByStaffId(listOf(a, b))
+
+    assertThat(result).containsOnly(java.util.Map.entry(a, "River"))
+  }
+
+  @Test
+  fun `resolveSurnamesByStaffId picks the first surname when the staff id has duplicate rows`() {
+    val a = BigInteger.valueOf(1)
+    every {
+      staffRepository.findSurnamesByStaffIds(setOf(a))
+    } returns listOf(
+      staffIdProjection(a, "River"),
+      staffIdProjection(a, "Rivera"),
+    )
+
+    val result = service.resolveSurnamesByStaffId(listOf(a))
+
+    assertThat(result).containsOnly(java.util.Map.entry(a, "River"))
+  }
+
+  @Test
+  fun `resolveSurnamesByStaffId drops nulls before hitting the repository`() {
+    val a = BigInteger.valueOf(1)
+    every { staffRepository.findSurnamesByStaffIds(setOf(a)) } returns
+      listOf(staffIdProjection(a, "River"))
+
+    val result = service.resolveSurnamesByStaffId(listOf(a, null))
+
+    assertThat(result).containsOnly(java.util.Map.entry(a, "River"))
+    verify(exactly = 1) { staffRepository.findSurnamesByStaffIds(setOf(a)) }
+  }
+
+  @Test
+  fun `resolveSurnamesByStaffId short-circuits when all inputs are null`() {
+    val result = service.resolveSurnamesByStaffId(listOf(null, null))
+
+    assertThat(result).isEmpty()
+    verify(exactly = 0) { staffRepository.findSurnamesByStaffIds(any()) }
+  }
+
+  private fun usernameProjection(usernameValue: String, lastNameValue: String): UsernameSurnameProjection = object : UsernameSurnameProjection {
+    override val username: String = usernameValue
+    override val lastName: String = lastNameValue
+  }
+
+  private fun staffIdProjection(staffIdValue: BigInteger, lastNameValue: String): StaffIdSurnameProjection = object : StaffIdSurnameProjection {
+    override val staffId: BigInteger = staffIdValue
+    override val lastName: String = lastNameValue
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestServiceTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.ent
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.ReferralStatusHistoryEntityFactory
 import uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.unit.domain.entity.factory.StaffEntityFactory
+import java.math.BigInteger
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -66,11 +67,21 @@ class SubjectAccessRequestServiceTest {
       organisationRepository,
       staffLookupService,
     )
-    // By default resolve every username to "River" and every staff ID to null; individual
-    // tests can override. This mirrors the behaviour of a happy-path staff lookup where
-    // one staff row (surname "River") exists for the sole username seeded below.
-    every { staffLookupService.findLastNameByUsername(any()) } returns "River"
-    every { staffLookupService.findLastNameByStaffId(any()) } returns null
+    // By default resolve every username to "River" and every staff ID to an empty
+    // result; individual tests can override. This mirrors the batch-lookup contract
+    // where `resolveSurnamesByUsername` returns a map keyed by the requested
+    // usernames and `resolveSurnamesByStaffId` returns an empty map when no staff
+    // rows exist for the given IDs.
+    every { staffLookupService.resolveSurnamesByUsername(any()) } answers {
+      @Suppress("UNCHECKED_CAST")
+      val usernames = firstArg<Collection<String?>>()
+      usernames.asSequence()
+        .filterNotNull()
+        .filter { it.isNotBlank() }
+        .toSet()
+        .associateWith { "River" }
+    }
+    every { staffLookupService.resolveSurnamesByStaffId(any()) } returns emptyMap<BigInteger, String>()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestServiceTest.kt
@@ -73,7 +73,6 @@ class SubjectAccessRequestServiceTest {
     // usernames and `resolveSurnamesByStaffId` returns an empty map when no staff
     // rows exist for the given IDs.
     every { staffLookupService.resolveSurnamesByUsername(any()) } answers {
-      @Suppress("UNCHECKED_CAST")
       val usernames = firstArg<Collection<String?>>()
       usernames.asSequence()
         .filterNotNull()


### PR DESCRIPTION
Follow-up to the surname-lookup helper and V144 index migration.

Collapse the O(rows) staff-surname point-lookup pattern in SubjectAccessRequestService into exactly two batch queries per SAR request (one by-username, one by-staff-id).

StaffRepository gains findSurnamesByUsernames / findSurnamesByStaffIds returning lightweight projection interfaces (uses the V144 indexes).

StaffLookupService adds resolveSurnamesByUsername / resolveSurnamesByStaffId, which filter null/blank inputs, dedupe multi-row matches (logging a WARN so duplicates stay visible in prod), and return maps keyed by identifier.

SubjectAccessRequestService.getPrisonContentFor now collects all usernames / staff IDs referenced by the referral, participation, audit and status-history entity sets up-front, resolves both batch maps once, and threads a StaffSurnames context object into each mapper. Scalar findLastNameByUsername / findLastNameByStaffId helpers remain for any non-batch caller.

Adds unit tests for the new batch resolvers (dedupe, null/blank filter, empty short-circuit, unmatched keys) and integration tests for the new projections