### PR TITLE
APG-2507 Update handling of referrals with deleted prison numbers

### DIFF
--- a/doc/how-to/handle-nomis-prisoner-merged-events.md
+++ b/doc/how-to/handle-nomis-prisoner-merged-events.md
@@ -31,7 +31,10 @@ Accessing these endpoints requires a personal HMPPS Auth production client with 
 
 ### Finding the new prisoner number
 
-The people search is used to search for a person in NOMIS using the `forename` and `surname` held in the `person` DB table. It returns a list of people that match the search criteria and discretion should be used to select the correct person and the new prisoner number when multiple results are returned.
+If you have nDelius access the CRN number held on the `pni_result.crn` column may be used to search for the correct person. After a prisoner merge in Nomis,
+the Case Summary screen may have the previous Noms number in the "Additional Identifiers" section.
+
+Alternatively the people search can be used to search for a person in NOMIS using the `forename` and `surname` held in the `person` DB table. It returns a list of people that match the search criteria and discretion should be used to select the correct person. 
 
 - [POST /people/search](../../src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/restapi/controller/PeopleController.kt)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/PniAssessment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/client/oasysApi/model/PniAssessment.kt
@@ -1,5 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.client.oasysApi.model
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class PniAssessment(
   val id: Long,
   val ldc: Ldc?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/domain/repository/ReferralRepository.kt
@@ -45,4 +45,10 @@ interface ReferralRepository : JpaRepository<ReferralEntity, UUID> {
     """,
   )
   fun findByIdWithHspDetails(@Param("id") id: UUID): Optional<ReferralEntity>
+
+  @Query(
+    value = "SELECT * FROM referral WHERE prison_number = :prisonNumber",
+    nativeQuery = true,
+  )
+  fun findAllByPrisonNumberIncludingDeleted(@Param("prisonNumber") prisonNumber: String): List<ReferralEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PersonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/PersonService.kt
@@ -264,7 +264,7 @@ class PersonService(
 
   @Transactional
   fun updatePrisonNumberForPrisoner(newPrisonerNumber: String, removedPrisonerNumber: String) {
-    val referrals = referralRepository.findAllByPrisonNumber(removedPrisonerNumber)
+    val referrals = referralRepository.findAllByPrisonNumberIncludingDeleted(removedPrisonerNumber)
     if (referrals.isEmpty()) {
       log.info("Merged prisoner with prisoner number $removedPrisonerNumber is not of interest")
       return


### PR DESCRIPTION
## Context

Updates in this PR address the fix to handle referrals with deleted prison numbers for completeness when updating prisoner numbers after a  NOMIS  prisoner merge.

## Changes in this PR

- Updated repository and service to manage referrals with deleted prison numbers.
- Added `@JsonIgnoreProperties` to `PniAssessment` to prevent unwanted deserialization issues.
- Improved documentation for managing merged prisoner records.

