### PR TITLE
APG-2495: SAR JSON to HTML renderer harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ To run linting and tests, do:
 The integration tests start a local Spring Boot instance which listens on a random port, and create containerised Postgres and Localstack instances via the test containers API,
 negating the need for any external docker dependencies.
 
+### Rendering a captured SAR JSON payload
+
+For OSAR handovers we sometimes need to render a captured SAR JSON payload into
+the same HTML the SAR aggregator produces. `SarHtmlRenderHarnessTest` is a
+dev-only harness that does this using the real `hmpps-subject-access-request-lib`
+template renderer. It is skipped unless `APG_SAR_HTML_INPUT` is set:
+
+```bash
+APG_SAR_HTML_INPUT=/path/to/sar-payload.json \
+  ./gradlew test --tests '*SarHtmlRenderHarnessTest*'
+```
+
+The rendered HTML is written to `$TMPDIR/apg-sar-rendered-<basename>.html`
+(override with `APG_SAR_HTML_OUT=/some/dir`).
+
 ### Pact
 
 [We use

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,8 @@ dependencies {
   testImplementation("org.testcontainers:testcontainers-junit-jupiter:2.0.5")
   testImplementation("org.jetbrains.kotlin:kotlin-test")
   testImplementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-test-support:2.4.2")
+  // Exposed at compile time for the SarHtmlRenderHarnessTest dev harness; already a runtime transitive.
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-lib:2.4.2")
   testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.2.0")
 
   runtimeOnly("org.flywaydb:flyway-database-postgresql:$flywayVersion")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/SarHtmlRenderHarnessTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/SarHtmlRenderHarnessTest.kt
@@ -1,0 +1,61 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import uk.gov.justice.digital.hmpps.subjectaccessrequest.rendering.RenderRequestInfo
+import uk.gov.justice.digital.hmpps.subjectaccessrequest.templates.RenderParameters
+import uk.gov.justice.digital.hmpps.subjectaccessrequest.templates.TemplateDataFetcherFacade
+import uk.gov.justice.digital.hmpps.subjectaccessrequest.templates.TemplateHelpers
+import uk.gov.justice.digital.hmpps.subjectaccessrequest.templates.TemplateRenderService
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * Dev-only harness: renders a captured SAR JSON payload to HTML using the same
+ * template + helpers the aggregator uses in production. Skipped unless
+ * `APG_SAR_HTML_INPUT` points at a JSON file. See README for usage.
+ */
+class SarHtmlRenderHarnessTest {
+
+  @Test
+  fun `render SAR JSON to HTML`() {
+    val inputPath = System.getenv("APG_SAR_HTML_INPUT")
+    assumeTrue(!inputPath.isNullOrBlank(), "APG_SAR_HTML_INPUT not set")
+
+    val jsonPath: Path = Paths.get(inputPath)
+    check(Files.exists(jsonPath)) { "input file not found: $jsonPath" }
+
+    val objectMapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+    // The API's SAR response is { "content": { ... } }; the template renders against content.
+    val rootNode = objectMapper.readTree(jsonPath.toFile())
+    val contentNode = if (rootNode.has("content")) rootNode.get("content") else rootNode
+    val data = objectMapper.treeToValue(contentNode, Map::class.java)
+
+    val template = this::class.java.classLoader
+      .getResource("sar_template.mustache")!!
+      .readText()
+
+    val helpers = TemplateHelpers(mock<TemplateDataFetcherFacade>(), objectMapper)
+    val renderer = TemplateRenderService(helpers)
+
+    val rendered = renderer.renderServiceTemplate(
+      RenderParameters(templateVersion = "1.0", template = template, data = data),
+      RenderRequestInfo(UUID.randomUUID(), "sar-html-renderer"),
+    ).toString(StandardCharsets.UTF_8)
+
+    val outDir = System.getenv("APG_SAR_HTML_OUT") ?: System.getProperty("java.io.tmpdir")
+    val baseName = jsonPath.fileName.toString().removeSuffix(".json")
+    val outPath = Paths.get(outDir, "apg-sar-rendered-$baseName.html")
+    Files.writeString(outPath, rendered, StandardCharsets.UTF_8)
+
+    println("Rendered ${rendered.length} chars -> ${outPath.toUri()}")
+  }
+}


### PR DESCRIPTION
### APG-2495 — SAR JSON to HTML renderer harness

**Type:** dev tooling. No production code change.

#### What

Adds a single env-guarded JUnit test — `SarHtmlRenderHarnessTest` — that takes a captured SAR JSON payload (from a dev/preprod call) and renders it into the same HTML the SAR aggregator produces, using the exact `TemplateRenderService` + `TemplateHelpers` from `hmpps-subject-access-request-lib`. Output is written to `$TMPDIR/apg-sar-rendered-<basename>.html` (override the directory with `APG_SAR_HTML_OUT`).

```zsh
APG_SAR_HTML_INPUT=/tmp/my-sar-payload.json \
  ./gradlew test --tests '*SarHtmlRenderHarnessTest*' --no-daemon
```

The env var acts as an `assumeTrue` gate — the test is silently skipped in normal CI runs, so it costs the pipeline nothing. Usage is also documented in the README under "Rendering a captured SAR JSON payload".

#### Why

Every OSAR retest cycle needs this: pull the captured JSON, render to HTML, hand off to OSAR / the aggregator team. Doing it from scratch takes ~1h of Handlebars-helper detective work every time because the SAR template uses helpers (`optionalValue`, `convertBoolean`, `formatDate`, `getIndexPlusOne`) that plain mustache CLIs don't understand.

First proven end-to-end on 2026-07-24 for the OSAR handover of the APG-2493 originalReferral enrichment — 189 referrals + 7 nested `originalReferral` sub-tables rendered correctly against a dev capture for PRN `A8610DY`.

#### Build impact

One extra `testImplementation` line for `hmpps-subject-access-request-lib:2.4.2` — it's already on `testRuntimeClasspath` transitively via `hmpps-subject-access-request-test-support`; the new line just exposes its classes at compile time.

No prod dependency, no prod classpath, no CI regressions.

#### Related

- APG-2493 (nested originalReferral — merged, #1101)
- APG-2492 (batch staff-surname resolver — merged in 3 PRs)
- APG-2510 (staff.username removal — merged, #1102)

