### PR TITLE
APG-2495: SAR harness (HTML + PDF) and document OSAR template registration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,8 @@ ready to be released once merged.
 
 - [ ] There are changes required to the Accredited Programmes UI for this change to work...
   - [ ] ... and they been released to production already
+- [ ] This PR modifies `src/main/resources/sar_template.mustache`...
+  - [ ] ... and I will [register the new template](../doc/how-to/register-sar-template.md) with the SAR team **before deploying** to each environment (dev, preprod, prod). Registering ahead of time stores the new template as `PENDING` and it is auto-promoted to `PUBLISHED` when the worker first fetches it, avoiding any ERRORED SARs during the release.
 
 ### Post-merge
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,29 @@ To run linting and tests, do:
 The integration tests start a local Spring Boot instance which listens on a random port, and create containerised Postgres and Localstack instances via the test containers API,
 negating the need for any external docker dependencies.
 
+### Rendering a captured SAR JSON payload
+
+For OSAR handovers we sometimes need to render a captured SAR JSON payload into
+the same HTML the SAR aggregator produces. `SarHtmlRenderHarnessTest` is a
+dev-only harness that does this using the real `hmpps-subject-access-request-lib`
+template renderer. It is skipped unless `APG_SAR_HTML_INPUT` is set:
+
+```bash
+APG_SAR_HTML_INPUT=/path/to/sar-payload.json \
+  ./gradlew test --tests '*SarHtmlRenderHarnessTest*'
+```
+
+The rendered HTML is written to `$TMPDIR/apg-sar-rendered-<basename>.html`
+(override with `APG_SAR_HTML_OUT=/some/dir`).
+
+To also produce the PDF that the SAR aggregator ships (page header with subject
+name + NOMIS ID, "Official Sensitive" footer), set `APG_SAR_HTML_PDF=true`. The
+PRN is picked up from the first referral in the payload; override with
+`APG_SAR_HTML_PRN=A1234BC` if needed. When this flag is set the test JVM is
+given `-Xmx4g` automatically. PDF rendering (via iText7) is significantly
+slower than HTML — a small per-subject payload is a few seconds, but a
+retest-style capture with hundreds of referrals may take many minutes.
+
 ### Pact
 
 [We use

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,8 @@ dependencies {
   testImplementation("org.testcontainers:testcontainers-junit-jupiter:2.0.5")
   testImplementation("org.jetbrains.kotlin:kotlin-test")
   testImplementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-test-support:2.4.2")
+  // Exposed at compile time for the SarHtmlRenderHarnessTest dev harness; already a runtime transitive.
+  testImplementation("uk.gov.justice.service.hmpps:hmpps-subject-access-request-lib:2.4.2")
   testImplementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter-test:2.2.0")
 
   runtimeOnly("org.flywaydb:flyway-database-postgresql:$flywayVersion")
@@ -95,6 +97,13 @@ testing {
             // testLogging.showStandardStreams = true
             maxParallelForks = 1
             environment["pact_do_not_track"] = "true"
+
+            // Give the test JVM more heap when the SAR-to-PDF harness is being run against
+            // a full-size captured payload — iText7 needs ~4g to render a real SAR without OOM.
+            if (System.getenv("APG_SAR_HTML_PDF")?.equals("true", ignoreCase = true) == true) {
+              maxHeapSize = "4g"
+            }
+
             val pactProviderTag = System.getenv("PACT_PROVIDER_TAG")
             val pactProviderVersion = System.getenv("PACT_PROVIDER_VERSION")
 

--- a/doc/how-to/register-sar-template.md
+++ b/doc/how-to/register-sar-template.md
@@ -1,0 +1,116 @@
+# Register the SAR template with OSAR
+
+## Background
+
+Our Subject Access Request (SAR) response is rendered into a PDF by the
+[`hmpps-subject-access-request-worker`][worker] using the Mustache template at
+[`src/main/resources/sar_template.mustache`](../../src/main/resources/sar_template.mustache).
+
+As a safeguard against unreviewed template changes reaching production, the
+worker refuses to render any template whose SHA-256 hash it does not recognise.
+Each deployed version of the template must therefore be registered with the
+Office for Subject Access Requests (OSAR) / SAR team **in every environment
+separately** (`dev`, `preprod`, `prod`).
+
+If the template hash on a running API does not match a registered version, the
+SAR UI shows the product as `ERRORED` for every request touching this service,
+even though our API itself is returning `200 OK`. Nothing appears in our
+Application Insights, because the failure happens inside the worker.
+
+## When to register — ideally *before* you deploy
+
+Registration is per-environment, so you will do this three times over the
+course of a release: once for `dev`, `preprod`, and `prod`.
+
+The SAR service supports registering a new template ahead of the deploy:
+
+- A newly registered template is stored as `PENDING`.
+- The currently `PUBLISHED` template stays in force until the worker actually
+  encounters the new template from our `/subject-access-request/template`
+  endpoint. At that point the new template is automatically promoted to
+  `PUBLISHED` and the previous version is retired.
+
+The recommended sequence per environment is therefore:
+
+1. Register the new template as `PENDING` **before** the release is deployed.
+2. Deploy the code change.
+3. On the next SAR touching this service, the worker fetches the new
+   template, promotion happens automatically, and no SAR errors.
+
+Registering *after* deployment still works — the SAR team can promote the new
+template, and any in-flight SARs are auto-retried ~30 minutes after their last
+attempt — but any SAR fired in the intervening window will show `ERRORED` in
+the SAR UI.
+
+Changes to `SubjectAccessRequestService.kt` that only alter the JSON payload
+(fields, ordering) do **not** require registration — only edits to the
+`.mustache` file itself change the hash.
+
+## Who to contact
+
+- Slack channel: [`#dps-subject-access-requests`][slack]
+- Owning team: Subject Access Request Service
+  (`subject-access-request-service@digital.justice.gov.uk`)
+- Point of contact who has registered our templates in the past: Dave
+  Llewellyn (as of July 2026)
+
+## How to register
+
+1. Identify the commit that contains the new template. If registering ahead
+   of the deploy, this is the merge commit on `main` (or the tip of the PR
+   branch about to be merged). If registering after the fact, confirm what
+   is actually deployed:
+
+   ```sh
+   curl -s https://accredited-programmes-api-<env>.hmpps.service.justice.gov.uk/info \
+     | jq '.git // .build // .'
+   ```
+
+   Replace `<env>` with `dev`, `preprod`, or the production host as
+   appropriate.
+
+2. Compute the SHA-256 of the template at that commit. From a checkout of the
+   repo:
+
+   ```sh
+   git show <commit-sha>:src/main/resources/sar_template.mustache | shasum -a 256
+   ```
+
+3. Post a request in [`#dps-subject-access-requests`][slack] with:
+
+   - Service name: `hmpps-accredited-programmes-api`
+   - Environment: e.g. `dev`
+   - Deployed commit SHA
+   - Permalink to the raw template at that SHA, e.g.
+     `https://raw.githubusercontent.com/ministryofjustice/hmpps-accredited-programmes-api/<commit-sha>/src/main/resources/sar_template.mustache`
+   - The SHA-256 of the file from step 2
+
+   A short message template:
+
+   > Hi — please could you register a new version of our SAR template on
+   > `<env>`? Service: `hmpps-accredited-programmes-api`, commit `<sha>`,
+   > file: `<raw permalink>`, sha256: `<hash>`. Thanks!
+
+4. Once the SAR team confirms it is registered, the template sits as
+   `PENDING`. When the code change is deployed and the worker next fetches
+   our template, it is auto-promoted to `PUBLISHED`. Retry a SAR for a known
+   subject and verify the product no longer shows `ERRORED`. Any SARs that
+   errored while the old template was in force are typically retried
+   automatically ~30 minutes after their last attempt.
+
+## Verifying you have the right hash
+
+The worker computes the hash over the exact file bytes it fetches from our
+`/subject-access-request/template` endpoint. You can reproduce that check
+locally:
+
+```sh
+curl -s https://accredited-programmes-api-<env>.hmpps.service.justice.gov.uk/subject-access-request/template \
+  | shasum -a 256
+```
+
+This should match the SHA-256 you sent to the SAR team.
+
+[worker]: https://github.com/ministryofjustice/hmpps-subject-access-request-worker
+[slack]: https://mojdt.slack.com/archives/dps-subject-access-requests
+

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/SarHtmlRenderHarnessTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/integration/SarHtmlRenderHarnessTest.kt
@@ -1,0 +1,76 @@
+package uk.gov.justice.digital.hmpps.hmppsaccreditedprogrammesapi.integration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import uk.gov.justice.digital.hmpps.subjectaccessrequest.PdfRenderer
+import uk.gov.justice.digital.hmpps.subjectaccessrequest.rendering.RenderRequestInfo
+import uk.gov.justice.digital.hmpps.subjectaccessrequest.templates.RenderParameters
+import uk.gov.justice.digital.hmpps.subjectaccessrequest.templates.TemplateDataFetcherFacade
+import uk.gov.justice.digital.hmpps.subjectaccessrequest.templates.TemplateHelpers
+import uk.gov.justice.digital.hmpps.subjectaccessrequest.templates.TemplateRenderService
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.UUID
+
+/**
+ * Dev-only harness: renders a captured SAR JSON payload to HTML using the same
+ * template + helpers the aggregator uses in production. Skipped unless
+ * `APG_SAR_HTML_INPUT` points at a JSON file. See README for usage.
+ */
+class SarHtmlRenderHarnessTest {
+
+  @Test
+  fun `render SAR JSON to HTML`() {
+    val inputPath = System.getenv("APG_SAR_HTML_INPUT")
+    assumeTrue(!inputPath.isNullOrBlank(), "APG_SAR_HTML_INPUT not set")
+
+    val jsonPath: Path = Paths.get(inputPath)
+    check(Files.exists(jsonPath)) { "input file not found: $jsonPath" }
+
+    val objectMapper: ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+
+    // The API's SAR response is { "content": { ... } }; the template renders against content.
+    val rootNode = objectMapper.readTree(jsonPath.toFile())
+    val contentNode = if (rootNode.has("content")) rootNode.get("content") else rootNode
+    val data = objectMapper.treeToValue(contentNode, Map::class.java)
+
+    val template = this::class.java.classLoader
+      .getResource("sar_template.mustache")!!
+      .readText()
+
+    val helpers = TemplateHelpers(mock<TemplateDataFetcherFacade>(), objectMapper)
+    val renderer = TemplateRenderService(helpers)
+
+    val rendered = renderer.renderServiceTemplate(
+      RenderParameters(templateVersion = "1.0", template = template, data = data),
+      RenderRequestInfo(UUID.randomUUID(), "sar-html-renderer"),
+    ).toString(StandardCharsets.UTF_8)
+
+    val outDir = System.getenv("APG_SAR_HTML_OUT") ?: System.getProperty("java.io.tmpdir")
+    val baseName = jsonPath.fileName.toString().removeSuffix(".json")
+    val outPath = Paths.get(outDir, "apg-sar-rendered-$baseName.html")
+    Files.writeString(outPath, rendered, StandardCharsets.UTF_8)
+
+    println("Rendered ${rendered.length} chars -> ${outPath.toUri()}")
+
+    if (System.getenv("APG_SAR_HTML_PDF").equals("true", ignoreCase = true)) {
+      val prn = System.getenv("APG_SAR_HTML_PRN")
+        ?: contentNode.get("referrals")
+          ?.takeIf { it.isArray && it.size() > 0 }
+          ?.get(0)?.get("prisonerNumber")?.asText()
+          ?.takeIf { it.isNotBlank() }
+      val pdfBytes = PdfRenderer()
+        .renderSubjectAccessRequestPdf(rendered, prn, null)
+        .toByteArray()
+      val pdfPath = Paths.get(outDir, "apg-sar-rendered-$baseName.pdf")
+      Files.write(pdfPath, pdfBytes)
+      println("Rendered ${pdfBytes.size} bytes PDF -> ${pdfPath.toUri()}")
+    }
+  }
+}


### PR DESCRIPTION
Two related changes falling out of the ERRORED-SAR investigation on dev today:

Extend the SAR HTML render harness to optionally produce the PDF the SAR worker ships, so we can locally reproduce the exact artefact the aggregator generates.

Document the OSAR template-registration process we hit while triaging that incident — any change to sar_template.mustache needs its SHA-256 registered per environment, otherwise the worker refuses to render and the UI shows the product as ERRORED.

SarHtmlRenderHarnessTest: opt-in via APG_SAR_HTML_PDF=true runs PdfRenderer after the HTML render and writes apg-sar-rendered-<basename>.pdf alongside the HTML. PRN falls back to the first referral in the payload; override with APG_SAR_HTML_PRN.

build.gradle.kts: bumps the test JVM heap to 4g only when APG_SAR_HTML_PDF=true, so normal test runs are unaffected.

README.md: documents the new flag and its heap requirement.

doc/how-to/register-sar-template.md: new how-to covering when, who, and how to register a template, including the PENDING→PUBLISHED promotion flow that lets us register ahead of a deploy.

.github/PULL_REQUEST_TEMPLATE.md: adds a checklist item so any PR touching sar_template.mustache is reminded to register in each environment before deploy.

**Testing**
Ran the harness against a captured dev payload for subject A8610DY:
```
APG_SAR_HTML_INPUT=/tmp/A8610DY-sar.json APG_SAR_HTML_PDF=true \
  ./gradlew test --tests '...SarHtmlRenderHarnessTest'
```
Produced valid HTML (7.7 KB) and PDF (2.9 KB) matching what the SAR worker generates.