### PR TITLE
APG-2546: strip SarOriginalReferral.id UUID from the SAR sub-block

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestService.kt
@@ -200,7 +200,6 @@ class SubjectAccessRequestService(
    * can render the block with the same `optionalValue` conventions.
    */
   data class SarOriginalReferral(
-    val id: UUID,
     val courseName: String?,
     val organisationName: String?,
     val submittedOn: LocalDateTime?,
@@ -323,7 +322,6 @@ class SubjectAccessRequestService(
     surnames: StaffSurnames,
     organisationNamesByCode: Map<String, String>,
   ): SarOriginalReferral = SarOriginalReferral(
-    id = id!!,
     courseName = offering?.course?.name,
     organisationName = offering?.organisationId?.let { organisationNamesByCode[it] },
     submittedOn = submittedOn,

--- a/src/main/resources/sar_template.mustache
+++ b/src/main/resources/sar_template.mustache
@@ -20,7 +20,6 @@
         {{#originalReferral}}
             <h4>Original referral</h4>
             <table class="summary-list">
-                <tr><td>Original referral ID</td><td>{{ optionalValue id }}</td></tr>
                 <tr><td>Course name</td><td>{{ optionalValue courseName }}</td></tr>
                 <tr><td>Organisation name</td><td>{{ optionalValue organisationName }}</td></tr>
                 <tr><td>Submitted on</td><td>{{ optionalValue (formatDate submittedOn) }}</td></tr>

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsaccreditedprogrammesapi/service/SubjectAccessRequestServiceTest.kt
@@ -254,7 +254,6 @@ class SubjectAccessRequestServiceTest {
       // parent state, and that organisation-name / referrer-surname come from
       // the batch maps (not a separate lookup per original).
       val originalReferral = referral.originalReferral!!
-      assertThat(originalReferral.id).isEqualTo(originalReferralId)
       assertThat(originalReferral.courseName).isEqualTo("Building Choices")
       assertThat(originalReferral.organisationName).isEqualTo("HMP Moorland")
       assertThat(originalReferral.submittedOn).isEqualTo(LocalDateTime.of(2021, 3, 15, 9, 30))


### PR DESCRIPTION
APG-2546: strip SarOriginalReferral.id UUID from the SAR sub-block

Follow-on to PR-5 (#1112) per its nine-lens review flag (2026-08-05).
PR-5 stripped every raw UUID on the SAR API surface except the nested
SarOriginalReferral.id, which was retained as a conscious "sub-block
unaffected" choice. Raby confirmed 2026-08-05 that Roxanne's row 105 +
111 blanket "No Ids to be included in SAR reports" rule applies here
too — internal referral primary keys are opaque to the subject once
the resolved details are rendered right next to them.

Changes:
- Delete val id: UUID from SarOriginalReferral data class
- Delete id = id!! from ReferralEntity.toSarOriginalReferral mapper
- Delete the "Original referral ID" row from the {{#originalReferral}}
  block of sar_template.mustache
- Drop the SubjectAccessRequestServiceTest assertion on
  originalReferral.id (line ~258) — coverage of the resolved
  sub-block via courseName / organisationName / statusCode /
  referrerSurname / referrerOverrideReason / hasLdc /
  additionalInformation assertions remains

Not changed:
- Entity-level ReferralEntity.originalReferralId — still required
  for the findAllById batch lookup that populates the sub-block
- Every other field on SarOriginalReferral — that's the observable
  contract for the subject and remains fully covered by unit tests
- SAR contract snapshots (sar-api-response.json +
  sar-expected-render-result.html) — no diff expected because the
  integration-test fixture doesn't seed a resolvable
  originalReferralId (the {{#originalReferral}} block never renders
  in the fixture). Coverage of the removal lives in the unit test.
  Snapshot regen was run and confirmed produced zero diff (would
  signal fixture drift otherwise).

Sample PDF: 3 pages (same as PR-5 baseline — nested block doesn't
render in the fixture).

